### PR TITLE
[Rgen] Ensure transformer tests can build with missing platforms.

### DIFF
--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Microsoft.Macios.Transformer.Tests.csproj
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Microsoft.Macios.Transformer.Tests.csproj
@@ -65,10 +65,10 @@
     
     <Target Name="BuildTestLibraries" BeforeTargets="BeforeBuild">
         <Message Text="Processing platform: %(Platform.Identity)" /> 
-        <Exec Command="make -j8 -C $(SourceDirectory) $(DotnetBuildDirectory)/ios/apidefinition-ios.dll"/>
-        <Exec Command="make -j8 -C $(SourceDirectory) $(DotnetBuildDirectory)/macos/apidefinition-macos.dll"/>
-        <Exec Command="make -j8 -C $(SourceDirectory) $(DotnetBuildDirectory)/tvos/apidefinition-tvos.dll"/>
-        <Exec Command="make -j8 -C $(SourceDirectory) $(DotnetBuildDirectory)/maccatalyst/apidefinition-maccatalyst.dll"/>
+        <Exec Condition="$(BUILD_BUILDID) == '' Or $(DOTNET_PLATFORMS.Contains('iOS'))" Command="make -j8 -C $(SourceDirectory) $(DotnetBuildDirectory)/ios/apidefinition-ios.dll"/>
+        <Exec Condition="$(BUILD_BUILDID) == '' Or $(DOTNET_PLATFORMS.Contains('macOS'))" Command="make -j8 -C $(SourceDirectory) $(DotnetBuildDirectory)/macos/apidefinition-macos.dll"/>
+        <Exec Condition="$(BUILD_BUILDID) == '' Or $(DOTNET_PLATFORMS.Contains('tvOS'))" Command="make -j8 -C $(SourceDirectory) $(DotnetBuildDirectory)/tvos/apidefinition-tvos.dll"/>
+        <Exec Condition="$(BUILD_BUILDID) == '' Or $(DOTNET_PLATFORMS.Contains('MacCatalyst'))" Command="make -j8 -C $(SourceDirectory) $(DotnetBuildDirectory)/maccatalyst/apidefinition-maccatalyst.dll"/>
     </Target>
 
 </Project>


### PR DESCRIPTION
When building in CI, check that the platform is included in the env variable to build the API definitions dll.