### PR TITLE
[BGen] Remove support for the System.Drawing objects.

### DIFF
--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -424,14 +424,11 @@ public partial class Generator : IMemberGatherer {
 			temp = string.Format ("{3}new NSNumber ({2}{1}{0});", denullify, parameterName, enumCast, nullCheck);
 		} else if (originalType == TypeCache.NSValue) {
 			var typeStr = string.Empty;
-			if (!TypeCache.NSValueCreateMap.TryGetValue (retType, out typeStr)) {
-				// HACK: These are problematic for X.M due to we do not ship System.Drawing for Full profile
-				if (retType.Name == "RectangleF" || retType.Name == "SizeF" || retType.Name == "PointF")
-					typeStr = retType.Name;
-				else
-					throw GetBindAsException ("box", retType.Name, originalType.Name, "container", minfo?.mi, pi);
+			if (TypeCache.NSValueCreateMap.TryGetValue (retType, out typeStr)) {
+				temp = string.Format ("{3}NSValue.From{0} ({2}{1});", typeStr, denullify, parameterName, nullCheck);
+			} else {
+				throw GetBindAsException ("box", retType.Name, originalType.Name, "container", minfo?.mi, pi);
 			}
-			temp = string.Format ("{3}NSValue.From{0} ({2}{1});", typeStr, denullify, parameterName, nullCheck);
 		} else if (originalType == TypeCache.NSString && IsSmartEnum (retType)) {
 			temp = isNullable ? $"{parameterName} is null ? null : " : string.Empty;
 			temp += $"{TypeManager.FormatType (retType.DeclaringType, retType)}Extensions.GetConstant ({parameterName}{denullify});";
@@ -452,13 +449,11 @@ public partial class Generator : IMemberGatherer {
 				valueConverter = $"new NSNumber ({cast}o{denullify}), {parameterName});";
 			} else if (arrType == TypeCache.NSValue && !isNullable) {
 				var typeStr = string.Empty;
-				if (!TypeCache.NSValueCreateMap.TryGetValue (arrRetType, out typeStr)) {
-					if (arrRetType.Name == "RectangleF" || arrRetType.Name == "SizeF" || arrRetType.Name == "PointF")
-						typeStr = retType.Name;
-					else
-						throw GetBindAsException ("box", arrRetType.Name, originalType.Name, "array", minfo?.mi, pi);
+				if (TypeCache.NSValueCreateMap.TryGetValue (arrRetType, out typeStr)) {
+					valueConverter = $"NSValue.From{typeStr} (o{denullify}), {parameterName});";
+				} else {
+					throw GetBindAsException ("box", arrRetType.Name, originalType.Name, "array", minfo?.mi, pi);
 				}
-				valueConverter = $"NSValue.From{typeStr} (o{denullify}), {parameterName});";
 			} else
 				throw new BindingException (1048, true, isNullable ? arrRetType.Name + "?[]" : retType.Name);
 			temp = $"NSArray.FromNSObjects (o => {valueConverter}";
@@ -498,15 +493,12 @@ public partial class Generator : IMemberGatherer {
 			if (isNullable)
 				append = $"?{append}";
 		} else if (originalReturnType == TypeCache.NSValue) {
-			if (!TypeManager.NSValueReturnMap.TryGetValue (retType, out append)) {
-				// HACK: These are problematic for X.M due to we do not ship System.Drawing for Full profile
-				if (retType.Name == "RectangleF" || retType.Name == "SizeF" || retType.Name == "PointF")
-					append = $".{retType.Name}Value";
-				else
-					throw GetBindAsException ("unbox", retType.Name, originalReturnType.Name, "container", minfo.mi);
+			if (TypeManager.NSValueReturnMap.TryGetValue (retType, out append)) {
+				if (isNullable)
+					append = $"?{append}";
+			} else {
+				throw GetBindAsException ("unbox", retType.Name, originalReturnType.Name, "container", minfo.mi);
 			}
-			if (isNullable)
-				append = $"?{append}";
 		} else if (originalReturnType == TypeCache.NSString && IsSmartEnum (retType)) {
 			append = $"{TypeManager.FormatType (retType.DeclaringType, retType)}Extensions.GetValue (";
 			suffix = ")";
@@ -532,12 +524,11 @@ public partial class Generator : IMemberGatherer {
 				} else
 					throw GetBindAsException ("unbox", retType.Name, arrType.Name, "array", minfo.mi);
 			} else if (arrType == TypeCache.NSValue && !arrIsNullable) {
-				if (arrRetType.Name == "RectangleF" || arrRetType.Name == "SizeF" || arrRetType.Name == "PointF")
-					valueFetcher = $"{(arrIsNullable ? "?" : string.Empty)}.{arrRetType.Name}Value";
-				else if (!TypeManager.NSValueReturnMap.TryGetValue (arrRetType, out valueFetcher))
+				if (TypeManager.NSValueReturnMap.TryGetValue (arrRetType, out valueFetcher)) {
+					append = string.Format ("ptr => {{\n\tusing (var val = Runtime.GetNSObject<NSValue> (ptr)!) {{\n\t\treturn val{0};\n\t}}\n}}", valueFetcher);
+				} else {
 					throw GetBindAsException ("unbox", retType.Name, arrType.Name, "array", minfo.mi);
-
-				append = string.Format ("ptr => {{\n\tusing (var val = Runtime.GetNSObject<NSValue> (ptr)!) {{\n\t\treturn val{0};\n\t}}\n}}", valueFetcher);
+				}
 			} else
 				throw new BindingException (1048, true, arrIsNullable ? arrRetType.Name + "?[]" : retType.Name);
 		} else
@@ -2137,12 +2128,6 @@ public partial class Generator : IMemberGatherer {
 						print (GenerateNSNumber ("", "DoubleValue"));
 					else if (propertyType == TypeCache.System_Float)
 						print (GenerateNSNumber ("", "FloatValue"));
-					else if (fullname == "System.Drawing.PointF")
-						print (GenerateNSValue ("PointFValue"));
-					else if (fullname == "System.Drawing.SizeF")
-						print (GenerateNSValue ("SizeFValue"));
-					else if (fullname == "System.Drawing.RectangleF")
-						print (GenerateNSValue ("RectangleFValue"));
 					else if (fullname == "CoreGraphics.CGPoint")
 						print (GenerateNSValue ("CGPointValue"));
 					else if (fullname == "CoreGraphics.CGSize")
@@ -6341,8 +6326,6 @@ public partial class Generator : IMemberGatherer {
 						print ("return Dlfcn.GetIntPtr (Libraries.{2}.Handle, \"{1}\");", field_pi.Name, fieldAttr.SymbolName, library_name);
 					} else if (field_pi.PropertyType == TypeCache.System_UIntPtr) {
 						print ("return Dlfcn.GetUIntPtr (Libraries.{2}.Handle, \"{1}\");", field_pi.Name, fieldAttr.SymbolName, library_name);
-					} else if (field_pi.PropertyType.FullName == "System.Drawing.SizeF") {
-						print ("return Dlfcn.GetSizeF (Libraries.{2}.Handle, \"{1}\");", field_pi.Name, fieldAttr.SymbolName, library_name);
 					} else if (field_pi.PropertyType == TypeCache.System_Int64) {
 						print ("return Dlfcn.GetInt64 (Libraries.{2}.Handle, \"{1}\");", field_pi.Name, fieldAttr.SymbolName, library_name);
 					} else if (field_pi.PropertyType == TypeCache.System_UInt64) {
@@ -6427,8 +6410,6 @@ public partial class Generator : IMemberGatherer {
 							print ("Dlfcn.SetIntPtr (Libraries.{2}.Handle, \"{1}\", value);", field_pi.Name, fieldAttr.SymbolName, library_name);
 						} else if (field_pi.PropertyType == TypeCache.System_UIntPtr) {
 							print ("Dlfcn.SetUIntPtr (Libraries.{2}.Handle, \"{1}\", value);", field_pi.Name, fieldAttr.SymbolName, library_name);
-						} else if (field_pi.PropertyType.FullName == "System.Drawing.SizeF") {
-							print ("Dlfcn.SetSizeF (Libraries.{2}.Handle, \"{1}\", value);", field_pi.Name, fieldAttr.SymbolName, library_name);
 						} else if (field_pi.PropertyType == TypeCache.System_Int64) {
 							print ("Dlfcn.SetInt64 (Libraries.{2}.Handle, \"{1}\", value);", field_pi.Name, fieldAttr.SymbolName, library_name);
 						} else if (field_pi.PropertyType == TypeCache.System_UInt64) {
@@ -7501,9 +7482,6 @@ public partial class Generator : IMemberGatherer {
 
 		var type = def as Type;
 		if (type is not null && (
-			type.FullName == "System.Drawing.PointF" ||
-			type.FullName == "System.Drawing.SizeF" ||
-			type.FullName == "System.Drawing.RectangleF" ||
 			type.FullName == "CoreGraphics.CGPoint" ||
 			type.FullName == "CoreGraphics.CGSize" ||
 			type.FullName == "CoreGraphics.CGRect"))

--- a/tests/generator/bindastests.cs
+++ b/tests/generator/bindastests.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using Foundation;
 using CoreMedia;
 using CoreAnimation;
+using CoreGraphics;
 using ObjCRuntime;
 
 namespace BindAsTests {
@@ -12,10 +13,10 @@ namespace BindAsTests {
 
 		[return: BindAs (typeof (bool?))]
 		[Export ("boolMethod:a:b:c:d:")]
-		NSNumber BoolMethod (int arg0, string arg1, [BindAs (typeof (RectangleF))] NSValue arg2, [BindAs (typeof (bool?))] NSNumber arg3, int arg4);
+		NSNumber BoolMethod (int arg0, string arg1, [BindAs (typeof (CGRect))] NSValue arg2, [BindAs (typeof (bool?))] NSNumber arg3, int arg4);
 
 		[Export ("stringMethod:a:b:c:d:")]
-		string stringMethod (int arg0, string arg1, [BindAs (typeof (RectangleF))] NSValue arg2, [BindAs (typeof (bool?))] NSNumber arg3, int arg4);
+		string stringMethod (int arg0, string arg1, [BindAs (typeof (CGRect))] NSValue arg2, [BindAs (typeof (bool?))] NSNumber arg3, int arg4);
 
 		[return: BindAs (typeof (bool?))]
 		[Export ("boolMethod:")]
@@ -45,7 +46,7 @@ namespace BindAsTests {
 		[Export ("cmtimeMethod")]
 		NSValue CMTimeMethod ();
 
-		[return: BindAs (typeof (PointF))]
+		[return: BindAs (typeof (CGPoint))]
 		[Static, Export ("pointMethodS:")]
 		NSValue PointFMethodS (sbyte arg1);
 
@@ -57,11 +58,11 @@ namespace BindAsTests {
 		[Export ("doubleProperty")]
 		NSNumber DoubleProperty { get; set; }
 
-		[BindAs (typeof (RectangleF?))]
+		[BindAs (typeof (CGRect?))]
 		[Static, Export ("rectangleFPropertyS")]
 		NSValue RectangleFPropertyS { get; set; }
 
-		[BindAs (typeof (SizeF))]
+		[BindAs (typeof (CGSize))]
 		[Export ("sizeFFProperty")]
 		NSValue SizeFProperty { get; set; }
 


### PR DESCRIPTION
We do not longer support them in dotnet so we remove the support from bgen and update the tests to use the CoreGraphics alternatives.

If a user adds any of the remove types they will get an exception with an unboxing error.