### PR TITLE
[net10.0] [dotnet] Detect if the 'marshal-ilgen' component is needed.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -14,6 +14,7 @@
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.LinkNativeCode" AssemblyFile="$(_XamarinTaskAssembly)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.MergeAppBundles" AssemblyFile="$(_XamarinTaskAssembly)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.MobileILStrip" AssemblyFile="$(_XamarinTaskAssembly)" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.MobileMarshalingPInvokeScanner" AssemblyFile="$(_XamarinTaskAssembly)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.MacDevMessage" AssemblyFile="$(_XamarinTaskAssembly)" />
 
 	<!-- Project types and how do we distinguish between them
@@ -453,7 +454,26 @@
 		</Touch>
 	</Target>
 
-	<Target Name="_ComputeMonoComponents" Condition="'$(UseMonoRuntime)' == 'true' And '$(_LibMonoLinkMode)' == 'static'" BeforeTargets="_MonoSelectRuntimeComponents" DependsOnTargets="_ComputeVariables">
+	<Target
+		Name="_MonoDecideMarshalILGenComponent"
+		Condition="'$(_AppleExcludeMarshalIlgenComponent)' != ''"
+		DependsOnTargets="_ComputeManagedAssemblyToLink"
+	>
+
+		<MobileMarshalingPInvokeScanner
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
+			Assemblies="@(ManagedAssemblyToLink)">
+			<Output TaskParameter="IncompatibleAssemblies" ItemName="_AssembliesThatRequireILGen" />
+		</MobileMarshalingPInvokeScanner>
+
+		<PropertyGroup>
+			<_AppleExcludeMarshalIlgenComponent Condition="'@(_AssembliesThatRequireILGen->Count())' == 0">true</_AppleExcludeMarshalIlgenComponent>
+			<_AppleExcludeMarshalIlgenComponent Condition="'@(_AssembliesThatRequireILGen->Count())' > 0">false</_AppleExcludeMarshalIlgenComponent>
+		</PropertyGroup>
+	</Target>
+
+	<Target Name="_ComputeMonoComponents" Condition="'$(UseMonoRuntime)' == 'true' And '$(_LibMonoLinkMode)' == 'static'" BeforeTargets="_MonoSelectRuntimeComponents" DependsOnTargets="_ComputeVariables;_MonoDecideMarshalILGenComponent">
 		<!-- https://github.com/dotnet/runtime/blob/main/docs/design/mono/components.md -->
 		<ItemGroup>
 			<_MonoComponent Include="hot_reload" Condition="'$(MtouchInterpreter)' != ''" />

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/MarshalingPInvokeScanner.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/MarshalingPInvokeScanner.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Tasks;
+using Microsoft.Build.Utilities;
+
+using Xamarin.Messaging.Build.Client;
+
+#nullable enable
+
+namespace Xamarin.MacDev.Tasks {
+	public class MobileMarshalingPInvokeScanner : MonoTargetsTasks.MarshalingPInvokeScanner, ITaskCallback {
+		public string SessionId { get; set; } = string.Empty;
+
+		// FIXME: we might want to add a property as an output parameter to indicate whether any assemblies require
+		// marshaling, because the MarshalingPInvokeScanner task has a list of assemblies, which remote builds might
+		// want to (completely unnecessarily) copy back to Windows.
+
+		public override bool Execute ()
+		{
+			if (this.ShouldExecuteRemotely (SessionId))
+				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
+
+			var result = base.Execute ();
+
+			return result;
+		}
+
+		public bool ShouldCopyToBuildServer (ITaskItem item)
+		{
+			// Some assemblies are already on the Mac, and we have a 0-length
+			// output file on Windows. We don't want to copy these files.
+			// However, some assemblies have to be copied, because they don't
+			// already exist on the Mac (typically resource assemblies). So
+			// filter to assemblies with a non-zero length.
+
+			var finfo = new FileInfo (item.ItemSpec);
+			if (!finfo.Exists || finfo.Length == 0)
+				return false;
+
+			return true;
+		}
+
+		public bool ShouldCreateOutputFile (ITaskItem item) => true;
+
+		public IEnumerable<ITaskItem> GetAdditionalItemsToBeCopied () => Enumerable.Empty<ITaskItem> ();
+	}
+}


### PR DESCRIPTION
🚧 No need to review yet 🚧

Use the runtime's MarshalingPInvokeScanner task to detect if the
'marshal-ilgen' Mono component is required or not at runtime, and if we find
it's not required, remove it from the list of components we include in the
app.

PENDING:

* Doesn't work yet, due to numerous bugs in the MarshalingPInvokeScanner task. See #15684 for more info.
* App size numbers.
* Tests?
* Make sure it works from Windows.

Fixes https://github.com/xamarin/xamarin-macios/issues/15684.