### PR TITLE
[Bgen] Simplify the NSValue BindAS generated code.

### DIFF
--- a/src/CoreAnimation/NSValue.cs
+++ b/src/CoreAnimation/NSValue.cs
@@ -12,13 +12,13 @@ namespace Foundation;
 
 public partial class NSValue : NSObject {
 
-    /// <summary>
-    /// Converts a native handle to a CATransform3D.
-    /// </summary>
-    /// <param name="handle">The native handle.</param>
-    public static CATransform3D ToCATransform3D (NativeHandle handle)
-    {
-        using var nsvalue = Runtime.GetNSObject<NSValue> (handle);
-        return nsvalue.CATransform3DValue;
-    }
+	/// <summary>
+	/// Converts a native handle to a CATransform3D.
+	/// </summary>
+	/// <param name="handle">The native handle.</param>
+	public static CATransform3D ToCATransform3D (NativeHandle handle)
+	{
+		using var nsvalue = Runtime.GetNSObject<NSValue> (handle);
+		return nsvalue.CATransform3DValue;
+	}
 }

--- a/src/CoreAnimation/NSValue.cs
+++ b/src/CoreAnimation/NSValue.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Runtime.InteropServices;
+
+using ObjCRuntime;
+using CoreLocation;
+
+#nullable enable
+
+namespace Foundation;
+
+public partial class NSValue : NSObject {
+
+    /// <summary>
+    /// Converts a native handle to a CATransform3D.
+    /// </summary>
+    /// <param name="handle">The native handle.</param>
+    public static CATransform3D ToCATransform3D (NativeHandle handle)
+    {
+        using var nsvalue = Runtime.GetNSObject<NSValue> (handle);
+        return nsvalue.CATransform3DValue;
+    }
+}

--- a/src/CoreAnimation/NSValue.cs
+++ b/src/CoreAnimation/NSValue.cs
@@ -16,6 +16,7 @@ public partial class NSValue : NSObject {
 	/// Converts a native handle to a CATransform3D.
 	/// </summary>
 	/// <param name="handle">The native handle.</param>
+	/// <returns>The CATransform3D.</returns>
 	public static CATransform3D ToCATransform3D (NativeHandle handle)
 	{
 		using var nsvalue = Runtime.GetNSObject<NSValue> (handle);

--- a/src/CoreAnimation/NSValue.cs
+++ b/src/CoreAnimation/NSValue.cs
@@ -4,7 +4,7 @@ using System;
 using System.Runtime.InteropServices;
 
 using ObjCRuntime;
-using CoreLocation;
+using CoreAnimation;
 
 #nullable enable
 
@@ -19,7 +19,7 @@ public partial class NSValue : NSObject {
 	/// <returns>The CATransform3D.</returns>
 	public static CATransform3D ToCATransform3D (NativeHandle handle)
 	{
-		using var nsvalue = Runtime.GetNSObject<NSValue> (handle);
+		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
 		return nsvalue.CATransform3DValue;
 	}
 }

--- a/src/CoreGraphics/NSValue.cs
+++ b/src/CoreGraphics/NSValue.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Runtime.InteropServices;
+
+using CoreGraphics;
+using ObjCRuntime;
+
+#nullable enable
+
+namespace Foundation;
+
+public partial class NSValue : NSObject {
+
+    /// <summary>
+    /// Converts a native handle to a CGAffineTransform.
+    /// </summary>
+    /// <param name="handle">The native handle.</param>
+    public static CGAffineTransform ToCGAffineTransform (NativeHandle handle)
+    {
+        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+        return nsvalue.CGAffineTransformValue;
+    }
+
+    /// <summary>
+    /// Converts a native handle to a CGPoint.
+    /// </summary>
+    /// <param name="handle">The native handle.</param>
+    public static CGPoint ToCGPoint (NativeHandle handle)
+    {
+        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+        return nsvalue.CGPointValue;
+    }
+    
+    /// <summary>
+    /// Converts a native handle to a CGRect.
+    /// </summary>
+    /// <param name="handle">The native handle.</param>
+    public static CGRect ToCGRect (NativeHandle handle)
+    {
+        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+        return nsvalue.CGRectValue;
+    }
+
+    /// <summary>
+    /// Converts a native handle to a CGSize.
+    /// </summary>
+    /// <param name="handle">The native handle.</param>
+    public static CGSize ToCGSize (NativeHandle handle)
+    {
+        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+        return nsvalue.CGSizeValue;
+    }
+
+#if MONOMAC
+
+    // @encode(CGAffineTransform) -> "{CGAffineTransform=dddddd}" but...
+    // using a C string crash on macOS (while it works fine on iOS)
+    [DllImport ("__Internal")]
+    extern static IntPtr xamarin_encode_CGAffineTransform ();
+
+    // The `+valueWithCGAffineTransform:` selector comes from UIKit and is not available on macOS
+    public unsafe static NSValue FromCGAffineTransform (CGAffineTransform tran)
+    {
+        return Create ((IntPtr) (void*) &tran, xamarin_encode_CGAffineTransform ());
+    }
+
+    // The `CGAffineTransformValue` selector comes from UIKit and is not available on macOS
+    public unsafe virtual CGAffineTransform CGAffineTransformValue {
+        get {
+            var result = new CGAffineTransform ();
+            // avoid potential buffer overflow since we use the older `getValue:` API to cover all platforms
+            // and we can cheat here with the actual string comparison (since we are the one doing it)
+            if (ObjCType == "{CGAffineTransform=dddddd}")
+                StoreValueAtAddress ((IntPtr) (void*) &result);
+            return result;
+        }
+    }
+
+#else
+
+    /// <summary>
+    /// Converts a native handle to a CGVector.
+    /// </summary>
+    /// <param name="handle">The native handle.</param>
+    public static CGVector ToCGVector (NativeHandle handle)
+    {
+        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+        return nsvalue.CGVectorValue;
+    }
+
+#endif
+}

--- a/src/CoreGraphics/NSValue.cs
+++ b/src/CoreGraphics/NSValue.cs
@@ -12,45 +12,45 @@ namespace Foundation;
 
 public partial class NSValue : NSObject {
 
-    /// <summary>
-    /// Converts a native handle to a CGAffineTransform.
-    /// </summary>
-    /// <param name="handle">The native handle.</param>
-    public static CGAffineTransform ToCGAffineTransform (NativeHandle handle)
-    {
-        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
-        return nsvalue.CGAffineTransformValue;
-    }
+	/// <summary>
+	/// Converts a native handle to a CGAffineTransform.
+	/// </summary>
+	/// <param name="handle">The native handle.</param>
+	public static CGAffineTransform ToCGAffineTransform (NativeHandle handle)
+	{
+		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+		return nsvalue.CGAffineTransformValue;
+	}
 
-    /// <summary>
-    /// Converts a native handle to a CGPoint.
-    /// </summary>
-    /// <param name="handle">The native handle.</param>
-    public static CGPoint ToCGPoint (NativeHandle handle)
-    {
-        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
-        return nsvalue.CGPointValue;
-    }
-    
-    /// <summary>
-    /// Converts a native handle to a CGRect.
-    /// </summary>
-    /// <param name="handle">The native handle.</param>
-    public static CGRect ToCGRect (NativeHandle handle)
-    {
-        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
-        return nsvalue.CGRectValue;
-    }
+	/// <summary>
+	/// Converts a native handle to a CGPoint.
+	/// </summary>
+	/// <param name="handle">The native handle.</param>
+	public static CGPoint ToCGPoint (NativeHandle handle)
+	{
+		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+		return nsvalue.CGPointValue;
+	}
 
-    /// <summary>
-    /// Converts a native handle to a CGSize.
-    /// </summary>
-    /// <param name="handle">The native handle.</param>
-    public static CGSize ToCGSize (NativeHandle handle)
-    {
-        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
-        return nsvalue.CGSizeValue;
-    }
+	/// <summary>
+	/// Converts a native handle to a CGRect.
+	/// </summary>
+	/// <param name="handle">The native handle.</param>
+	public static CGRect ToCGRect (NativeHandle handle)
+	{
+		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+		return nsvalue.CGRectValue;
+	}
+
+	/// <summary>
+	/// Converts a native handle to a CGSize.
+	/// </summary>
+	/// <param name="handle">The native handle.</param>
+	public static CGSize ToCGSize (NativeHandle handle)
+	{
+		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+		return nsvalue.CGSizeValue;
+	}
 
 #if MONOMAC
 
@@ -79,15 +79,15 @@ public partial class NSValue : NSObject {
 
 #else
 
-    /// <summary>
-    /// Converts a native handle to a CGVector.
-    /// </summary>
-    /// <param name="handle">The native handle.</param>
-    public static CGVector ToCGVector (NativeHandle handle)
-    {
-        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
-        return nsvalue.CGVectorValue;
-    }
+	/// <summary>
+	/// Converts a native handle to a CGVector.
+	/// </summary>
+	/// <param name="handle">The native handle.</param>
+	public static CGVector ToCGVector (NativeHandle handle)
+	{
+		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+		return nsvalue.CGVectorValue;
+	}
 
 #endif
 }

--- a/src/CoreGraphics/NSValue.cs
+++ b/src/CoreGraphics/NSValue.cs
@@ -16,6 +16,7 @@ public partial class NSValue : NSObject {
 	/// Converts a native handle to a CGAffineTransform.
 	/// </summary>
 	/// <param name="handle">The native handle.</param>
+	/// <returns>The CGAffineTransform.</returns>
 	public static CGAffineTransform ToCGAffineTransform (NativeHandle handle)
 	{
 		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
@@ -26,6 +27,7 @@ public partial class NSValue : NSObject {
 	/// Converts a native handle to a CGPoint.
 	/// </summary>
 	/// <param name="handle">The native handle.</param>
+	/// <returns>The CGPoint.</returns>
 	public static CGPoint ToCGPoint (NativeHandle handle)
 	{
 		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
@@ -36,6 +38,7 @@ public partial class NSValue : NSObject {
 	/// Converts a native handle to a CGRect.
 	/// </summary>
 	/// <param name="handle">The native handle.</param>
+	/// <returns>The CGRect.</returns>
 	public static CGRect ToCGRect (NativeHandle handle)
 	{
 		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
@@ -46,6 +49,7 @@ public partial class NSValue : NSObject {
 	/// Converts a native handle to a CGSize.
 	/// </summary>
 	/// <param name="handle">The native handle.</param>
+	/// <returns>The CGSize.</returns>
 	public static CGSize ToCGSize (NativeHandle handle)
 	{
 		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
@@ -83,6 +87,7 @@ public partial class NSValue : NSObject {
 	/// Converts a native handle to a CGVector.
 	/// </summary>
 	/// <param name="handle">The native handle.</param>
+	/// <returns>The CGVector.</returns>
 	public static CGVector ToCGVector (NativeHandle handle)
 	{
 		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;

--- a/src/CoreLocation/NSValue.cs
+++ b/src/CoreLocation/NSValue.cs
@@ -12,13 +12,13 @@ namespace Foundation;
 
 public partial class NSValue : NSObject {
 
-    /// <summary>
-    /// Converts a native handle to a CLLocationCoordinate2D.
-    /// </summary>
-    /// <param name="handle">The native handle.</param>
-    public static CLLocationCoordinate2D ToCLLocationCoordinate2D (NativeHandle handle)
-    {
-        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
-        return nsvalue.CoordinateValue;
-    }
+	/// <summary>
+	/// Converts a native handle to a CLLocationCoordinate2D.
+	/// </summary>
+	/// <param name="handle">The native handle.</param>
+	public static CLLocationCoordinate2D ToCLLocationCoordinate2D (NativeHandle handle)
+	{
+		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+		return nsvalue.CoordinateValue;
+	}
 }

--- a/src/CoreLocation/NSValue.cs
+++ b/src/CoreLocation/NSValue.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Runtime.InteropServices;
+
+using ObjCRuntime;
+using CoreLocation;
+
+#nullable enable
+
+namespace Foundation;
+
+public partial class NSValue : NSObject {
+
+    /// <summary>
+    /// Converts a native handle to a CLLocationCoordinate2D.
+    /// </summary>
+    /// <param name="handle">The native handle.</param>
+    public static CLLocationCoordinate2D ToCLLocationCoordinate2D (NativeHandle handle)
+    {
+        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+        return nsvalue.CoordinateValue;
+    }
+}

--- a/src/CoreLocation/NSValue.cs
+++ b/src/CoreLocation/NSValue.cs
@@ -16,6 +16,7 @@ public partial class NSValue : NSObject {
 	/// Converts a native handle to a CLLocationCoordinate2D.
 	/// </summary>
 	/// <param name="handle">The native handle.</param>
+	/// <returns>The CLLocationCoordinate2D.</returns>
 	public static CLLocationCoordinate2D ToCLLocationCoordinate2D (NativeHandle handle)
 	{
 		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;

--- a/src/CoreMedia/NSValue.cs
+++ b/src/CoreMedia/NSValue.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Runtime.InteropServices;
+
+using ObjCRuntime;
+using CoreMedia;
+
+#nullable enable
+
+namespace Foundation;
+
+public partial class NSValue : NSObject {
+
+    /// <summary>
+    /// Converts a native handle to a CMTime.
+    /// </summary>
+    /// <param name="handle">The native handle.</param>
+    public static CMTimeRange ToCMTimeRange (NativeHandle handle)
+    {
+        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+        return nsvalue.CMTimeRangeValue;
+    }
+
+    /// <summary>
+    /// Converts a native handle to a CMTime.
+    /// </summary>
+    /// <param name="handle">The native handle.</param>
+    public static CMTime ToCMTime (NativeHandle handle)
+    {
+        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+        return nsvalue.CMTimeValue;
+    }
+
+    /// <summary>
+    /// Converts a native handle to a CMTimeMapping.
+    /// </summary>
+    /// <param name="handle">The native handle.</param>
+    public static CMTimeMapping ToCMTimeMapping (NativeHandle handle)
+    {
+        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+        return nsvalue.CMTimeMappingValue;
+    }
+
+    /// <summary>
+    /// Converts a native handle to a CMTimeRange.
+    /// </summary>
+    /// <param name="handle">The native handle.</param>
+    public static CMVideoDimensions ToCMVideoDimensions (NativeHandle handle)
+    {
+        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+        return nsvalue.CMVideoDimensionsValue;
+    }
+
+}

--- a/src/CoreMedia/NSValue.cs
+++ b/src/CoreMedia/NSValue.cs
@@ -12,44 +12,44 @@ namespace Foundation;
 
 public partial class NSValue : NSObject {
 
-    /// <summary>
-    /// Converts a native handle to a CMTime.
-    /// </summary>
-    /// <param name="handle">The native handle.</param>
-    public static CMTimeRange ToCMTimeRange (NativeHandle handle)
-    {
-        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
-        return nsvalue.CMTimeRangeValue;
-    }
+	/// <summary>
+	/// Converts a native handle to a CMTime.
+	/// </summary>
+	/// <param name="handle">The native handle.</param>
+	public static CMTimeRange ToCMTimeRange (NativeHandle handle)
+	{
+		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+		return nsvalue.CMTimeRangeValue;
+	}
 
-    /// <summary>
-    /// Converts a native handle to a CMTime.
-    /// </summary>
-    /// <param name="handle">The native handle.</param>
-    public static CMTime ToCMTime (NativeHandle handle)
-    {
-        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
-        return nsvalue.CMTimeValue;
-    }
+	/// <summary>
+	/// Converts a native handle to a CMTime.
+	/// </summary>
+	/// <param name="handle">The native handle.</param>
+	public static CMTime ToCMTime (NativeHandle handle)
+	{
+		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+		return nsvalue.CMTimeValue;
+	}
 
-    /// <summary>
-    /// Converts a native handle to a CMTimeMapping.
-    /// </summary>
-    /// <param name="handle">The native handle.</param>
-    public static CMTimeMapping ToCMTimeMapping (NativeHandle handle)
-    {
-        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
-        return nsvalue.CMTimeMappingValue;
-    }
+	/// <summary>
+	/// Converts a native handle to a CMTimeMapping.
+	/// </summary>
+	/// <param name="handle">The native handle.</param>
+	public static CMTimeMapping ToCMTimeMapping (NativeHandle handle)
+	{
+		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+		return nsvalue.CMTimeMappingValue;
+	}
 
-    /// <summary>
-    /// Converts a native handle to a CMTimeRange.
-    /// </summary>
-    /// <param name="handle">The native handle.</param>
-    public static CMVideoDimensions ToCMVideoDimensions (NativeHandle handle)
-    {
-        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
-        return nsvalue.CMVideoDimensionsValue;
-    }
+	/// <summary>
+	/// Converts a native handle to a CMTimeRange.
+	/// </summary>
+	/// <param name="handle">The native handle.</param>
+	public static CMVideoDimensions ToCMVideoDimensions (NativeHandle handle)
+	{
+		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+		return nsvalue.CMVideoDimensionsValue;
+	}
 
 }

--- a/src/CoreMedia/NSValue.cs
+++ b/src/CoreMedia/NSValue.cs
@@ -16,6 +16,7 @@ public partial class NSValue : NSObject {
 	/// Converts a native handle to a CMTime.
 	/// </summary>
 	/// <param name="handle">The native handle.</param>
+	/// <returns>The CMTime.</returns>
 	public static CMTimeRange ToCMTimeRange (NativeHandle handle)
 	{
 		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
@@ -26,6 +27,7 @@ public partial class NSValue : NSObject {
 	/// Converts a native handle to a CMTime.
 	/// </summary>
 	/// <param name="handle">The native handle.</param>
+	/// <returns>The CMTime.</returns>
 	public static CMTime ToCMTime (NativeHandle handle)
 	{
 		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
@@ -36,6 +38,7 @@ public partial class NSValue : NSObject {
 	/// Converts a native handle to a CMTimeMapping.
 	/// </summary>
 	/// <param name="handle">The native handle.</param>
+	/// <returns>The CMTimeMapping.</returns>
 	public static CMTimeMapping ToCMTimeMapping (NativeHandle handle)
 	{
 		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
@@ -46,6 +49,7 @@ public partial class NSValue : NSObject {
 	/// Converts a native handle to a CMTimeRange.
 	/// </summary>
 	/// <param name="handle">The native handle.</param>
+	/// <returns>The CMTimeRange.</returns>
 	public static CMVideoDimensions ToCMVideoDimensions (NativeHandle handle)
 	{
 		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;

--- a/src/Foundation/NSValue.cs
+++ b/src/Foundation/NSValue.cs
@@ -29,8 +29,6 @@ using System.Drawing;
 #endif
 using System.Runtime.InteropServices;
 
-using CoreGraphics;
-
 // Disable until we get around to enable + fix any issues.
 #nullable disable
 
@@ -72,30 +70,6 @@ namespace Foundation {
 		}
 #endif
 
-#if MONOMAC
-		// @encode(CGAffineTransform) -> "{CGAffineTransform=dddddd}" but...
-		// using a C string crash on macOS (while it works fine on iOS)
-		[DllImport ("__Internal")]
-		extern static IntPtr xamarin_encode_CGAffineTransform ();
-
-		// The `+valueWithCGAffineTransform:` selector comes from UIKit and is not available on macOS
-		public unsafe static NSValue FromCGAffineTransform (CGAffineTransform tran)
-		{
-			return Create ((IntPtr) (void*) &tran, xamarin_encode_CGAffineTransform ());
-		}
-
-		// The `CGAffineTransformValue` selector comes from UIKit and is not available on macOS
-		public unsafe virtual CGAffineTransform CGAffineTransformValue {
-			get {
-				var result = new CGAffineTransform ();
-				// avoid potential buffer overflow since we use the older `getValue:` API to cover all platforms
-				// and we can cheat here with the actual string comparison (since we are the one doing it)
-				if (ObjCType == "{CGAffineTransform=dddddd}")
-					StoreValueAtAddress ((IntPtr) (void*) &result);
-				return result;
-			}
-		}
-#endif
 #endif
 	}
 }

--- a/src/MapKit/NSValue.cs
+++ b/src/MapKit/NSValue.cs
@@ -12,14 +12,14 @@ namespace Foundation;
 
 public partial class NSValue : NSObject {
 
-    /// <summary>
-    /// Converts a native handle to a MKCoordinateRegion.
-    /// </summary>
-    /// <param name="handle">The native handle.</param>
-    public static MKCoordinateSpan ToMKCoordinateSpan (NativeHandle handle)
-    {
-        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
-        return nsvalue.CoordinateSpanValue;
-    }
+	/// <summary>
+	/// Converts a native handle to a MKCoordinateRegion.
+	/// </summary>
+	/// <param name="handle">The native handle.</param>
+	public static MKCoordinateSpan ToMKCoordinateSpan (NativeHandle handle)
+	{
+		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+		return nsvalue.CoordinateSpanValue;
+	}
 
 }

--- a/src/MapKit/NSValue.cs
+++ b/src/MapKit/NSValue.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Runtime.InteropServices;
+
+using ObjCRuntime;
+using MapKit;
+
+#nullable enable
+
+namespace Foundation;
+
+public partial class NSValue : NSObject {
+
+    /// <summary>
+    /// Converts a native handle to a MKCoordinateRegion.
+    /// </summary>
+    /// <param name="handle">The native handle.</param>
+    public static MKCoordinateSpan ToMKCoordinateSpan (NativeHandle handle)
+    {
+        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+        return nsvalue.CoordinateSpanValue;
+    }
+
+}

--- a/src/MapKit/NSValue.cs
+++ b/src/MapKit/NSValue.cs
@@ -16,6 +16,7 @@ public partial class NSValue : NSObject {
 	/// Converts a native handle to a MKCoordinateRegion.
 	/// </summary>
 	/// <param name="handle">The native handle.</param>
+	/// <returns>The MKCoordinateRegion.</returns>
 	public static MKCoordinateSpan ToMKCoordinateSpan (NativeHandle handle)
 	{
 		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;

--- a/src/SceneKit/NSValue.cs
+++ b/src/SceneKit/NSValue.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Runtime.InteropServices;
+
+using ObjCRuntime;
+using SceneKit;
+
+#nullable enable
+
+namespace Foundation;
+
+public partial class NSValue : NSObject {
+
+    /// <summary>
+    /// Converts a native handle to a SCNMatrix4.
+    /// </summary>
+    /// <param name="handle">The native handle.</param>
+    public static SCNMatrix4 ToSCNMatrix4 (NativeHandle handle)
+    {
+        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+        return nsvalue.SCNMatrix4Value;
+    }
+
+    /// <summary>
+    /// Converts a native handle to a NSRange.
+    /// </summary>
+    /// <param name="handle">The native handle.</param>
+    public static NSRange ToNSRange (NativeHandle handle)
+    {
+        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+        return nsvalue.RangeValue;
+    }
+
+    /// <summary>
+    /// Converts a native handle to a SCNVector3.
+    /// </summary>
+    /// <param name="handle">The native handle.</param>
+    public static SCNVector3 ToSCNVector3 (NativeHandle handle)
+    {
+        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+        return nsvalue.Vector3Value;
+    }
+
+    /// <summary>
+    /// Converts a native handle to a SCNVector4.
+    /// </summary>
+    /// <param name="handle">The native handle.</param>
+    public static SCNVector4 ToSCNVector4 (NativeHandle handle)
+    {
+        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+        return nsvalue.Vector4Value;
+    }
+
+}

--- a/src/SceneKit/NSValue.cs
+++ b/src/SceneKit/NSValue.cs
@@ -12,44 +12,44 @@ namespace Foundation;
 
 public partial class NSValue : NSObject {
 
-    /// <summary>
-    /// Converts a native handle to a SCNMatrix4.
-    /// </summary>
-    /// <param name="handle">The native handle.</param>
-    public static SCNMatrix4 ToSCNMatrix4 (NativeHandle handle)
-    {
-        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
-        return nsvalue.SCNMatrix4Value;
-    }
+	/// <summary>
+	/// Converts a native handle to a SCNMatrix4.
+	/// </summary>
+	/// <param name="handle">The native handle.</param>
+	public static SCNMatrix4 ToSCNMatrix4 (NativeHandle handle)
+	{
+		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+		return nsvalue.SCNMatrix4Value;
+	}
 
-    /// <summary>
-    /// Converts a native handle to a NSRange.
-    /// </summary>
-    /// <param name="handle">The native handle.</param>
-    public static NSRange ToNSRange (NativeHandle handle)
-    {
-        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
-        return nsvalue.RangeValue;
-    }
+	/// <summary>
+	/// Converts a native handle to a NSRange.
+	/// </summary>
+	/// <param name="handle">The native handle.</param>
+	public static NSRange ToNSRange (NativeHandle handle)
+	{
+		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+		return nsvalue.RangeValue;
+	}
 
-    /// <summary>
-    /// Converts a native handle to a SCNVector3.
-    /// </summary>
-    /// <param name="handle">The native handle.</param>
-    public static SCNVector3 ToSCNVector3 (NativeHandle handle)
-    {
-        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
-        return nsvalue.Vector3Value;
-    }
+	/// <summary>
+	/// Converts a native handle to a SCNVector3.
+	/// </summary>
+	/// <param name="handle">The native handle.</param>
+	public static SCNVector3 ToSCNVector3 (NativeHandle handle)
+	{
+		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+		return nsvalue.Vector3Value;
+	}
 
-    /// <summary>
-    /// Converts a native handle to a SCNVector4.
-    /// </summary>
-    /// <param name="handle">The native handle.</param>
-    public static SCNVector4 ToSCNVector4 (NativeHandle handle)
-    {
-        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
-        return nsvalue.Vector4Value;
-    }
+	/// <summary>
+	/// Converts a native handle to a SCNVector4.
+	/// </summary>
+	/// <param name="handle">The native handle.</param>
+	public static SCNVector4 ToSCNVector4 (NativeHandle handle)
+	{
+		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+		return nsvalue.Vector4Value;
+	}
 
 }

--- a/src/SceneKit/NSValue.cs
+++ b/src/SceneKit/NSValue.cs
@@ -16,6 +16,7 @@ public partial class NSValue : NSObject {
 	/// Converts a native handle to a SCNMatrix4.
 	/// </summary>
 	/// <param name="handle">The native handle.</param>
+	/// <returns>The SCNMatrix4.</returns>	
 	public static SCNMatrix4 ToSCNMatrix4 (NativeHandle handle)
 	{
 		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
@@ -26,6 +27,7 @@ public partial class NSValue : NSObject {
 	/// Converts a native handle to a NSRange.
 	/// </summary>
 	/// <param name="handle">The native handle.</param>
+	/// <returns>The NSRange.</returns>
 	public static NSRange ToNSRange (NativeHandle handle)
 	{
 		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
@@ -36,6 +38,7 @@ public partial class NSValue : NSObject {
 	/// Converts a native handle to a SCNVector3.
 	/// </summary>
 	/// <param name="handle">The native handle.</param>
+	/// <returns>The SCNVector3.</returns>
 	public static SCNVector3 ToSCNVector3 (NativeHandle handle)
 	{
 		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
@@ -46,6 +49,7 @@ public partial class NSValue : NSObject {
 	/// Converts a native handle to a SCNVector4.
 	/// </summary>
 	/// <param name="handle">The native handle.</param>
+	/// <returns>The SCNVector4.</returns>
 	public static SCNVector4 ToSCNVector4 (NativeHandle handle)
 	{
 		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;

--- a/src/UIKit/NSValue.cs
+++ b/src/UIKit/NSValue.cs
@@ -12,24 +12,24 @@ namespace Foundation;
 
 public partial class NSValue : NSObject {
 
-    /// <summary>
-    /// Converts a native handle to a UIEdgeInsets.
-    /// </summary>
-    /// <param name="handle">The native handle.</param>
-    public static UIEdgeInsets ToUIEdgeInsets (NativeHandle handle)
-    {
-        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
-        return nsvalue.UIEdgeInsetsValue;
-    }
+	/// <summary>
+	/// Converts a native handle to a UIEdgeInsets.
+	/// </summary>
+	/// <param name="handle">The native handle.</param>
+	public static UIEdgeInsets ToUIEdgeInsets (NativeHandle handle)
+	{
+		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+		return nsvalue.UIEdgeInsetsValue;
+	}
 
-    /// <summary>
-    /// Converts a native handle to a UIOffset.
-    /// </summary>
-    /// <param name="handle">The native handle.</param>
-    public static UIOffset ToUIOffset (NativeHandle handle)
-    {
-        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
-        return nsvalue.UIOffsetValue;
-    }
+	/// <summary>
+	/// Converts a native handle to a UIOffset.
+	/// </summary>
+	/// <param name="handle">The native handle.</param>
+	public static UIOffset ToUIOffset (NativeHandle handle)
+	{
+		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+		return nsvalue.UIOffsetValue;
+	}
 }
 

--- a/src/UIKit/NSValue.cs
+++ b/src/UIKit/NSValue.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Runtime.InteropServices;
+
+using ObjCRuntime;
+using UIKit;
+
+#nullable enable
+
+namespace Foundation;
+
+public partial class NSValue : NSObject {
+
+    /// <summary>
+    /// Converts a native handle to a UIEdgeInsets.
+    /// </summary>
+    /// <param name="handle">The native handle.</param>
+    public static UIEdgeInsets ToUIEdgeInsets (NativeHandle handle)
+    {
+        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+        return nsvalue.UIEdgeInsetsValue;
+    }
+
+    /// <summary>
+    /// Converts a native handle to a UIOffset.
+    /// </summary>
+    /// <param name="handle">The native handle.</param>
+    public static UIOffset ToUIOffset (NativeHandle handle)
+    {
+        using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+        return nsvalue.UIOffsetValue;
+    }
+}
+

--- a/src/UIKit/NSValue.cs
+++ b/src/UIKit/NSValue.cs
@@ -16,6 +16,7 @@ public partial class NSValue : NSObject {
 	/// Converts a native handle to a UIEdgeInsets.
 	/// </summary>
 	/// <param name="handle">The native handle.</param>
+	/// <returns>The UIEdgeInsets.</returns>
 	public static UIEdgeInsets ToUIEdgeInsets (NativeHandle handle)
 	{
 		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
@@ -26,10 +27,22 @@ public partial class NSValue : NSObject {
 	/// Converts a native handle to a UIOffset.
 	/// </summary>
 	/// <param name="handle">The native handle.</param>
+	/// <returns>The UIOffset.</returns>
 	public static UIOffset ToUIOffset (NativeHandle handle)
 	{
 		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
 		return nsvalue.UIOffsetValue;
+	}
+
+	/// <summary>
+	/// Converts a native handle to a NSDirectionalEdgeInsets.
+	/// </summary>
+	/// <param name="handle">The native handle.</param>
+	/// <returns>The NSDirectionalEdgeInsets.</returns>
+	public static NSDirectionalEdgeInsets ToNSDirectionalEdgeInsets (NativeHandle handle)
+	{
+		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
+		return nsvalue.NSDirectionalEdgeInsetsValue;
 	}
 }
 

--- a/src/UIKit/NSValue.cs
+++ b/src/UIKit/NSValue.cs
@@ -42,7 +42,7 @@ public partial class NSValue : NSObject {
 	public static NSDirectionalEdgeInsets ToNSDirectionalEdgeInsets (NativeHandle handle)
 	{
 		using var nsvalue = Runtime.GetNSObject<NSValue> (handle)!;
-		return nsvalue.NSDirectionalEdgeInsetsValue;
+		return nsvalue.DirectionalEdgeInsetsValue;
 	}
 }
 

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -524,8 +524,8 @@ public partial class Generator : IMemberGatherer {
 				} else
 					throw GetBindAsException ("unbox", retType.Name, arrType.Name, "array", minfo.mi);
 			} else if (arrType == TypeCache.NSValue && !arrIsNullable) {
-				if (TypeManager.NSValueReturnMap.TryGetValue (arrRetType, out valueFetcher)) {
-					append = string.Format ("ptr => {{\n\tusing (var val = Runtime.GetNSObject<NSValue> (ptr)!) {{\n\t\treturn val{0};\n\t}}\n}}", valueFetcher);
+				if (TypeManager.NSValueBindAsMap.TryGetValue (arrRetType, out valueFetcher)) {
+					append = string.Format ("NSValue.{0}", valueFetcher);
 				} else {
 					throw GetBindAsException ("unbox", retType.Name, arrType.Name, "array", minfo.mi);
 				}

--- a/src/bgen/TypeManager.cs
+++ b/src/bgen/TypeManager.cs
@@ -146,6 +146,60 @@ public class TypeManager {
 			return nsvalueReturnMap;
 		}
 	}
+	
+#pragma warning disable format
+	Dictionary<Type, string>? nsvalueBindAsMap;
+	public Dictionary<Type, string> NSValueBindAsMap {
+		get {
+			if (nsvalueBindAsMap is not null)
+				return nsvalueBindAsMap;
+			Tuple<Type?, string> [] general = {
+				new(TypeCache.CGAffineTransform, "ToCGAffineTransform"),
+				new(TypeCache.NSRange, "ToNSRange"),
+				new(TypeCache.CGVector, "ToCGVector"),
+				new(TypeCache.SCNMatrix4, "ToSCNMatrix4"),
+				new(TypeCache.CLLocationCoordinate2D, "ToCLLocationCoordinate2D"),
+				new(TypeCache.SCNVector3, "ToSCNVector3"),
+				new(TypeCache.SCNVector4, "ToSCNVector4"),
+				new(TypeCache.CoreGraphics_CGPoint, "ToCGPoint"),
+				new(TypeCache.CoreGraphics_CGRect, "ToCGRect"),
+				new(TypeCache.CoreGraphics_CGSize, "ToCGSize"),
+				new(TypeCache.MKCoordinateSpan, "ToMKCoordinateSpan"),
+			};
+
+			Tuple<Type?, string> [] uiKitMap = Array.Empty<Tuple<Type?, string>> ();
+			if (Frameworks.HaveUIKit)
+				uiKitMap = new Tuple<Type?, string> [] {
+					new(TypeCache.UIEdgeInsets, "ToUIEdgeInsets"),
+					new(TypeCache.UIOffset, "ToUIOffset"),
+				};
+
+			Tuple<Type?, string> [] coreMedia = Array.Empty<Tuple<Type?, string>> ();
+			if (Frameworks.HaveCoreMedia)
+				coreMedia = new Tuple<Type?, string> [] {
+					new(TypeCache.CMTimeRange, "ToCMTimeRange"), 
+					new(TypeCache.CMTime, "ToCMTime"),
+					new(TypeCache.CMTimeMapping, "ToCMTimeMapping"),
+					new (TypeCache.CMVideoDimensions, "ToCMVideoDimensions"),
+				};
+
+			Tuple<Type?, string> [] animation = Array.Empty<Tuple<Type?, string>> ();
+			if (Frameworks.HaveCoreAnimation)
+				animation = new Tuple<Type?, string> [] { new(TypeCache.CATransform3D, "ToCATransform3D"), };
+
+			nsvalueBindAsMap = new();
+			foreach (var typeMap in new [] { general, uiKitMap, coreMedia, animation }) {
+				foreach (var tuple in typeMap) {
+					if (tuple.Item1 is not null)
+						nsvalueBindAsMap [tuple.Item1] = tuple.Item2;
+				}
+			}
+
+			return nsvalueBindAsMap;
+		}
+	}
+	
+#pragma warning restore format
 
 	public Type? GetUnderlyingNullableType (Type type)
 	{

--- a/src/bgen/TypeManager.cs
+++ b/src/bgen/TypeManager.cs
@@ -154,32 +154,33 @@ public class TypeManager {
 			if (nsvalueBindAsMap is not null)
 				return nsvalueBindAsMap;
 			Tuple<Type?, string> [] general = {
-				new(TypeCache.CGAffineTransform, "ToCGAffineTransform"),
-				new(TypeCache.NSRange, "ToNSRange"),
-				new(TypeCache.CGVector, "ToCGVector"),
-				new(TypeCache.SCNMatrix4, "ToSCNMatrix4"),
-				new(TypeCache.CLLocationCoordinate2D, "ToCLLocationCoordinate2D"),
-				new(TypeCache.SCNVector3, "ToSCNVector3"),
-				new(TypeCache.SCNVector4, "ToSCNVector4"),
-				new(TypeCache.CoreGraphics_CGPoint, "ToCGPoint"),
-				new(TypeCache.CoreGraphics_CGRect, "ToCGRect"),
-				new(TypeCache.CoreGraphics_CGSize, "ToCGSize"),
-				new(TypeCache.MKCoordinateSpan, "ToMKCoordinateSpan"),
+				new (TypeCache.CGAffineTransform, "ToCGAffineTransform"),
+				new (TypeCache.NSRange, "ToNSRange"),
+				new (TypeCache.CGVector, "ToCGVector"),
+				new (TypeCache.SCNMatrix4, "ToSCNMatrix4"),
+				new (TypeCache.CLLocationCoordinate2D, "ToCLLocationCoordinate2D"),
+				new (TypeCache.SCNVector3, "ToSCNVector3"),
+				new (TypeCache.SCNVector4, "ToSCNVector4"),
+				new (TypeCache.CoreGraphics_CGPoint, "ToCGPoint"),
+				new (TypeCache.CoreGraphics_CGRect, "ToCGRect"),
+				new (TypeCache.CoreGraphics_CGSize, "ToCGSize"),
+				new (TypeCache.MKCoordinateSpan, "ToMKCoordinateSpan"),
 			};
 
 			Tuple<Type?, string> [] uiKitMap = Array.Empty<Tuple<Type?, string>> ();
 			if (Frameworks.HaveUIKit)
 				uiKitMap = new Tuple<Type?, string> [] {
-					new(TypeCache.UIEdgeInsets, "ToUIEdgeInsets"),
-					new(TypeCache.UIOffset, "ToUIOffset"),
+					new (TypeCache.UIEdgeInsets, "ToUIEdgeInsets"),
+					new (TypeCache.UIOffset, "ToUIOffset"),
+					new (TypeCache.NSDirectionalEdgeInsets, "ToNSDirectionalEdgeInsets"),
 				};
 
 			Tuple<Type?, string> [] coreMedia = Array.Empty<Tuple<Type?, string>> ();
 			if (Frameworks.HaveCoreMedia)
 				coreMedia = new Tuple<Type?, string> [] {
-					new(TypeCache.CMTimeRange, "ToCMTimeRange"), 
-					new(TypeCache.CMTime, "ToCMTime"),
-					new(TypeCache.CMTimeMapping, "ToCMTimeMapping"),
+					new (TypeCache.CMTimeRange, "ToCMTimeRange"), 
+					new (TypeCache.CMTime, "ToCMTime"),
+					new (TypeCache.CMTimeMapping, "ToCMTimeMapping"),
 					new (TypeCache.CMVideoDimensions, "ToCMVideoDimensions"),
 				};
 

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -552,6 +552,7 @@ COREGRAPHICS_SOURCES = \
 	CoreGraphics/CGSession.cs \
 	CoreGraphics/CGShading.cs \
 	CoreGraphics/NativeDrawingMethods.cs \
+	CoreGraphics/NSValue.cs \
 
 # CoreHaptics
 
@@ -588,6 +589,7 @@ CORELOCATION_SOURCES = \
 	CoreLocation/CLBeaconRegion.cs \
 	CoreLocation/CLCompat.cs \
 	CoreLocation/CLLocationManager.cs \
+	CoreLocation/NSValue.cs \
 
 # CoreMedia
 
@@ -613,6 +615,7 @@ COREMEDIA_SOURCES = \
 	CoreMedia/CMCustomBlockAllocator.cs \
 	CoreMedia/CMBufferQueue.cs \
 	CoreMedia/CMMemoryPool.cs \
+	CoreMedia/NSValue.cs \
 
 # CoreMidi
 
@@ -1130,6 +1133,7 @@ MAPKIT_SOURCES = \
 	MapKit/MKPolygon.cs \
 	MapKit/MKPolyline.cs \
 	MapKit/MKUserLocation.cs \
+	MapKit/NSValue.cs \
 
 # MediaAccessibility
 
@@ -1591,6 +1595,7 @@ SCENEKIT_SOURCES = \
 	SceneKit/SCNSceneSource.cs \
 	SceneKit/SCNSkinner.cs \
 	SceneKit/SCNTechnique.cs \
+	SceneKit/NSValue.cs \
 
 # ScreenCaptureKit
 
@@ -1816,6 +1821,7 @@ UIKIT_SOURCES = \
 	UIKit/UIViewControllerTransitionCoordinatorContext.cs \
 	UIKit/UIWindow.cs \
 	UIKit/UIWindowScene.cs \
+	UIKit/NSValue.cs \
 
 # UserNotifications
 

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -432,6 +432,7 @@ COREANIMATION_SOURCES = \
 	CoreAnimation/CAMediaTimingFunction.cs \
 	CoreAnimation/CAScrollLayer.cs \
 	CoreAnimation/CATextLayer.cs \
+	CoreAnimation/NSValue.cs \
 
 # CoreBluetooth
 


### PR DESCRIPTION
As with previous changes, move to use a method group instead of a lambda with a using block.

We only add the new methods in those platforms that have the specifict frameworks by using partial class. That way we keep the code cleaner than with a collection of #if statements.