### PR TITLE
[Rgen] Remove properties that are part of the binding type.

### DIFF
--- a/src/ObjCBindings/ExportAttribute.cs
+++ b/src/ObjCBindings/ExportAttribute.cs
@@ -51,21 +51,6 @@ namespace ObjCBindings {
 		/// </summary >
 		public string? Library { get; set; } = null;
 
-		/// <summary>
-		///
-		/// </summary >
-		public MethodAttributes DefaultCtorVisibility { get; set; }
-
-		/// <summary>
-		///
-		/// </summary >
-		public MethodAttributes IntPtrCtorVisibility { get; set; }
-
-		/// <summary>
-		///
-		/// </summary >
-		public MethodAttributes StringCtorVisibility { get; set; }
-
 		protected ExportAttribute () { }
 
 		/// <summary>


### PR DESCRIPTION
Looks like we landed code that should have never landed. But there is no issues because the API is marked as experimental. It is the rgen binding API.