### PR TITLE
[RGen] Add missing configuration options for notifications.

### DIFF
--- a/src/ObjCBindings/FieldAttribute.cs
+++ b/src/ObjCBindings/FieldAttribute.cs
@@ -28,6 +28,16 @@ namespace ObjCBindings {
 		public string? LibraryName { get; set; } = default;
 
 		/// <summary>
+		/// Get/Set the notification type.
+		/// </summary >
+		public Type? Type { get; set; } = null;
+
+		/// <summary>
+		/// Get/Set the notification center.
+		/// </summary >
+		public string? NotificationCenter { get; set; } = null;
+
+		/// <summary>
 		/// Create a new FieldAttribute for the given symbol and using the namespace as its containing library.
 		/// <param name="symbolName">The name of the symbol.</param>
 		/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/FieldData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/FieldData.cs
@@ -18,12 +18,12 @@ readonly struct FieldData<T> : IEquatable<FieldData<T>> where T : Enum {
 	}
 	public string SymbolName { get; }
 	public string? LibraryName { get; }
-	
+
 	/// <summary>
 	/// Gets and set the type to be used. This is a property that can be used on notifications.
 	/// </summary>
 	public string? Type { get; init; }
-	
+
 	/// <summary>
 	/// The notification center to be used, if null, the default one will be used.
 	/// </summary>
@@ -56,11 +56,11 @@ readonly struct FieldData<T> : IEquatable<FieldData<T>> where T : Enum {
 		string? symbolName;
 		string? libraryName = null;
 		T? flags = default;
-		
+
 		// notifications customizations
 		string? notificationType = null;
 		string? notificationCenter = null;
-		
+
 		switch (count) {
 		case 1:
 			if (!attributeData.ConstructorArguments [0].TryGetIdentifier (out symbolName)) {
@@ -118,8 +118,8 @@ readonly struct FieldData<T> : IEquatable<FieldData<T>> where T : Enum {
 			}
 		}
 
-		data = new(symbolName, libraryName, flags) {
-			Type = notificationType, 
+		data = new (symbolName, libraryName, flags) {
+			Type = notificationType,
 			NotificationCenter = notificationCenter,
 		};
 		return true;
@@ -169,9 +169,9 @@ readonly struct FieldData<T> : IEquatable<FieldData<T>> where T : Enum {
 	{
 		var sb = new StringBuilder ($"{{ SymbolName: '{SymbolName}', ");
 		sb.Append ($"LibraryName: '{LibraryName ?? "null"}', ");
-		sb.Append ($"Type: '{Type ?? "null" }', ");
+		sb.Append ($"Type: '{Type ?? "null"}', ");
 		sb.Append ($"NotificationCenter: '{NotificationCenter ?? "null"}', ");
-		sb.Append($"Flags: '{Flags}' }}");
+		sb.Append ($"Flags: '{Flags}' }}");
 		return sb.ToString ();
 	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/FieldData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/FieldData.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.Macios.Generator.Extensions;
 
@@ -17,6 +18,16 @@ readonly struct FieldData<T> : IEquatable<FieldData<T>> where T : Enum {
 	}
 	public string SymbolName { get; }
 	public string? LibraryName { get; }
+	
+	/// <summary>
+	/// Gets and set the type to be used. This is a property that can be used on notifications.
+	/// </summary>
+	public string? Type { get; init; }
+	
+	/// <summary>
+	/// The notification center to be used, if null, the default one will be used.
+	/// </summary>
+	public string? NotificationCenter { get; init; }
 
 	public T? Flags { get; } = default;
 
@@ -45,6 +56,11 @@ readonly struct FieldData<T> : IEquatable<FieldData<T>> where T : Enum {
 		string? symbolName;
 		string? libraryName = null;
 		T? flags = default;
+		
+		// notifications customizations
+		string? notificationType = null;
+		string? notificationCenter = null;
+		
 		switch (count) {
 		case 1:
 			if (!attributeData.ConstructorArguments [0].TryGetIdentifier (out symbolName)) {
@@ -89,13 +105,23 @@ readonly struct FieldData<T> : IEquatable<FieldData<T>> where T : Enum {
 			case "Flags":
 				flags = (T) value.Value!;
 				break;
+			case "Type":
+				notificationType = ((INamedTypeSymbol) value.Value!).ToDisplayString ();
+				break;
+			case "NotificationCenter":
+				notificationCenter = (string?) value.Value!;
+				break;
 			default:
 				data = null;
 				error = new (ParsingError.UnknownNamedArgument, name);
 				return false;
 			}
 		}
-		data = new (symbolName, libraryName, flags);
+
+		data = new(symbolName, libraryName, flags) {
+			Type = notificationType, 
+			NotificationCenter = notificationCenter,
+		};
 		return true;
 	}
 
@@ -105,6 +131,10 @@ readonly struct FieldData<T> : IEquatable<FieldData<T>> where T : Enum {
 		if (SymbolName != other.SymbolName)
 			return false;
 		if (LibraryName != other.LibraryName)
+			return false;
+		if (Type != other.Type)
+			return false;
+		if (NotificationCenter != other.NotificationCenter)
 			return false;
 		if (Flags is not null && other.Flags is not null) {
 			return Flags.Equals (other.Flags);
@@ -137,6 +167,11 @@ readonly struct FieldData<T> : IEquatable<FieldData<T>> where T : Enum {
 	/// <inheritdoc />
 	public override string ToString ()
 	{
-		return $"{{ SymbolName: '{SymbolName}', LibraryName: '{LibraryName ?? "null"}', Flags: '{Flags}' }}";
+		var sb = new StringBuilder ($"{{ SymbolName: '{SymbolName}', ");
+		sb.Append ($"LibraryName: '{LibraryName ?? "null"}', ");
+		sb.Append ($"Type: '{Type ?? "null" }', ");
+		sb.Append ($"NotificationCenter: '{NotificationCenter ?? "null"}', ");
+		sb.Append($"Flags: '{Flags}' }}");
+		return sb.ToString ();
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Attributes/FieldDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Attributes/FieldDataTests.cs
@@ -63,11 +63,11 @@ public class FieldDataTests {
 		{
 			yield return [
 				new FieldData<EnumValue> ("symbol", null, EnumValue.Default),
-				"{ SymbolName: 'symbol', LibraryName: 'null', Flags: 'Default' }"
+				"{ SymbolName: 'symbol', LibraryName: 'null', Type: 'null', NotificationCenter: 'null', Flags: 'Default' }"
 			];
 			yield return [
 				new FieldData<EnumValue> ("symbol", "lib", EnumValue.Default),
-				"{ SymbolName: 'symbol', LibraryName: 'lib', Flags: 'Default' }"
+				"{ SymbolName: 'symbol', LibraryName: 'lib', Type: 'null', NotificationCenter: 'null', Flags: 'Default' }"
 			];
 		}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassBindingTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassBindingTests.cs
@@ -640,7 +640,7 @@ public partial class MyClass {
 					]
 				}
 			];
-			
+
 			const string notificationCenterPropertyClass = @"
 using ObjCBindings;
 
@@ -711,7 +711,7 @@ public partial class MyClass {
 					]
 				}
 			];
-			
+
 			const string notificationTypePropertyClass = @"
 using ObjCBindings;
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassBindingTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassBindingTests.cs
@@ -640,6 +640,150 @@ public partial class MyClass {
 					]
 				}
 			];
+			
+			const string notificationCenterPropertyClass = @"
+using ObjCBindings;
+
+namespace NS;
+
+[BindingType]
+public partial class MyClass {
+	[Field<Property> (""name"", Flags = Property.Notification, NotificationCenter=""SharedWorkspace.NotificationCenter"")]
+	public partial string Name { get; set; } = string.Empty;
+}
+";
+
+			yield return [
+				notificationCenterPropertyClass,
+				new Binding (
+					bindingInfo: new (new BindingTypeData<Class> ()),
+					name: "MyClass",
+					@namespace: ["NS"],
+					fullyQualifiedSymbol: "NS.MyClass",
+					symbolAvailability: new ()
+				) {
+					Base = "object",
+					Interfaces = ImmutableArray<string>.Empty,
+					Attributes = [
+						new ("ObjCBindings.BindingTypeAttribute")
+					],
+					UsingDirectives = new HashSet<string> { "ObjCBindings" },
+					Modifiers = [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+						SyntaxFactory.Token (SyntaxKind.PartialKeyword)
+					],
+					Properties = [
+						new (
+							name: "Name",
+							returnType: ReturnTypeForString (),
+							symbolAvailability: new (),
+							attributes: [
+								new ("ObjCBindings.FieldAttribute<ObjCBindings.Property>", ["name", "ObjCBindings.Property.Notification", "SharedWorkspace.NotificationCenter"])
+							],
+							modifiers: [
+								SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
+							],
+							accessors: [
+								new (
+									accessorKind: AccessorKind.Getter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
+									modifiers: []
+								),
+								new (
+									accessorKind: AccessorKind.Setter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
+									modifiers: []
+								),
+							]
+						) {
+
+							ExportFieldData = new (
+								fieldData: new (symbolName: "name", flags: Property.Notification) {
+									NotificationCenter = "SharedWorkspace.NotificationCenter",
+								},
+								libraryName: "NS"),
+						}
+					]
+				}
+			];
+			
+			const string notificationTypePropertyClass = @"
+using ObjCBindings;
+
+namespace NS;
+
+[BindingType]
+public partial class MyClass {
+	[Field<Property> (""name"", Flags = Property.Notification, Type=typeof (UIApplicationLaunchEventArgs))]
+	public partial string Name { get; set; } = string.Empty;
+}
+
+public class UIApplicationLaunchEventArgs {}
+";
+
+			yield return [
+				notificationTypePropertyClass,
+				new Binding (
+					bindingInfo: new (new BindingTypeData<Class> ()),
+					name: "MyClass",
+					@namespace: ["NS"],
+					fullyQualifiedSymbol: "NS.MyClass",
+					symbolAvailability: new ()
+				) {
+					Base = "object",
+					Interfaces = ImmutableArray<string>.Empty,
+					Attributes = [
+						new ("ObjCBindings.BindingTypeAttribute")
+					],
+					UsingDirectives = new HashSet<string> { "ObjCBindings" },
+					Modifiers = [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+						SyntaxFactory.Token (SyntaxKind.PartialKeyword)
+					],
+					Properties = [
+						new (
+							name: "Name",
+							returnType: ReturnTypeForString (),
+							symbolAvailability: new (),
+							attributes: [
+								new ("ObjCBindings.FieldAttribute<ObjCBindings.Property>", ["name", "ObjCBindings.Property.Notification", "NS.UIApplicationLaunchEventArgs"])
+							],
+							modifiers: [
+								SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+								SyntaxFactory.Token (SyntaxKind.PartialKeyword),
+							],
+							accessors: [
+								new (
+									accessorKind: AccessorKind.Getter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
+									modifiers: []
+								),
+								new (
+									accessorKind: AccessorKind.Setter,
+									symbolAvailability: new (),
+									exportPropertyData: null,
+									attributes: [],
+									modifiers: []
+								),
+							]
+						) {
+
+							ExportFieldData = new (
+								fieldData: new (symbolName: "name", flags: Property.Notification) {
+									Type = "NS.UIApplicationLaunchEventArgs",
+								},
+								libraryName: "NS"),
+						}
+					]
+				}
+			];
 
 			const string fieldPropertyClass = @"
 using ObjCBindings;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumMemberCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumMemberCodeChangesTests.cs
@@ -262,7 +262,6 @@ public class EnumMemberCodeChangesTests {
 	class TestDataToString : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
-
 			var simpleEnum = new EnumMember (
 				name: "EnumValue",
 				libraryName: "Test",
@@ -271,7 +270,6 @@ public class EnumMemberCodeChangesTests {
 				symbolAvailability: new (),
 				attributes: []);
 			yield return [simpleEnum, "{ Name: 'EnumValue' SymbolAvailability: [] FieldInfo:  Attributes: [] }"];
-
 			var fieldDataEnum = new EnumMember (
 				name: "EnumValue",
 				libraryName: "Test",
@@ -281,7 +279,7 @@ public class EnumMemberCodeChangesTests {
 				attributes: []);
 			yield return [
 				fieldDataEnum,
-				"{ Name: 'EnumValue' SymbolAvailability: [] FieldInfo: FieldData = { SymbolName: 'x', LibraryName: 'libName', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library Attributes: [] }"
+				"{ Name: 'EnumValue' SymbolAvailability: [] FieldInfo: FieldData = { SymbolName: 'x', LibraryName: 'libName', Type: 'null', NotificationCenter: 'null', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library Attributes: [] }",
 			];
 
 			var builder = SymbolAvailability.CreateBuilder ();
@@ -296,7 +294,7 @@ public class EnumMemberCodeChangesTests {
 				attributes: []);
 			yield return [
 				availabilityEnum,
-				"{ Name: 'EnumValue' SymbolAvailability: [{ Platform: 'iOS', Supported: '0.0', Unsupported: [], Obsoleted: [] }] FieldInfo: FieldData = { SymbolName: 'x', LibraryName: 'libName', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library Attributes: [] }"
+				"{ Name: 'EnumValue' SymbolAvailability: [{ Platform: 'iOS', Supported: '0.0', Unsupported: [], Obsoleted: [] }] FieldInfo: FieldData = { SymbolName: 'x', LibraryName: 'libName', Type: 'null', NotificationCenter: 'null', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library Attributes: [] }",
 			];
 
 			var attrsEnum = new EnumMember (
@@ -311,7 +309,7 @@ public class EnumMemberCodeChangesTests {
 				]);
 			yield return [
 				attrsEnum,
-				"{ Name: 'EnumValue' SymbolAvailability: [{ Platform: 'iOS', Supported: '0.0', Unsupported: [], Obsoleted: [] }] FieldInfo: FieldData = { SymbolName: 'x', LibraryName: 'libName', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library Attributes: [{ Name: Attribute1, Arguments: [] }, { Name: Attribute2, Arguments: [] }] }"
+				"{ Name: 'EnumValue' SymbolAvailability: [{ Platform: 'iOS', Supported: '0.0', Unsupported: [], Obsoleted: [] }] FieldInfo: FieldData = { SymbolName: 'x', LibraryName: 'libName', Type: 'null', NotificationCenter: 'null', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library Attributes: [{ Name: Attribute1, Arguments: [] }, { Name: Attribute2, Arguments: [] }] }",
 			];
 		}
 


### PR DESCRIPTION
Add the missing notification configuration options for the FieldAttribute. Do remember that we will use the analyzer to make sure that those options are only used when the user passes the notification flag.