### PR TITLE
[Bgen/Rgen] Rename method to be an overload of GetValue.

### DIFF
--- a/src/bgen/Enums.cs
+++ b/src/bgen/Enums.cs
@@ -314,7 +314,7 @@ public partial class Generator {
 					print ($"/// <param name=\"handle\">The native handle with the name of the constant to retrieve.</param>");
 				}
 
-				print ("public static {0} GetValueFromHandle ({1} handle)", type.Name, NativeHandleType);
+				print ("public static {0} GetValue ({1} handle)", type.Name, NativeHandleType);
 				print ("{");
 				indent++;
 				print ("using var str = Runtime.GetNSObject<{0}> (handle){1};", backingFieldTypeName, !nullable ? "!" : "");

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -509,7 +509,7 @@ public partial class Generator : IMemberGatherer {
 			var arrRetType = arrIsNullable ? nullableElementType : retType.GetElementType ();
 			var valueFetcher = string.Empty;
 			if (arrType == TypeCache.NSString && !arrIsNullable)
-				append = $"{TypeManager.FormatType (arrRetType.DeclaringType, arrRetType)}Extensions.GetValueFromHandle";
+				append = $"{TypeManager.FormatType (arrRetType.DeclaringType, arrRetType)}Extensions.GetValue ";
 			else if (arrType == TypeCache.NSNumber && !arrIsNullable) {
 				if (arrRetType.IsEnum) {
 					// get the underlying type of the enum and use a callback with the appropiate one

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/EnumEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/EnumEmitter.cs
@@ -99,7 +99,7 @@ class EnumEmitter : ICodeEmitter {
 
 		// get value from a handle, this is a helper method used in the BindAs bindings.
 		using (var getValueFromHandle =
-			   classBlock.CreateBlock ($"public static {binding.Name} GetValueFromHandle (NativeHandle handle)",
+			   classBlock.CreateBlock ($"public static {binding.Name} GetValue (NativeHandle handle)",
 				   true)) {
 			getValueFromHandle.WriteRaw (
 @"using var str = Runtime.GetNSObject<NSString> (handle)!;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/SmartEnum/Data/ExpectedAVCaptureDeviceTypeEnum.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/SmartEnum/Data/ExpectedAVCaptureDeviceTypeEnum.cs
@@ -196,7 +196,7 @@ public static partial class AVCaptureDeviceTypeExtensions
 		throw new NotSupportedException ($"The constant {constant} has no associated enum value on this platform.");
 	}
 
-	public static AVCaptureDeviceType GetValueFromHandle (NativeHandle handle)
+	public static AVCaptureDeviceType GetValue (NativeHandle handle)
 	{
 		using var str = Runtime.GetNSObject<NSString> (handle)!;
 		return GetValue (str);

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/SmartEnum/Data/ExpectedAVCaptureSystemPressureLevel.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/SmartEnum/Data/ExpectedAVCaptureSystemPressureLevel.cs
@@ -106,7 +106,7 @@ public static partial class AVCaptureSystemPressureLevelExtensions
 		throw new NotSupportedException ($"The constant {constant} has no associated enum value on this platform.");
 	}
 
-	public static AVCaptureSystemPressureLevel GetValueFromHandle (NativeHandle handle)
+	public static AVCaptureSystemPressureLevel GetValue (NativeHandle handle)
 	{
 		using var str = Runtime.GetNSObject<NSString> (handle)!;
 		return GetValue (str);

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/SmartEnum/Data/ExpectedCustomLibraryEnum.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/SmartEnum/Data/ExpectedCustomLibraryEnum.cs
@@ -77,7 +77,7 @@ public static partial class CustomLibraryEnumExtensions
 		throw new NotSupportedException ($"The constant {constant} has no associated enum value on this platform.");
 	}
 
-	public static CustomLibraryEnum GetValueFromHandle (NativeHandle handle)
+	public static CustomLibraryEnum GetValue (NativeHandle handle)
 	{
 		using var str = Runtime.GetNSObject<NSString> (handle)!;
 		return GetValue (str);

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/SmartEnum/Data/ExpectedCustomLibraryEnumInternal.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/SmartEnum/Data/ExpectedCustomLibraryEnumInternal.cs
@@ -77,7 +77,7 @@ public static partial class CustomLibraryEnumInternalExtensions
 		throw new NotSupportedException ($"The constant {constant} has no associated enum value on this platform.");
 	}
 
-	public static CustomLibraryEnumInternal GetValueFromHandle (NativeHandle handle)
+	public static CustomLibraryEnumInternal GetValue (NativeHandle handle)
 	{
 		using var str = Runtime.GetNSObject<NSString> (handle)!;
 		return GetValue (str);

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/SmartEnum/Data/ExpectedMacOSAVMediaCharacteristics.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/SmartEnum/Data/ExpectedMacOSAVMediaCharacteristics.cs
@@ -359,7 +359,7 @@ static partial class AVMediaCharacteristicsExtensions
 		throw new NotSupportedException ($"The constant {constant} has no associated enum value on this platform.");
 	}
 
-	public static AVMediaCharacteristics GetValueFromHandle (NativeHandle handle)
+	public static AVMediaCharacteristics GetValue (NativeHandle handle)
 	{
 		using var str = Runtime.GetNSObject<NSString> (handle)!;
 		return GetValue (str);

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/SmartEnum/Data/ExpectediOSAVMediaCharacteristics.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/SmartEnum/Data/ExpectediOSAVMediaCharacteristics.cs
@@ -378,7 +378,7 @@ static partial class AVMediaCharacteristicsExtensions
 		throw new NotSupportedException ($"The constant {constant} has no associated enum value on this platform.");
 	}
 
-	public static AVMediaCharacteristics GetValueFromHandle (NativeHandle handle)
+	public static AVMediaCharacteristics GetValue (NativeHandle handle)
 	{
 		using var str = Runtime.GetNSObject<NSString> (handle)!;
 		return GetValue (str);


### PR DESCRIPTION
We talked about it in a PR in which we agreed to have the same name and have it as an overload.