### PR TITLE
[devops] Install .NET before trying to install simulators.

### DIFF
--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -964,8 +964,12 @@ check_7z
 check_objective_sharpie
 check_old_simulators
 if test -z "$IGNORE_DOTNET"; then
-	ok "Installed .NET SDKs:"
-	(IFS=$'\n'; for i in $(/usr/local/share/dotnet/dotnet --list-sdks); do log "$i"; done)
+	if test -f /usr/local/share/dotnet/dotnet; then
+		ok "Installed .NET SDKs:"
+		(IFS=$'\n'; for i in $(/usr/local/share/dotnet/dotnet --list-sdks); do log "$i"; done)
+	else
+		warn ".NET is not installed"
+	fi
 fi
 
 if test -z $FAIL; then

--- a/tools/devops/automation/templates/tests/build.yml
+++ b/tools/devops/automation/templates/tests/build.yml
@@ -230,6 +230,10 @@ steps:
     github_token: ${{ parameters.gitHubToken }}
   timeoutInMinutes: 250
 
+- task: UseDotNet@2
+  inputs:
+    version: 9.x
+
 - bash: |
     set -x
     set -e

--- a/tools/devops/automation/templates/windows/reserve-mac.yml
+++ b/tools/devops/automation/templates/windows/reserve-mac.yml
@@ -102,6 +102,10 @@ steps:
     github_token: ${{ parameters.gitHubToken }}
   timeoutInMinutes: 250
 
+- task: UseDotNet@2
+  inputs:
+    version: 9.x
+
 - bash: $(Build.SourcesDirectory)/$(BUILD_REPOSITORY_TITLE)/system-dependencies.sh --ignore-mono --ignore-visual-studio --ignore-mono --ignore-sharpie --ignore-shellcheck --ignore-yamllint --provision-simulators
   displayName: 'Provision simulators'
   timeoutInMinutes: 250


### PR DESCRIPTION
Because installing simulators means running a C# project, which requires .NET to build.

Also improve the .NET version check systemdependencies.sh to not blindly try
to execute `dotnet`, but check for its presence first.

This fixes a couple of issues on bots that don't have .NET installed.