### PR TITLE
[mono-api-html] Improve attribute handling.

### DIFF
--- a/tools/api-tools/mono-api-html/ApiChange.cs
+++ b/tools/api-tools/mono-api-html/ApiChange.cs
@@ -27,7 +27,7 @@ namespace Mono.ApiTools {
 			return this;
 		}
 
-		public ApiChange AppendAdded (string text, bool breaking = false)
+		public ApiChange AppendAdded (string text, bool breaking)
 		{
 			State.Formatter.DiffAddition (Member, text, breaking);
 			Breaking |= breaking;
@@ -35,7 +35,7 @@ namespace Mono.ApiTools {
 			return this;
 		}
 
-		public ApiChange AppendRemoved (string text, bool breaking = true)
+		public ApiChange AppendRemoved (string text, bool breaking)
 		{
 			State.Formatter.DiffRemoval (Member, text, breaking);
 			Breaking |= breaking;
@@ -43,7 +43,7 @@ namespace Mono.ApiTools {
 			return this;
 		}
 
-		public ApiChange AppendModified (string old, string @new, bool breaking = true)
+		public ApiChange AppendModified (string old, string @new, bool breaking)
 		{
 			State.Formatter.DiffModification (Member, old, @new, breaking);
 			Breaking |= breaking;

--- a/tools/api-tools/mono-api-html/AssemblyComparer.cs
+++ b/tools/api-tools/mono-api-html/AssemblyComparer.cs
@@ -50,6 +50,14 @@ namespace Mono.ApiTools {
 			comparer = new NamespaceComparer (state);
 		}
 
+		public override string GroupName {
+			get { return "assemblies"; }
+		}
+
+		public override string ElementName {
+			get { return "assembly"; }
+		}
+
 		public string SourceAssembly { get; private set; }
 		public string TargetAssembly { get; private set; }
 

--- a/tools/api-tools/mono-api-html/ClassComparer.cs
+++ b/tools/api-tools/mono-api-html/ClassComparer.cs
@@ -26,9 +26,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Xml.Linq;
+using Microsoft.VisualBasic;
 
 namespace Mono.ApiTools {
 
@@ -53,6 +56,14 @@ namespace Mono.ApiTools {
 			mcomparer = new MethodComparer (state);
 		}
 
+		public override string GroupName {
+			get { return "classes"; }
+		}
+
+		public override string ElementName {
+			get { return "class"; }
+		}
+		
 		public override void SetContext (XElement current)
 		{
 			State.Type = current.GetAttribute ("name");
@@ -88,18 +99,7 @@ namespace Mono.ApiTools {
 
 			var type = target.Attribute ("type").Value;
 
-			if (type == "enum") {
-				// check if [Flags] is present
-				var cattrs = target.Element ("attributes");
-				if (cattrs is not null) {
-					foreach (var ca in cattrs.Elements ("attribute")) {
-						if (ca.GetAttribute ("name") == "System.FlagsAttribute") {
-							Indent ().WriteLine ("[Flags]");
-							break;
-						}
-					}
-				}
-			}
+			WriteAttributes (target);
 
 			Indent ().Write ("public");
 
@@ -276,6 +276,14 @@ namespace Mono.ApiTools {
 			// hack - there could be changes that we're not monitoring (e.g. attributes properties)
 			Formatter.PushOutput ();
 
+			var attributeDiff = new ApiChange ("", State);
+			RenderAttributes (source, target, attributeDiff);
+			if (attributeDiff.AnyChange) {
+				Formatter.BeginAttributeModification ();
+				Formatter.Diff (attributeDiff);
+				Formatter.EndAttributeModification ();
+			}
+
 			var sb = source.GetAttribute ("base");
 			var tb = target.GetAttribute ("base");
 			var rm = $"{State.Namespace}.{State.Type}: Modified base type: '{sb}' to '{tb}'";
@@ -319,9 +327,6 @@ namespace Mono.ApiTools {
 
 		public override void Removed (XElement source)
 		{
-			if (source.Elements ("attributes").SelectMany (a => a.Elements ("attribute")).Any (c => c.Attribute ("name")?.Value == "System.ObsoleteAttribute"))
-				return;
-
 			string name = State.Namespace + "." + State.Type;
 
 			var memberDescription = $"{name}: Removed type";
@@ -329,7 +334,7 @@ namespace Mono.ApiTools {
 			if (State.IgnoreRemoved.Any (re => re.IsMatch (name)))
 				return;
 
-			Formatter.BeginTypeRemoval ();
+			Formatter.BeginTypeRemoval (!source.IsExperimental ());
 			Formatter.EndTypeRemoval ();
 		}
 

--- a/tools/api-tools/mono-api-html/ClassComparer.cs
+++ b/tools/api-tools/mono-api-html/ClassComparer.cs
@@ -63,7 +63,7 @@ namespace Mono.ApiTools {
 		public override string ElementName {
 			get { return "class"; }
 		}
-		
+
 		public override void SetContext (XElement current)
 		{
 			State.Type = current.GetAttribute ("name");

--- a/tools/api-tools/mono-api-html/Comparer.cs
+++ b/tools/api-tools/mono-api-html/Comparer.cs
@@ -28,6 +28,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Xml.Linq;
 
 namespace Mono.ApiTools {
@@ -37,11 +38,103 @@ namespace Mono.ApiTools {
 		protected List<XElement> removed;
 		protected ApiChanges modified;
 
+		public abstract string GroupName { get; }
+		public abstract string ElementName { get; }
+
 		public Comparer (State state)
 		{
 			State = state;
 			removed = new List<XElement> ();
 			modified = new ApiChanges (state);
+		}
+
+		protected void WriteAttributes (XElement element)
+		{
+			foreach (var attribute in element.EnumerateAttributes ())
+				Indent ().WriteLine (RenderAttribute (attribute));
+		}
+
+		protected string RenderAttribute (XElement attribute)
+		{
+			var sb = new StringBuilder ();
+			sb.Append ("[");
+			sb.Append (attribute.GetAttribute ("name"));
+			sb.Append ("(");
+			var args = attribute.Element ("arguments");
+			if (args is not null) {
+				var arguments = args.Elements ("argument").ToArray ();
+				foreach (var arg in arguments) {
+					var value = arg.GetAttribute ("value");
+					var isString = arg.GetAttribute ("type") == "System.String";
+					if (isString)
+						sb.Append ('"');
+					sb.Append (value);
+					if (isString)
+						sb.Append ('"');
+					if (arg != arguments.Last ())
+						sb.Append (", ");
+				}
+			}
+			var props = attribute.Element ("properties");
+			if (props is not null) {
+				var properties = props.Elements ("property").ToArray ();
+				foreach (var prop in properties) {
+					sb.Append (prop.GetAttribute ("name"));
+					sb.Append (" = ");
+					sb.Append (prop.GetAttribute ("value"));
+					if (prop != properties.Last ())
+						sb.Append (", ");
+				}
+			}
+			sb.Append (")]");
+			return sb.ToString ();
+		}
+
+		protected void RenderAttributes (XElement source, XElement target, ApiChange diff)
+		{
+			var srcAttributes = source.EnumerateAttributes ().Select (RenderAttribute).OrderBy (v => v).ToArray ();
+			var tgtAttributes = target.EnumerateAttributes ().Select (RenderAttribute).OrderBy (v => v).ToArray ();
+			if (srcAttributes.SequenceEqual (tgtAttributes))
+				return;
+
+			var added = tgtAttributes.Except (srcAttributes).ToList ();
+			var removed = srcAttributes.Except (tgtAttributes).ToList ();
+			var modified = new List<(string Source, string Target)> ();
+
+			for (var i = added.Count - 1; i >= 0; i--) {
+				var addedType = added [i].Substring (0, added [i].IndexOf ('('));
+				var removedOfSameTypeIndex = removed.FindIndex ((v) => v.StartsWith (addedType));
+				if (removedOfSameTypeIndex == -1)
+					continue;
+
+				modified.Add ((removed [removedOfSameTypeIndex], added [i]));
+				added.RemoveAt (i);
+				removed.RemoveAt (removedOfSameTypeIndex);
+			}
+
+			if (added.Any ()) {
+				foreach (var a in added) {
+					var breaking = a.StartsWith ("[System.Diagnostics.CodeAnalysis.ExperimentalAttribute");
+					diff.AppendAdded (a  + "\n", breaking);
+				}
+			}
+			if (modified.Any ()) {
+				foreach (var a in modified) {
+					diff.AppendModified (a.Source + "\n", a.Target + "\n", false);
+				}
+			}
+			if (removed.Any ()) {
+				foreach (var a in removed) {
+					diff.AppendRemoved (a  + "\n", false);
+				}
+			}
+		}
+
+		protected virtual bool IsBreakingRemoval (XElement e)
+		{
+			if (e.IsExperimental ())
+				return false;
+			return true;
 		}
 
 		public State State { get; }

--- a/tools/api-tools/mono-api-html/Comparer.cs
+++ b/tools/api-tools/mono-api-html/Comparer.cs
@@ -115,7 +115,7 @@ namespace Mono.ApiTools {
 			if (added.Any ()) {
 				foreach (var a in added) {
 					var breaking = a.StartsWith ("[System.Diagnostics.CodeAnalysis.ExperimentalAttribute");
-					diff.AppendAdded (a  + "\n", breaking);
+					diff.AppendAdded (a + "\n", breaking);
 				}
 			}
 			if (modified.Any ()) {
@@ -125,7 +125,7 @@ namespace Mono.ApiTools {
 			}
 			if (removed.Any ()) {
 				foreach (var a in removed) {
-					diff.AppendRemoved (a  + "\n", false);
+					diff.AppendRemoved (a + "\n", false);
 				}
 			}
 		}

--- a/tools/api-tools/mono-api-html/ConstructorComparer.cs
+++ b/tools/api-tools/mono-api-html/ConstructorComparer.cs
@@ -75,6 +75,7 @@ namespace Mono.ApiTools {
 
 			var change = new ApiChange (GetDescription (source), State);
 			change.Header = "Modified " + GroupName;
+			RenderAttributes (source, target, change);
 			RenderMethodAttributes (source, target, change);
 			RenderReturnType (source, target, change);
 			RenderName (source, target, change);

--- a/tools/api-tools/mono-api-html/EventComparer.cs
+++ b/tools/api-tools/mono-api-html/EventComparer.cs
@@ -52,6 +52,7 @@ namespace Mono.ApiTools {
 
 			var change = new ApiChange (GetDescription (source), State);
 			change.Header = "Modified " + GroupName;
+			RenderAttributes (source, target, change);
 			change.Append ("public event ");
 
 			var srcEventType = source.GetTypeName ("eventtype", State);

--- a/tools/api-tools/mono-api-html/FieldComparer.cs
+++ b/tools/api-tools/mono-api-html/FieldComparer.cs
@@ -58,9 +58,9 @@ namespace Mono.ApiTools {
 				if (srcNotSerialized != tgtNotSerialized) {
 					// this is not a breaking change, so only render it if it changed.
 					if (srcNotSerialized) {
-						change.AppendRemoved ($"[NonSerialized]{Environment.NewLine}");
+						change.AppendRemoved ($"[NonSerialized]{Environment.NewLine}", false);
 					} else {
-						change.AppendAdded ($"[NonSerialized]{Environment.NewLine}");
+						change.AppendAdded ($"[NonSerialized]{Environment.NewLine}", false);
 					}
 				}
 
@@ -134,6 +134,8 @@ namespace Mono.ApiTools {
 			var change = new ApiChange (GetDescription (source), State);
 			change.Header = "Modified " + GroupName;
 
+			RenderAttributes (source, target, change);
+
 			if (State.BaseType == "System.Enum") {
 				change.Append (name).Append (" = ");
 				if (srcValue != tgtValue) {
@@ -170,7 +172,7 @@ namespace Mono.ApiTools {
 
 					// Hardcode that changes to ObjCRuntime.Constants.[Sdk]Version aren't breaking.
 					var fullname = GetFullName (source);
-					var breaking = true;
+					var breaking = !source.IsExperimental ();
 					switch (fullname) {
 					case "ObjCRuntime.Constants.Version":
 					case "ObjCRuntime.Constants.SdkVersion":

--- a/tools/api-tools/mono-api-html/Formatter.cs
+++ b/tools/api-tools/mono-api-html/Formatter.cs
@@ -150,10 +150,14 @@ namespace Mono.ApiTools {
 		{
 		}
 
-		public abstract void BeginTypeRemoval ();
+		public abstract void BeginTypeRemoval (bool breaking);
 		public virtual void EndTypeRemoval ()
 		{
 		}
+
+		public abstract void BeginAttributeModification ();
+		public abstract void AddAttributeModification (string source, string target, bool breaking);
+		public abstract void EndAttributeModification ();
 
 		public abstract void BeginMemberAddition (IEnumerable<XElement> list, MemberComparer member);
 		public abstract void AddMember (MemberComparer member, bool isInterfaceBreakingChange, string obsolete, string description);
@@ -162,11 +166,12 @@ namespace Mono.ApiTools {
 		public abstract void BeginMemberModification (string sectionName);
 		public abstract void EndMemberModification ();
 
-		public abstract void BeginMemberRemoval (IEnumerable<XElement> list, MemberComparer member);
+		public abstract void BeginMemberRemoval (IEnumerable<XElement> list, MemberComparer member, bool breaking);
 		public abstract void RemoveMember (MemberComparer member, bool breaking, string obsolete, string description);
 		public abstract void EndMemberRemoval ();
 
 		public abstract void RenderObsoleteMessage (TextChunk chunk, MemberComparer member, string description, string optionalObsoleteMessage);
+		public abstract void RenderAttribute (TextChunk chunk, Comparer member, string attributeName, bool breaking, string description, params string [] attributeArguments);
 
 		public abstract void DiffAddition (TextChunk chunk, string text, bool breaking);
 		public abstract void DiffModification (TextChunk chunk, string old, string @new, bool breaking);

--- a/tools/api-tools/mono-api-html/Helpers.cs
+++ b/tools/api-tools/mono-api-html/Helpers.cs
@@ -47,25 +47,64 @@ namespace Mono.ApiTools {
 			return n.Value;
 		}
 
+		// if this member/type or potentially any of its parents is marked as experimental
+		public static bool IsExperimental (this XElement self, bool recursive, out string diagnosticId)
+		{
+			return TryGetAttributeProperty (self,  "System.Diagnostics.CodeAnalysis.ExperimentalAttribute", recursive, out diagnosticId);
+		}
+
+		// if this member/type or any of its parents is marked as experimental
+		public static bool IsExperimental (this XElement self)
+		{
+			return IsExperimental (self, true, out var _);
+		}
+
+		public static IEnumerable<XElement> EnumerateAttributes (this XElement self, string attributeName = null)
+		{
+			if (self is null)
+				yield break;
+
+			var attribs = self.Element ("attributes");
+			if (attribs is null)
+				yield break;
+
+			foreach (var attrib in attribs.Elements ("attribute")) {
+				if (!string.IsNullOrEmpty (attributeName) && attrib.GetAttribute ("name") != attributeName)
+					continue;
+				yield return attrib;
+			}
+		}
+
+		static bool TryGetAttributeProperty (this XElement self, string attributeName, bool recursive, out string firstArgument)
+		{
+			firstArgument = null;
+
+			if (self is null)
+				return false;
+
+			foreach (var ca in self.EnumerateAttributes (attributeName)) {
+				var args = ca.Element ("arguments");
+				if (args is not null) {
+					var firstCtorArgument = args.Elements ("argument")?.FirstOrDefault ();
+					if (firstCtorArgument is not null && firstCtorArgument.GetAttribute ("type") == "System.String") {
+						firstArgument = firstCtorArgument.GetAttribute ("value");
+					}
+				}
+
+				return true;
+			}
+
+			if (recursive)
+				return TryGetAttributeProperty (self.Parent, attributeName, recursive, out firstArgument);
+
+			return false;
+		}
+
 		// null == no obsolete, String.Empty == no description
 		public static string GetObsoleteMessage (this XElement self)
 		{
-			var cattrs = self.Element ("attributes");
-			if (cattrs is null)
-				return null;
-
-			foreach (var ca in cattrs.Elements ("attribute")) {
-				if (ca.GetAttribute ("name") != "System.ObsoleteAttribute")
-					continue;
-				var props = ca.Element ("properties");
-				if (props is null)
-					return String.Empty; // no description
-				foreach (var p in props.Elements ("property")) {
-					if (p.GetAttribute ("name") != "Message")
-						continue;
-					return p.GetAttribute ("value");
-				}
-			}
+			if (TryGetAttributeProperty (self, "System.ObsoleteAttribute", false, out string message))
+				return message ?? String.Empty;
 			return null;
 		}
 

--- a/tools/api-tools/mono-api-html/Helpers.cs
+++ b/tools/api-tools/mono-api-html/Helpers.cs
@@ -50,7 +50,7 @@ namespace Mono.ApiTools {
 		// if this member/type or potentially any of its parents is marked as experimental
 		public static bool IsExperimental (this XElement self, bool recursive, out string diagnosticId)
 		{
-			return TryGetAttributeProperty (self,  "System.Diagnostics.CodeAnalysis.ExperimentalAttribute", recursive, out diagnosticId);
+			return TryGetAttributeProperty (self, "System.Diagnostics.CodeAnalysis.ExperimentalAttribute", recursive, out diagnosticId);
 		}
 
 		// if this member/type or any of its parents is marked as experimental

--- a/tools/api-tools/mono-api-html/HtmlFormatter.cs
+++ b/tools/api-tools/mono-api-html/HtmlFormatter.cs
@@ -369,7 +369,7 @@ namespace Mono.ApiTools {
 
 		void AppendEncoded (string value)
 		{
-			System.Web.HttpUtility.HtmlEncode (value, output);	
+			System.Web.HttpUtility.HtmlEncode (value, output);
 		}
 	}
 }

--- a/tools/api-tools/mono-api-html/HtmlFormatter.cs
+++ b/tools/api-tools/mono-api-html/HtmlFormatter.cs
@@ -43,6 +43,16 @@ namespace Mono.ApiTools {
 
 		public bool AnyBreakingChanges;
 
+		string GetBreakingAttribute (bool breaking)
+		{
+			return breaking ? "data-is-breaking" : "data-is-non-breaking";
+		}
+
+		string GetBreakingClass (bool breaking)
+		{
+			return breaking ? "breaking" : "";
+		}
+
 		public override string LesserThan => "&lt;";
 		public override string GreaterThan => "&gt;";
 
@@ -55,7 +65,7 @@ namespace Mono.ApiTools {
 				output.WriteLine ("\t.added { color: green; }");
 				output.WriteLine ("\t.removed-inline { text-decoration: line-through; }");
 				output.WriteLine ("\t.removed-breaking-inline { color: red;}");
-				output.WriteLine ("\t.added-breaking-inline { text-decoration: underline; }");
+				output.WriteLine ("\t.added-breaking-inline { color: red; }");
 				output.WriteLine ("\t.nonbreaking { color: black; }");
 				output.WriteLine ("\t.breaking { color: red; }");
 				output.WriteLine ("</style>");
@@ -160,6 +170,33 @@ namespace Mono.ApiTools {
 			output.WriteLine ($"</div> <!-- end namespace {State.Namespace} -->");
 		}
 
+		public override void BeginAttributeModification ()
+		{
+			output.WriteLine ("<div>");
+			output.WriteLine ("<p>Modified attributes:</p>");
+			output.WriteLine ("<pre>");
+			IndentLevel++;
+		}
+
+		public override void AddAttributeModification (string source, string target, bool breaking)
+		{
+			output.Write ("\t<span class='removed-inline removed-attribute {0}' {1}>", GetBreakingClass (breaking), GetBreakingAttribute (breaking));
+			AppendEncoded (source);
+			output.WriteLine ("</span>");
+			output.Write ("\t<span class='added added-attribute {0}' {1}>", GetBreakingClass (breaking), GetBreakingAttribute (breaking));
+			AppendEncoded (target);
+			output.WriteLine ("</span>");
+			if (breaking)
+				AnyBreakingChanges = true;
+		}
+
+		public override void EndAttributeModification ()
+		{
+			IndentLevel--;
+			output.WriteLine ("</pre>");
+			output.WriteLine ("</div>");
+		}
+
 		public override void BeginTypeAddition ()
 		{
 			output.WriteLine ($"<div> <!-- start type {State.Type} -->");
@@ -184,10 +221,11 @@ namespace Mono.ApiTools {
 			output.WriteLine ($"</div> <!-- end type {State.Type} -->");
 		}
 
-		public override void BeginTypeRemoval ()
+		public override void BeginTypeRemoval (bool breaking)
 		{
-			output.Write ($"<h3>Removed Type <span class='breaking' data-is-breaking>{State.Namespace}.{State.Type}</span></h3>");
-			AnyBreakingChanges = true;
+			output.Write ($"<h3>Removed Type <span class='{GetBreakingClass (breaking)}' {GetBreakingAttribute (breaking)}>{State.Namespace}.{State.Type}</span></h3>");
+			if (breaking)
+				AnyBreakingChanges = true;
 		}
 
 		public override void BeginMemberAddition (IEnumerable<XElement> list, MemberComparer member)
@@ -205,7 +243,7 @@ namespace Mono.ApiTools {
 
 		public override void AddMember (MemberComparer member, bool isInterfaceBreakingChange, string obsolete, string description)
 		{
-			output.Write ("<span class='added added-{0} {1}' {2}>", member.ElementName, isInterfaceBreakingChange ? "breaking" : string.Empty, isInterfaceBreakingChange ? "data-is-breaking" : "data-is-non-breaking");
+			output.Write ("<span class='added added-{0} {1}' {2}>", member.ElementName, GetBreakingClass (isInterfaceBreakingChange), GetBreakingAttribute (isInterfaceBreakingChange));
 			output.Write ($"{obsolete}{description}");
 			output.WriteLine ("</span>");
 			if (isInterfaceBreakingChange)
@@ -230,12 +268,13 @@ namespace Mono.ApiTools {
 			output.WriteLine ("</pre>");
 		}
 
-		public override void BeginMemberRemoval (IEnumerable<XElement> list, MemberComparer member)
+		public override void BeginMemberRemoval (IEnumerable<XElement> list, MemberComparer member, bool breaking)
 		{
 			if (State.BaseType == "System.Enum") {
 				output.WriteLine ("<p>Removed value{0}:</p>", list.Count () > 1 ? "s" : String.Empty);
-				output.WriteLine ("<pre class='removed' data-is-breaking>");
-				AnyBreakingChanges = true;
+				output.WriteLine ($"<pre class='removed' {GetBreakingAttribute (breaking)}>");
+				if (breaking)
+					AnyBreakingChanges = true;
 			} else {
 				output.WriteLine ("<p>Removed {0}:</p>", list.Count () > 1 ? member.GroupName : member.ElementName);
 				output.WriteLine ("<pre>");
@@ -246,7 +285,7 @@ namespace Mono.ApiTools {
 		public override void RemoveMember (MemberComparer member, bool breaking, string obsolete, string description)
 		{
 			WriteIndentation ();
-			output.Write ("<span class='removed removed-{0} {2}' {1}>", member.ElementName, breaking ? "data-is-breaking" : "data-is-non-breaking", breaking ? "breaking" : string.Empty);
+			output.Write ("<span class='removed removed-{0} {2}' {1}>", member.ElementName, GetBreakingAttribute (breaking), GetBreakingClass (breaking));
 			if (obsolete.Length > 0) {
 				output.Write (obsolete);
 				WriteIndentation ();
@@ -259,11 +298,19 @@ namespace Mono.ApiTools {
 
 		public override void RenderObsoleteMessage (TextChunk chunk, MemberComparer member, string description, string optionalObsoleteMessage)
 		{
+			RenderAttribute (chunk, member, "Obsolete", false, description, optionalObsoleteMessage);
+		}
+
+		public override void RenderAttribute (TextChunk chunk, Comparer member, string attributeName, bool breaking, string description, params string [] attributeArguments)
+		{
 			var output = chunk.GetStringBuilder (this);
-			output.Append ($"<span class='obsolete obsolete-{member.ElementName}' data-is-non-breaking>");
-			output.Append ("[Obsolete (");
-			if (!String.IsNullOrEmpty (optionalObsoleteMessage))
-				output.Append ('"').Append (optionalObsoleteMessage).Append ('"');
+			output.Append ($"<span class='obsolete obsolete-{member.ElementName} {GetBreakingClass (breaking)}' {GetBreakingAttribute (breaking)}>");
+			output.Append ($"[{attributeName} (");
+			foreach (var arg in attributeArguments) {
+				output.Append ('"').Append (arg).Append ('"');
+				if (arg != attributeArguments.Last ())
+					output.Append (", ");
+			}
 			output.AppendLine (")]");
 			output.Append (description);
 			output.Append ("</span>");
@@ -310,7 +357,7 @@ namespace Mono.ApiTools {
 
 		public override void Diff (ApiChange apichange)
 		{
-			output.Write ("<div {0}>", apichange.Breaking ? "data-is-breaking" : "data-is-non-breaking");
+			output.Write ("<div {0}>", GetBreakingAttribute (apichange.Breaking));
 			foreach (var line in apichange.Member.GetStringBuilder (this).ToString ().Split (new [] { Environment.NewLine }, 0)) {
 				output.Write ('\t');
 				output.WriteLine (line);
@@ -318,6 +365,11 @@ namespace Mono.ApiTools {
 			output.Write ("</div>");
 			if (apichange.Breaking)
 				AnyBreakingChanges = true;
+		}
+
+		void AppendEncoded (string value)
+		{
+			System.Web.HttpUtility.HtmlEncode (value, output);	
 		}
 	}
 }

--- a/tools/api-tools/mono-api-html/MarkdownFormatter.cs
+++ b/tools/api-tools/mono-api-html/MarkdownFormatter.cs
@@ -62,6 +62,26 @@ namespace Mono.ApiTools {
 			output.WriteLine ();
 		}
 
+		public override void BeginAttributeModification ()
+		{
+			output.WriteLine ("<div>");
+			output.WriteLine ("<p>Modified attributes:</p>");
+			output.WriteLine ("<pre>");
+			IndentLevel++;
+		}
+
+		public override void AddAttributeModification (string source, string target, bool breaking)
+		{
+			output.WriteLine ($"-{source}");
+			output.WriteLine ($"+{target}");
+		}
+
+		public override void EndAttributeModification ()
+		{
+			output.WriteLine ("```");
+			output.WriteLine ();
+		}
+
 		public override void BeginTypeAddition ()
 		{
 			output.WriteLine ($"#### New Type: {@State.Namespace}.{State.Type}");
@@ -81,7 +101,7 @@ namespace Mono.ApiTools {
 			output.WriteLine ();
 		}
 
-		public override void BeginTypeRemoval ()
+		public override void BeginTypeRemoval (bool breaking)
 		{
 			output.WriteLine ($"#### Removed Type {State.Namespace}.{State.Type}");
 		}
@@ -122,7 +142,7 @@ namespace Mono.ApiTools {
 			output.WriteLine ();
 		}
 
-		public override void BeginMemberRemoval (IEnumerable<XElement> list, MemberComparer member)
+		public override void BeginMemberRemoval (IEnumerable<XElement> list, MemberComparer member, bool breaking)
 		{
 			if (State.BaseType == "System.Enum") {
 				output.WriteLine ("Removed value{0}:", list.Count () > 1 ? "s" : String.Empty);
@@ -147,10 +167,18 @@ namespace Mono.ApiTools {
 
 		public override void RenderObsoleteMessage (TextChunk chunk, MemberComparer member, string description, string optionalObsoleteMessage)
 		{
+			RenderAttribute (chunk, member, "Obsolete", false, description, optionalObsoleteMessage);
+		}
+
+		public override void RenderAttribute (TextChunk chunk, Comparer member, string attributeName, bool breaking, string description, params string [] attributeArguments)
+		{
 			var output = chunk.GetStringBuilder (this);
-			output.Append ("[Obsolete (");
-			if (!String.IsNullOrEmpty (optionalObsoleteMessage))
-				output.Append ('"').Append (optionalObsoleteMessage).Append ('"');
+			output.Append ($"[{attributeName} (");
+			foreach (var arg in attributeArguments) {
+				output.Append (arg);
+				if (arg != attributeArguments.Last ())
+					output.Append (", ");
+			}
 			output.AppendLine (")]");
 			output.Append (description);
 		}

--- a/tools/api-tools/mono-api-html/MultiplexedFormatter.cs
+++ b/tools/api-tools/mono-api-html/MultiplexedFormatter.cs
@@ -68,6 +68,23 @@ namespace Mono.ApiTools {
 			foreach (var formatter in formatters)
 				formatter.BeginNamespace (Replace (formatter, action));
 		}
+		public override void BeginAttributeModification ()
+		{
+			foreach (var formatter in formatters)
+				formatter.BeginAttributeModification ();
+		}
+
+		public override void AddAttributeModification (string oldAttributeName, string newAttributeName, bool breaking)
+		{
+			foreach (var formatter in formatters)
+				formatter.AddAttributeModification (oldAttributeName, newAttributeName, breaking);
+		}
+
+		public override void EndAttributeModification ()
+		{
+			foreach (var formatter in formatters)
+				formatter.EndAttributeModification ();
+		}
 
 		public override void BeginTypeAddition ()
 		{
@@ -87,10 +104,10 @@ namespace Mono.ApiTools {
 				formatter.BeginTypeModification ();
 		}
 
-		public override void BeginTypeRemoval ()
+		public override void BeginTypeRemoval (bool breaking)
 		{
 			foreach (var formatter in formatters)
-				formatter.BeginTypeRemoval ();
+				formatter.BeginTypeRemoval (breaking);
 		}
 
 		public override void BeginMemberAddition (IEnumerable<XElement> list, MemberComparer member)
@@ -123,10 +140,10 @@ namespace Mono.ApiTools {
 				formatter.EndMemberModification ();
 		}
 
-		public override void BeginMemberRemoval (IEnumerable<XElement> list, MemberComparer member)
+		public override void BeginMemberRemoval (IEnumerable<XElement> list, MemberComparer member, bool breaking)
 		{
 			foreach (var formatter in formatters)
-				formatter.BeginMemberRemoval (list, member);
+				formatter.BeginMemberRemoval (list, member, breaking);
 		}
 
 		public override void RemoveMember (MemberComparer member, bool is_breaking, string obsolete, string description)
@@ -145,6 +162,12 @@ namespace Mono.ApiTools {
 		{
 			foreach (var formatter in formatters)
 				formatter.RenderObsoleteMessage (chunk, member, Replace (formatter, description), Replace (formatter, optionalObsoleteMessage));
+		}
+
+		public override void RenderAttribute (TextChunk chunk, Comparer member, string attributeName, bool breaking, string description, params string [] attributeArguments)
+		{
+			foreach (var formatter in formatters)
+				formatter.RenderAttribute (chunk, member, attributeName, breaking, Replace (formatter, description), attributeArguments);
 		}
 
 		public override void DiffAddition (TextChunk chunk, string text, bool breaking)

--- a/tools/api-tools/mono-api-html/NamespaceComparer.cs
+++ b/tools/api-tools/mono-api-html/NamespaceComparer.cs
@@ -42,6 +42,14 @@ namespace Mono.ApiTools {
 			comparer = new ClassComparer (state);
 		}
 
+		public override string GroupName {
+			get { return "namespaces"; }
+		}
+
+		public override string ElementName {
+			get { return "namespace"; }
+		}
+
 		public void Compare (XElement source, XElement target)
 		{
 			var s = source.Element ("namespaces");

--- a/tools/api-tools/mono-api-html/PropertyComparer.cs
+++ b/tools/api-tools/mono-api-html/PropertyComparer.cs
@@ -116,20 +116,20 @@ namespace Mono.ApiTools {
 				if (srcGetter is not null) {
 					change.Append (" ").Append ("get;");
 				} else {
-					change.Append (" ").AppendAdded ("get;");
+					change.Append (" ").AppendAdded ("get;", false);
 				}
 			} else if (srcGetter is not null) {
-				change.Append (" ").AppendRemoved ("get;");
+				change.Append (" ").AppendRemoved ("get;", !tgtGetter.IsExperimental ());
 			}
 
 			if (tgtSetter is not null) {
 				if (srcSetter is not null) {
 					change.Append (" ").Append ("set;");
 				} else {
-					change.Append (" ").AppendAdded ("set;");
+					change.Append (" ").AppendAdded ("set;", false);
 				}
 			} else if (srcSetter is not null) {
-				change.Append (" ").AppendRemoved ("set;");
+				change.Append (" ").AppendRemoved ("set;", !tgtSetter.IsExperimental ());
 			}
 
 			change.Append (" }");
@@ -192,7 +192,8 @@ namespace Mono.ApiTools {
 
 			var change = new ApiChange (GetDescription (source), State);
 			change.Header = "Modified " + GroupName;
-			RenderMethodAttributes (GetMethodAttributes (srcGetter, srcSetter), GetMethodAttributes (tgtGetter, tgtSetter), change);
+			RenderAttributes (source, target, change);
+			RenderMethodAttributes (source, target, GetMethodAttributes (srcGetter, srcSetter), GetMethodAttributes (tgtGetter, tgtSetter), change);
 			RenderPropertyType (source, target, change);
 			if (isIndexer) {
 				RenderIndexers (srcIndexers, tgtIndexers, change);

--- a/tools/api-tools/mono-api-info/mono-api-info.cs
+++ b/tools/api-tools/mono-api-info/mono-api-info.cs
@@ -1362,14 +1362,14 @@ namespace Mono.ApiTools {
 							writer.WriteStartElement ("argument");
 							writer.WriteAttributeString ("type", arg.Type.FullName);
 							if (arg.Value is null) {
-								
+
 							} else {
 								writer.WriteAttributeString ("value", arg.Value.ToString ());
 							}
 							writer.WriteEndElement (); // argument
 						}
 						writer.WriteEndElement (); // arguments
-}
+					}
 
 					if (att.HasProperties) {
 						writer.WriteStartElement ("properties");

--- a/tools/api-tools/mono-api-info/mono-api-info.cs
+++ b/tools/api-tools/mono-api-info/mono-api-info.cs
@@ -1342,7 +1342,6 @@ namespace Mono.ApiTools {
 				if (!provider.HasCustomAttributes)
 					continue;
 
-
 				var ass = provider as AssemblyDefinition;
 				if (ass is not null && !state.FollowForwarders)
 					TypeForwardedToData.OutputForwarders (writer, ass, state);
@@ -1357,310 +1356,42 @@ namespace Mono.ApiTools {
 					writer.WriteStartElement ("attribute");
 					writer.WriteAttributeString ("name", attName);
 
-					var attribute_mapping = CreateAttributeMapping (att);
-
-					if (attribute_mapping is not null) {
-						var mapping = attribute_mapping.Where ((attr) => attr.Key != "TypeId");
-						if (mapping.Any ()) {
-							writer.WriteStartElement ("properties");
-							foreach (var kvp in mapping) {
-								string name = kvp.Key;
-								object o = kvp.Value;
-
-								writer.WriteStartElement ("property");
-								writer.WriteAttributeString ("name", name);
-
-								if (o is null) {
-									writer.WriteAttributeString ("value", "null");
-								} else {
-									string value = o.ToString ();
-									if (attName.EndsWith ("GuidAttribute", StringComparison.Ordinal))
-										value = value.ToUpper ();
-									writer.WriteAttributeString ("value", value);
-								}
-
-								writer.WriteEndElement (); // property
+					if (att.HasConstructorArguments) {
+						writer.WriteStartElement ("arguments");
+						foreach (var arg in att.ConstructorArguments) {
+							writer.WriteStartElement ("argument");
+							writer.WriteAttributeString ("type", arg.Type.FullName);
+							if (arg.Value is null) {
+								
+							} else {
+								writer.WriteAttributeString ("value", arg.Value.ToString ());
 							}
-							writer.WriteEndElement (); // properties
+							writer.WriteEndElement (); // argument
 						}
+						writer.WriteEndElement (); // arguments
+}
+
+					if (att.HasProperties) {
+						writer.WriteStartElement ("properties");
+						foreach (var prop in att.Properties) {
+							writer.WriteStartElement ("property");
+							writer.WriteAttributeString ("name", prop.Name);
+							writer.WriteAttributeString ("type", prop.Argument.Type.FullName);
+							if (prop.Argument.Value is null) {
+
+							} else {
+								writer.WriteAttributeString ("value", prop.Argument.Value.ToString ());
+							}
+							writer.WriteEndElement (); // property
+						}
+						writer.WriteEndElement (); // properties
 					}
+
 					writer.WriteEndElement (); // attribute
 				}
 			}
 
 			writer.WriteEndElement (); // attributes
-		}
-
-		Dictionary<string, object> CreateAttributeMapping (CustomAttribute attribute)
-		{
-			Dictionary<string, object> mapping = null;
-
-			if (!state.TypeHelper.TryResolve (attribute))
-				return mapping;
-
-			PopulateMapping (ref mapping, attribute);
-
-			var constructor = state.TypeHelper.GetMethod (attribute.Constructor);
-			if (constructor is null || !constructor.HasParameters)
-				return mapping;
-
-			PopulateMapping (ref mapping, constructor, attribute);
-
-			return mapping;
-		}
-
-		static void PopulateMapping (ref Dictionary<string, object> mapping, CustomAttribute attribute)
-		{
-			if (!attribute.HasProperties)
-				return;
-
-			foreach (var named_argument in attribute.Properties) {
-				var name = named_argument.Name;
-				var arg = named_argument.Argument;
-
-				if (arg.Value is CustomAttributeArgument)
-					arg = (CustomAttributeArgument) arg.Value;
-
-				if (mapping is null)
-					mapping = new Dictionary<string, object> (StringComparer.Ordinal);
-				mapping.Add (name, GetArgumentValue (arg.Type, arg.Value));
-			}
-		}
-
-		static Dictionary<FieldReference, int> CreateArgumentFieldMapping (MethodDefinition constructor)
-		{
-			Dictionary<FieldReference, int> field_mapping = null;
-
-			int? argument = null;
-
-			foreach (Instruction instruction in constructor.Body.Instructions) {
-				switch (instruction.OpCode.Code) {
-				case Code.Ldarg_1:
-					argument = 1;
-					break;
-				case Code.Ldarg_2:
-					argument = 2;
-					break;
-				case Code.Ldarg_3:
-					argument = 3;
-					break;
-				case Code.Ldarg:
-				case Code.Ldarg_S:
-					argument = ((ParameterDefinition) instruction.Operand).Index + 1;
-					break;
-
-				case Code.Stfld:
-					FieldReference field = (FieldReference) instruction.Operand;
-					if (field.DeclaringType.FullName != constructor.DeclaringType.FullName)
-						continue;
-
-					if (!argument.HasValue)
-						break;
-
-					if (field_mapping is null)
-						field_mapping = new Dictionary<FieldReference, int> ();
-
-					if (!field_mapping.ContainsKey (field))
-						field_mapping.Add (field, (int) argument - 1);
-
-					argument = null;
-					break;
-				}
-			}
-
-			return field_mapping;
-		}
-
-		static Dictionary<PropertyDefinition, FieldReference> CreatePropertyFieldMapping (TypeDefinition type)
-		{
-			Dictionary<PropertyDefinition, FieldReference> property_mapping = null;
-
-			foreach (PropertyDefinition property in type.Properties) {
-				if (property.GetMethod is null)
-					continue;
-				if (!property.GetMethod.HasBody)
-					continue;
-
-				foreach (Instruction instruction in property.GetMethod.Body.Instructions) {
-					if (instruction.OpCode.Code != Code.Ldfld)
-						continue;
-
-					FieldReference field = (FieldReference) instruction.Operand;
-					if (field.DeclaringType.FullName != type.FullName)
-						continue;
-
-					if (property_mapping is null)
-						property_mapping = new Dictionary<PropertyDefinition, FieldReference> ();
-					property_mapping.Add (property, field);
-					break;
-				}
-			}
-
-			return property_mapping;
-		}
-
-		static void PopulateMapping (ref Dictionary<string, object> mapping, MethodDefinition constructor, CustomAttribute attribute)
-		{
-			if (!constructor.HasBody)
-				return;
-
-			// Custom handling for attributes with arguments which cannot be easily extracted
-			var ca = attribute.ConstructorArguments;
-			switch (constructor.DeclaringType.FullName) {
-			case "System.Runtime.CompilerServices.DecimalConstantAttribute":
-				var dca = constructor.Parameters [2].ParameterType == constructor.Module.TypeSystem.Int32 ?
-					new DecimalConstantAttribute ((byte) ca [0].Value, (byte) ca [1].Value, (int) ca [2].Value, (int) ca [3].Value, (int) ca [4].Value) :
-					new DecimalConstantAttribute ((byte) ca [0].Value, (byte) ca [1].Value, (uint) ca [2].Value, (uint) ca [3].Value, (uint) ca [4].Value);
-
-				if (mapping is null)
-					mapping = new Dictionary<string, object> (StringComparer.Ordinal);
-				mapping.Add ("Value", dca.Value);
-				return;
-			case "System.ComponentModel.BindableAttribute":
-				if (ca.Count != 1)
-					break;
-
-				if (mapping is null)
-					mapping = new Dictionary<string, object> (StringComparer.Ordinal);
-
-				if (constructor.Parameters [0].ParameterType == constructor.Module.TypeSystem.Boolean) {
-					mapping.Add ("Bindable", ca [0].Value);
-				} else if (constructor.Parameters [0].ParameterType.FullName == "System.ComponentModel.BindableSupport") {
-					if ((int) ca [0].Value == 0)
-						mapping.Add ("Bindable", false);
-					else if ((int) ca [0].Value == 1)
-						mapping.Add ("Bindable", true);
-					else
-						throw new NotImplementedException ();
-				} else {
-					throw new NotImplementedException ();
-				}
-
-				return;
-			}
-
-			var field_mapping = CreateArgumentFieldMapping (constructor);
-			if (field_mapping is not null) {
-				var property_mapping = CreatePropertyFieldMapping ((TypeDefinition) constructor.DeclaringType);
-
-				if (property_mapping is not null) {
-					foreach (var pair in property_mapping) {
-						int argument;
-						if (!field_mapping.TryGetValue (pair.Value, out argument))
-							continue;
-
-						var ca_arg = ca [argument];
-						if (ca_arg.Value is CustomAttributeArgument)
-							ca_arg = (CustomAttributeArgument) ca_arg.Value;
-
-						if (mapping is null)
-							mapping = new Dictionary<string, object> (StringComparer.Ordinal);
-						mapping.Add (pair.Key.Name, GetArgumentValue (ca_arg.Type, ca_arg.Value));
-					}
-				}
-			}
-		}
-
-		static object GetArgumentValue (TypeReference reference, object value)
-		{
-			var type = reference.Resolve ();
-			if (type is null)
-				return value;
-
-			if (type.IsEnum) {
-				if (IsFlaggedEnum (type))
-					return GetFlaggedEnumValue (type, value);
-
-				return GetEnumValue (type, value);
-			}
-
-			return value;
-		}
-
-		static bool IsFlaggedEnum (TypeDefinition type)
-		{
-			if (!type.IsEnum)
-				return false;
-
-			if (!type.HasCustomAttributes)
-				return false;
-
-			foreach (CustomAttribute attribute in type.CustomAttributes)
-				if (attribute.Constructor.DeclaringType.FullName == "System.FlagsAttribute")
-					return true;
-
-			return false;
-		}
-
-		static object GetFlaggedEnumValue (TypeDefinition type, object value)
-		{
-			if (value is ulong)
-				return GetFlaggedEnumValue (type, (ulong) value);
-
-			long flags = Convert.ToInt64 (value);
-			var signature = new StringBuilder ();
-
-			for (int i = type.Fields.Count - 1; i >= 0; i--) {
-				FieldDefinition field = type.Fields [i];
-
-				if (!field.HasConstant)
-					continue;
-
-				long flag = Convert.ToInt64 (field.Constant);
-
-				if (flag == 0)
-					continue;
-
-				if ((flags & flag) == flag) {
-					if (signature.Length != 0)
-						signature.Append (", ");
-
-					signature.Append (field.Name);
-					flags -= flag;
-				}
-			}
-
-			return signature.ToString ();
-		}
-
-		static object GetFlaggedEnumValue (TypeDefinition type, ulong flags)
-		{
-			var signature = new StringBuilder ();
-
-			for (int i = type.Fields.Count - 1; i >= 0; i--) {
-				FieldDefinition field = type.Fields [i];
-
-				if (!field.HasConstant)
-					continue;
-
-				ulong flag = Convert.ToUInt64 (field.Constant);
-
-				if (flag == 0)
-					continue;
-
-				if ((flags & flag) == flag) {
-					if (signature.Length != 0)
-						signature.Append (", ");
-
-					signature.Append (field.Name);
-					flags -= flag;
-				}
-			}
-
-			return signature.ToString ();
-		}
-
-		static object GetEnumValue (TypeDefinition type, object value)
-		{
-			foreach (FieldDefinition field in type.Fields) {
-				if (!field.HasConstant)
-					continue;
-
-				if (Comparer.Default.Compare (field.Constant, value) == 0)
-					return field.Name;
-			}
-
-			return value;
 		}
 
 		bool SkipAttribute (CustomAttribute attribute)


### PR DESCRIPTION
* Simplify and expand how custom attributes are written into the xml description
  by not doing any fancy computation about the attribute properties, instead just
  write out what's in IL: any constructor arguments + parameter arguments.
* Compare and show attributes for types and members.
* Special-case [Experimental] attributes:
  * Adding an [Experimental] attribute to an existing type/member  is a breaking change.
  * If a type or a member has an [Experimental] attribute, no changes within are breaking.
* Removal of an obsolete type/member is a breaking change, so show it as such.