### PR TITLE
[Bgen] Simplify the BindAs of arrays.

### DIFF
--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -2944,8 +2944,9 @@ public partial class Generator : IMemberGatherer {
 					throw new BindingException (1071, true, minfo.mi.DeclaringType.FullName, minfo.mi.Name);
 				}
 				var bindAsT = bindAttrType.GetElementType ();
+				var suffix = string.Empty;
 				cast_a = $"NSArray.ArrayFromHandleFunc <{TypeManager.FormatType (bindAsT.DeclaringType, bindAsT)}> (";
-				cast_b = $", {GetFromBindAsWrapper (minfo, out suffix)}, {owns})!";
+				cast_b = $", {GetFromBindAsWrapper (minfo, out suffix)}, {owns})!" + suffix;
 			} else if (etype == TypeCache.System_String) {
 				cast_a = "CFArray.StringArrayFromHandle (";
 				cast_b = $", {owns})!";

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -2944,12 +2944,8 @@ public partial class Generator : IMemberGatherer {
 					throw new BindingException (1071, true, minfo.mi.DeclaringType.FullName, minfo.mi.Name);
 				}
 				var bindAsT = bindAttrType.GetElementType ();
-				var suffix = string.Empty;
-				print ("{0} retvalarrtmp;", NativeHandleType);
-				cast_a = "((retvalarrtmp = ";
-				cast_b = ") == IntPtr.Zero ? null! : (";
-				cast_b += $"NSArray.ArrayFromHandleFunc <{TypeManager.FormatType (bindAsT.DeclaringType, bindAsT)}> (retvalarrtmp, {GetFromBindAsWrapper (minfo, out suffix)}, {owns})" + suffix;
-				cast_b += $"))";
+				cast_a = $"NSArray.ArrayFromHandleFunc <{TypeManager.FormatType (bindAsT.DeclaringType, bindAsT)}> (";
+				cast_b = $", {GetFromBindAsWrapper (minfo, out suffix)}, {owns})!";
 			} else if (etype == TypeCache.System_String) {
 				cast_a = "CFArray.StringArrayFromHandle (";
 				cast_b = $", {owns})!";


### PR DESCRIPTION
If we look at the implementation of NSArray.ArrayFromHandleFunc we can see that we have the following:

```csharp
// Used when we need to provide our constructor
static public T [] ArrayFromHandleFunc<T> (NativeHandle handle, Func<NativeHandle, T> createObject)
{
  if (handle == NativeHandle.Zero)
    return null;

  var c = GetCount (handle);
  T [] ret = new T [c];

  for (uint i = 0; i < c; i++)
    ret [i] = createObject (GetAtIndex (handle, i));

  return ret;
}
```
As you can see, we do not need to check if the passed pointer to the function is IntPtr.Zero as we currently do in the generated code:
```csharp
[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
[BindAs (typeof (global::CoreMedia.CMTime[]), OriginalType = typeof (NSValue[]))]
public virtual global::CoreMedia.CMTime[] EnumeratedDurations {
  [Export ("enumeratedDurations", ArgumentSemantic.Retain)]
  get {
    global::CoreMedia.CMTime[] ret;
    if (IsDirectBinding) {
      NativeHandle retvalarrtmp;
      ret = ((retvalarrtmp = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, Selector.GetHandle ("enumeratedDurations"))) == IntPtr.Zero ? null! : (NSArray.ArrayFromHandleFunc <global::CoreMedia.CMTime> (retvalarrtmp, NSValue.ToCMTime, false)));
    } else {
      NativeHandle retvalarrtmp;
      ret = ((retvalarrtmp = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.SuperHandle, Selector.GetHandle ("enumeratedDurations"))) == IntPtr.Zero ? null! : (NSArray.ArrayFromHandleFunc <global::CoreMedia.CMTime> (retvalarrtmp, NSValue.ToCMTime, false)));
    }
    return ret!;
  }
}
```
The above code can be simplified to be:
```csharp
[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
[BindAs (typeof (global::CoreMedia.CMTime[]), OriginalType = typeof (NSValue[]))]
public virtual global::CoreMedia.CMTime[] EnumeratedDurations {
  [Export ("enumeratedDurations", ArgumentSemantic.Retain)]
  get {
    global::CoreMedia.CMTime[] ret;
    if (IsDirectBinding) {
      ret = NSArray.ArrayFromHandleFunc <global::CoreMedia.CMTime> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, Selector.GetHandle ("enumeratedDurations")), NSValue.ToCMTime, false)!;
    } else {
      ret = NSArray.ArrayFromHandleFunc <global::CoreMedia.CMTime> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.SuperHandle, Selector.GetHandle ("enumeratedDurations")), NSValue.ToCMTime, false)!;
    }
    return ret!;
  }
}
```
The code will have the same output when the IntPtr == IntPtr.Zero but it is simpler to understand.