### PR TITLE
[tests] Add MarshalAs attribute for bool return value.

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -759,6 +759,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 		extern static void void_objc_msgSend_out_IntPtr_bool (IntPtr receiver, IntPtr selector, out NativeHandle path, bool create);
 
 		[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
+		[return: MarshalAs(UnmanagedType.U1)]
 		extern static bool bool_objc_msgSend_ref_intptr (IntPtr receiver, IntPtr selector, ref NativeHandle path);
 
 		[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]


### PR DESCRIPTION
This fixes a test failure with NativeAOT on x64.