### PR TITLE
[Rgen] Use TypeInfo as part of the BindAsData property.

### DIFF
--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Microsoft.Macios.Bindings.Analyzer.csproj
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Microsoft.Macios.Bindings.Analyzer.csproj
@@ -36,6 +36,9 @@
         <Compile Include="../Microsoft.Macios.Generator/AttributesNames.cs" >
             <Link>Generator/AttributesNames.cs</Link>
         </Compile>
+        <Compile Include="../Microsoft.Macios.Generator/CollectionComparer.cs" >
+            <Link>Generator/CollectionComparer.cs</Link>
+        </Compile>
         <Compile Include="../Microsoft.Macios.Generator/DictionaryComparer.cs" >
             <Link>Generator/DictionaryComparer.cs</Link>
         </Compile>
@@ -63,6 +66,9 @@
         <Compile Include="../Microsoft.Macios.Generator/Attributes/UnsupportedOSPlatformData.cs" >
             <Link>Generator/Attributes/UnsupportedOSPlatformData.cs</Link>
         </Compile>
+        <Compile Include="../Microsoft.Macios.Generator/DataModel/TypeInfo.cs" >
+            <Link>DataModel/TypeInfo.cs</Link>
+        </Compile>
         <Compile Include="../Microsoft.Macios.Generator/Extensions/ApplePlatformExtensions.cs" >
             <Link>Generator/Extensions/ApplePlatformExtensions.cs</Link>
         </Compile>
@@ -71,6 +77,9 @@
         </Compile>
         <Compile Include="../Microsoft.Macios.Generator/Extensions/Delegates.cs" >
             <Link>Generator/Extensions/Delegates.cs</Link>
+        </Compile>
+        <Compile Include="../Microsoft.Macios.Generator/Extensions/SpecialTypeExtensions.cs" >
+            <Link>Generator/Extensions/SpecialTypeExtensions.cs</Link>
         </Compile>
         <Compile Include="../Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Core.cs">
             <Link>Generator/Extensions/TypeSymbolExtensions.Core.cs</Link>

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/BindFromData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/BindFromData.cs
@@ -4,20 +4,21 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
+using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
 
 namespace Microsoft.Macios.Generator.Attributes;
 
 readonly struct BindFromData : IEquatable<BindFromData> {
 
-	public string Type { get; }
-	public string? OriginalType { get; }
+	public TypeInfo Type { get; }
+	public TypeInfo? OriginalType { get; }
 
-	public BindFromData (string type)
+	public BindFromData (TypeInfo type)
 	{
 		Type = type;
 	}
 
-	public BindFromData (string type, string? originalType)
+	public BindFromData (TypeInfo type, TypeInfo? originalType)
 	{
 		Type = type;
 		OriginalType = originalType;
@@ -29,12 +30,12 @@ readonly struct BindFromData : IEquatable<BindFromData> {
 	{
 		data = null;
 		var count = attributeData.ConstructorArguments.Length;
-		string? type;
-		string? originalType = null;
+		TypeInfo type;
+		TypeInfo? originalType = null;
 
 		switch (count) {
 		case 1:
-			type = ((INamedTypeSymbol) attributeData.ConstructorArguments [0].Value!).ToDisplayString ();
+			type = new ((INamedTypeSymbol) attributeData.ConstructorArguments [0].Value!);
 			break;
 		default:
 			// no other constructors are available
@@ -49,10 +50,10 @@ readonly struct BindFromData : IEquatable<BindFromData> {
 		foreach (var (name, value) in attributeData.NamedArguments) {
 			switch (name) {
 			case "Type":
-				type = ((INamedTypeSymbol) value.Value!).ToDisplayString ();
+				type = new ((INamedTypeSymbol) value.Value!);
 				break;
 			case "OriginalType":
-				originalType = ((INamedTypeSymbol) value.Value!).ToDisplayString ();
+				originalType = new ((INamedTypeSymbol) value.Value!);
 				break;
 			default:
 				data = null;
@@ -66,7 +67,8 @@ readonly struct BindFromData : IEquatable<BindFromData> {
 	/// <inheritdoc />
 	public bool Equals (BindFromData other)
 	{
-		return Type == other.Type && OriginalType == other.OriginalType;
+		return Type.FullyQualifiedName == other.Type.FullyQualifiedName 
+		       && OriginalType?.FullyQualifiedName == other.OriginalType?.FullyQualifiedName;
 	}
 
 	/// <inheritdoc />
@@ -93,6 +95,6 @@ readonly struct BindFromData : IEquatable<BindFromData> {
 
 	public override string ToString ()
 	{
-		return $"{{ Type: '{Type}', OriginalType: '{OriginalType ?? "null"}' }}";
+		return $"{{ Type: '{Type.FullyQualifiedName}', OriginalType: '{OriginalType?.FullyQualifiedName ?? "null"}' }}";
 	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/BindFromData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/BindFromData.cs
@@ -67,8 +67,8 @@ readonly struct BindFromData : IEquatable<BindFromData> {
 	/// <inheritdoc />
 	public bool Equals (BindFromData other)
 	{
-		return Type.FullyQualifiedName == other.Type.FullyQualifiedName 
-		       && OriginalType?.FullyQualifiedName == other.OriginalType?.FullyQualifiedName;
+		return Type.FullyQualifiedName == other.Type.FullyQualifiedName
+			   && OriginalType?.FullyQualifiedName == other.OriginalType?.FullyQualifiedName;
 	}
 
 	/// <inheritdoc />

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
@@ -12,67 +12,16 @@ readonly partial struct TypeInfo {
 	/// True if the type needs to use a stret call.
 	/// </summary>
 	public bool NeedsStret { get; init; }
-
-	/// <summary>
-	/// True if the type represents a delegate.
-	/// </summary>
-	public bool IsDelegate { get; init; }
-
+	
 	/// <summary>
 	/// Get the name of the variable for the type when it is used as a return value.
 	/// </summary>
 	public string ReturnVariableName => "ret"; // nothing fancy for now
-
-	internal TypeInfo (ITypeSymbol symbol, Compilation compilation) :
-		this (
-			symbol is IArrayTypeSymbol arrayTypeSymbol
-				? arrayTypeSymbol.ElementType.ToDisplayString ()
-				: symbol.ToDisplayString ().Trim ('?', '[', ']'),
-			symbol.SpecialType)
+	
+	internal TypeInfo (ITypeSymbol symbol, Compilation compilation) : this (symbol)
 	{
-		IsNullable = symbol.NullableAnnotation == NullableAnnotation.Annotated;
-		IsBlittable = symbol.IsBlittable ();
-		IsSmartEnum = symbol.IsSmartEnum ();
-		IsReferenceType = symbol.IsReferenceType;
-		IsStruct = symbol.TypeKind == TypeKind.Struct;
-		IsInterface = symbol.TypeKind == TypeKind.Interface;
-		IsDelegate = symbol.TypeKind == TypeKind.Delegate;
-		IsNativeIntegerType = symbol.IsNativeIntegerType;
 		IsNativeEnum = symbol.HasAttribute (AttributesNames.NativeEnumAttribute);
 		NeedsStret = symbol.NeedsStret (compilation);
-
-		// data that we can get from the symbol without being INamedType
-		symbol.GetInheritance (
-			isNSObject: out isNSObject,
-			isNativeObject: out isINativeObject,
-			isDictionaryContainer: out isDictionaryContainer,
-			parents: out parents,
-			interfaces: out interfaces);
-
-		IsWrapped = symbol.IsWrapped (isNSObject);
-		if (symbol is IArrayTypeSymbol arraySymbol) {
-			IsArray = true;
-			ArrayElementTypeIsWrapped = arraySymbol.ElementType.IsWrapped ();
-		}
-
-		// try to get the named type symbol to have more educated decisions
-		var namedTypeSymbol = symbol as INamedTypeSymbol;
-
-		// store the enum special type, useful when generate code that needs to cast
-		EnumUnderlyingType = namedTypeSymbol?.EnumUnderlyingType?.SpecialType;
-
-		if (!IsReferenceType && IsNullable && namedTypeSymbol is not null) {
-			// get the type argument for nullable, which we know is the data that was boxed and use it to 
-			// overwrite the SpecialType 
-			var typeArgument = namedTypeSymbol.TypeArguments [0];
-			SpecialType = typeArgument.SpecialType;
-			MetadataName = SpecialType is SpecialType.None or SpecialType.System_Void
-				? null : typeArgument.MetadataName;
-		} else {
-			MetadataName = SpecialType is SpecialType.None or SpecialType.System_Void
-				? null : symbol.MetadataName;
-		}
-
 	}
 
 }

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
@@ -12,12 +12,12 @@ readonly partial struct TypeInfo {
 	/// True if the type needs to use a stret call.
 	/// </summary>
 	public bool NeedsStret { get; init; }
-	
+
 	/// <summary>
 	/// Get the name of the variable for the type when it is used as a return value.
 	/// </summary>
 	public string ReturnVariableName => "ret"; // nothing fancy for now
-	
+
 	internal TypeInfo (ITypeSymbol symbol, Compilation compilation) : this (symbol)
 	{
 		IsNativeEnum = symbol.HasAttribute (AttributesNames.NativeEnumAttribute);

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -140,6 +140,11 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		get => isDictionaryContainer;
 		init => isDictionaryContainer = value;
 	}
+	
+	/// <summary>
+	/// True if the type represents a delegate.
+	/// </summary>
+	public bool IsDelegate { get; init; }
 
 	readonly ImmutableArray<string> parents = [];
 	public ImmutableArray<string> Parents {
@@ -175,6 +180,55 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		IsArray = isArray;
 		IsReferenceType = isReferenceType;
 		IsStruct = isStruct;
+	}
+	
+	internal TypeInfo (ITypeSymbol symbol) :
+		this (
+			symbol is IArrayTypeSymbol arrayTypeSymbol
+				? arrayTypeSymbol.ElementType.ToDisplayString ()
+				: symbol.ToDisplayString ().Trim ('?', '[', ']'),
+			symbol.SpecialType)
+	{
+		IsNullable = symbol.NullableAnnotation == NullableAnnotation.Annotated;
+		IsBlittable = symbol.IsBlittable ();
+		IsSmartEnum = symbol.IsSmartEnum ();
+		IsReferenceType = symbol.IsReferenceType;
+		IsStruct = symbol.TypeKind == TypeKind.Struct;
+		IsInterface = symbol.TypeKind == TypeKind.Interface;
+		IsDelegate = symbol.TypeKind == TypeKind.Delegate;
+		IsNativeIntegerType = symbol.IsNativeIntegerType;
+
+		// data that we can get from the symbol without being INamedType
+		symbol.GetInheritance (
+			isNSObject: out isNSObject,
+			isNativeObject: out isINativeObject,
+			isDictionaryContainer: out isDictionaryContainer,
+			parents: out parents,
+			interfaces: out interfaces);
+
+		IsWrapped = symbol.IsWrapped (isNSObject);
+		if (symbol is IArrayTypeSymbol arraySymbol) {
+			IsArray = true;
+			ArrayElementTypeIsWrapped = arraySymbol.ElementType.IsWrapped ();
+		}
+
+		// try to get the named type symbol to have more educated decisions
+		var namedTypeSymbol = symbol as INamedTypeSymbol;
+
+		// store the enum special type, useful when generate code that needs to cast
+		EnumUnderlyingType = namedTypeSymbol?.EnumUnderlyingType?.SpecialType;
+
+		if (!IsReferenceType && IsNullable && namedTypeSymbol is not null) {
+			// get the type argument for nullable, which we know is the data that was boxed and use it to 
+			// overwrite the SpecialType 
+			var typeArgument = namedTypeSymbol.TypeArguments [0];
+			SpecialType = typeArgument.SpecialType;
+			MetadataName = SpecialType is SpecialType.None or SpecialType.System_Void
+				? null : typeArgument.MetadataName;
+		} else {
+			MetadataName = SpecialType is SpecialType.None or SpecialType.System_Void
+				? null : symbol.MetadataName;
+		}
 	}
 
 	/// <inheritdoc/>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -140,7 +140,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		get => isDictionaryContainer;
 		init => isDictionaryContainer = value;
 	}
-	
+
 	/// <summary>
 	/// True if the type represents a delegate.
 	/// </summary>
@@ -181,7 +181,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		IsReferenceType = isReferenceType;
 		IsStruct = isStruct;
 	}
-	
+
 	internal TypeInfo (ITypeSymbol symbol) :
 		this (
 			symbol is IArrayTypeSymbol arrayTypeSymbol

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -600,9 +600,9 @@ static partial class BindingSyntaxFactory {
 		// based on the bindas type call one of the helper factory methods
 		return (Type: parameter.BindAs.Value.Type, IsArray: parameter.Type.IsArray) switch {
 			{ IsArray: true } => GetNSArrayBindFromAuxVariable (parameter),
-			{ Type: "Foundation.NSNumber" } => GetNSNumberAuxVariable (parameter),
-			{ Type: "Foundation.NSValue" } => GetNSValueAuxVariable (parameter),
-			{ Type: "Foundation.NSString" } => GetNSStringSmartEnumAuxVariable(parameter),
+			{ Type.FullyQualifiedName: "Foundation.NSNumber" } => GetNSNumberAuxVariable (parameter),
+			{ Type.FullyQualifiedName: "Foundation.NSValue" } => GetNSValueAuxVariable (parameter),
+			{ Type.FullyQualifiedName: "Foundation.NSString" } => GetNSStringSmartEnumAuxVariable(parameter),
 			_ => null,
 		};
 #pragma warning restore format

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Core.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Core.cs
@@ -476,7 +476,7 @@ static partial class TypeSymbolExtensions {
 
 		return availability;
 	}
-	
+
 	/// <summary>
 	/// A type is considered wrapped if it is an Interface or is an child of the NSObject class or the NSObject
 	/// itself.

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Core.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Core.cs
@@ -476,4 +476,32 @@ static partial class TypeSymbolExtensions {
 
 		return availability;
 	}
+	
+	/// <summary>
+	/// A type is considered wrapped if it is an Interface or is an child of the NSObject class or the NSObject
+	/// itself.
+	/// </summary>
+	/// <param name="symbol">The symbol to check if it is wrapped.</param>
+	/// <param name="isNSObject">If the symbol is a NSObject of inherits from an NSObject.</param>
+	/// <returns>True if the ymbol is considered to be wrapped.</returns>
+	public static bool IsWrapped (this ITypeSymbol symbol, bool isNSObject)
+		=> symbol.TypeKind == TypeKind.Interface || isNSObject;
+
+	/// <summary>
+	/// A type is considered wrapped if it is an Interface or is an child of the NSObject class or the NSObject
+	/// itself.
+	/// </summary>
+	/// <param name="symbol">The symbol to check if it is wrapped.</param>
+	/// <returns>True if the symbol is considered to be wrapped.</returns>
+	public static bool IsWrapped (this ITypeSymbol symbol)
+	{
+		symbol.GetInheritance (
+			isNSObject: out bool isNSObject,
+			isNativeObject: out bool _,
+			isDictionaryContainer: out bool _,
+			parents: out ImmutableArray<string> _,
+			interfaces: out ImmutableArray<string> _);
+		// either we are a NSObject or we are a subclass of it
+		return IsWrapped (symbol, isNSObject);
+	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Generator.cs
@@ -195,31 +195,4 @@ static partial class TypeSymbolExtensions {
 		return ArmNeedStret (returnType, compilation);
 	}
 
-	/// <summary>
-	/// A type is considered wrapped if it is an Interface or is an child of the NSObject class or the NSObject
-	/// itself.
-	/// </summary>
-	/// <param name="symbol">The symbol to check if it is wrapped.</param>
-	/// <param name="isNSObject">If the symbol is a NSObject of inherits from an NSObject.</param>
-	/// <returns>True if the ymbol is considered to be wrapped.</returns>
-	public static bool IsWrapped (this ITypeSymbol symbol, bool isNSObject)
-		=> symbol.TypeKind == TypeKind.Interface || isNSObject;
-
-	/// <summary>
-	/// A type is considered wrapped if it is an Interface or is an child of the NSObject class or the NSObject
-	/// itself.
-	/// </summary>
-	/// <param name="symbol">The symbol to check if it is wrapped.</param>
-	/// <returns>True if the symbol is considered to be wrapped.</returns>
-	public static bool IsWrapped (this ITypeSymbol symbol)
-	{
-		symbol.GetInheritance (
-			isNSObject: out bool isNSObject,
-			isNativeObject: out bool _,
-			isDictionaryContainer: out bool _,
-			parents: out ImmutableArray<string> _,
-			interfaces: out ImmutableArray<string> _);
-		// either we are a NSObject or we are a subclass of it
-		return IsWrapped (symbol, isNSObject);
-	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests/FromDeclarationTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests/FromDeclarationTests.cs
@@ -571,7 +571,7 @@ namespace NS {
 					],
 					parameters: []
 				) {
-					BindAs = new ("Foundation.NSNumber"),
+					BindAs = new (ReturnTypeForNSObject ("Foundation.NSNumber")),
 				}
 			];
 
@@ -605,7 +605,7 @@ namespace NS {
 							Attributes = [
 								new ("ObjCBindings.BindFromAttribute", ["Foundation.NSNumber"]),
 							],
-							BindAs = new BindFromData ("Foundation.NSNumber"),
+							BindAs = new (ReturnTypeForNSObject ("Foundation.NSNumber")),
 						}
 					]
 				)

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests/FromDeclarationTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests/FromDeclarationTests.cs
@@ -956,7 +956,7 @@ public class TestClass {
 					]
 				) {
 					ExportPropertyData = new (selector: "name"),
-					BindAs = new ("Foundation.NSNumber"),
+					BindAs = new (ReturnTypeForNSObject ("Foundation.NSNumber")),
 				}
 			];
 		}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
@@ -541,7 +541,10 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				new Parameter (
 					position: 0,
 					type: ReturnTypeForArray ("nint"),
-					name: "myParam") { BindAs = new ("Foundation.NSNumber"), },
+					name: "myParam")
+				{
+					BindAs = new (ReturnTypeForNSObject ("Foundation.NSNumber")),
+				},
 				"var nsb_myParam = NSArray.FromNSObjects (obj => new NSNumber (obj), myParam);"
 			];
 
@@ -550,7 +553,10 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				new Parameter (
 					position: 0,
 					type: ReturnTypeForArray ("CoreGraphics.CGAffineTransform", isStruct: true),
-					name: "myParam") { BindAs = new ("Foundation.NSValue"), },
+					name: "myParam")
+				{
+					BindAs = new (ReturnTypeForNSObject ("Foundation.NSValue")),
+				},
 				"var nsb_myParam = NSArray.FromNSObjects (obj => new NSValue (obj), myParam);"
 			];
 
@@ -559,7 +565,10 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				new Parameter (
 					position: 0,
 					type: ReturnTypeForArray ("MySmartEnum", isEnum: true, isSmartEnum: true),
-					name: "myParam") { BindAs = new ("Foundation.NSString"), },
+					name: "myParam")
+				{
+					BindAs = new (ReturnTypeForNSObject ("Foundation.NSString")),
+				},
 				"var nsb_myParam = NSArray.FromNSObjects (obj => obj.GetConstant(), myParam);"
 			];
 		}
@@ -588,7 +597,10 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				new Parameter (
 					position: 0,
 					type: ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_UInt64),
-					name: "myParam") { BindAs = new ("Foundation.NSNumber"), },
+					name: "myParam")
+				{
+					BindAs = new (ReturnTypeForNSObject ("Foundation.NSNumber")),
+				},
 				"var nsb_myParam = NSNumber.FromUInt64 ((ulong) myParam);",
 			];
 
@@ -596,7 +608,10 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				new Parameter (
 					position: 0,
 					type: ReturnTypeForArray ("nint"),
-					name: "myParam") { BindAs = new ("Foundation.NSNumber"), },
+					name: "myParam")
+				{
+					BindAs = new (ReturnTypeForNSObject ("Foundation.NSNumber")),
+				},
 				"var nsb_myParam = NSArray.FromNSObjects (obj => new NSNumber (obj), myParam);"
 			];
 
@@ -605,7 +620,10 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				new Parameter (
 					position: 0,
 					type: ReturnTypeForStruct ("CoreAnimation.CATransform3D"),
-					name: "myParam") { BindAs = new ("Foundation.NSValue"), },
+					name: "myParam") 
+				{
+					BindAs = new (ReturnTypeForNSObject ("Foundation.NSValue")),
+				},
 				"var nsb_myParam = NSValue.FromCATransform3D (myParam);",
 			];
 
@@ -613,7 +631,10 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				new Parameter (
 					position: 0,
 					type: ReturnTypeForArray ("CoreGraphics.CGAffineTransform", isStruct: true),
-					name: "myParam") { BindAs = new ("Foundation.NSValue"), },
+					name: "myParam")
+				{
+					BindAs = new (ReturnTypeForNSObject ("Foundation.NSValue")),
+				},
 				"var nsb_myParam = NSArray.FromNSObjects (obj => new NSValue (obj), myParam);"
 			];
 
@@ -622,7 +643,10 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				new Parameter (
 					position: 0,
 					type: ReturnTypeForEnum ("CoreAnimation.CATransform3D", isSmartEnum: true),
-					name: "myParam") { BindAs = new ("Foundation.NSString"), },
+					name: "myParam")
+				{
+					BindAs = new (ReturnTypeForNSObject ("Foundation.NSString")),
+				},
 				"var nsb_myParam = myParam.GetConstant ();",
 			];
 
@@ -630,7 +654,10 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				new Parameter (
 					position: 0,
 					type: ReturnTypeForArray ("MySmartEnum", isEnum: true, isSmartEnum: true),
-					name: "myParam") { BindAs = new ("Foundation.NSString"), },
+					name: "myParam")
+				{
+					BindAs = new (ReturnTypeForNSObject ("Foundation.NSString")),
+				},
 				"var nsb_myParam = NSArray.FromNSObjects (obj => obj.GetConstant(), myParam);"
 			];
 
@@ -706,7 +733,10 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 			Parameter parameter = new (
 				position: 0,
 				type: ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_UInt64),
-				name: "myParam") { BindAs = new ("Foundation.NSNumber") };
+				name: "myParam")
+			{ 
+				BindAs = new (ReturnTypeForNSObject ("Foundation.NSNumber")),
+			};
 
 			yield return [
 				GetBindFromAuxVariable (parameter)!,
@@ -716,7 +746,10 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 			parameter = new (
 				position: 0,
 				type: ReturnTypeForArray ("nint"),
-				name: "myParam") { BindAs = new ("Foundation.NSNumber") };
+				name: "myParam")
+			{
+				BindAs = new (ReturnTypeForNSObject ("Foundation.NSNumber")),
+			};
 
 			yield return [
 				GetBindFromAuxVariable (parameter)!,
@@ -726,7 +759,10 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 			parameter = new (
 				position: 0,
 				type: ReturnTypeForStruct ("CoreAnimation.CATransform3D"),
-				name: "myParam") { BindAs = new ("Foundation.NSValue") };
+				name: "myParam")
+			{
+				BindAs = new (ReturnTypeForNSObject ("Foundation.NSValue")),
+			};
 
 			yield return [
 				GetBindFromAuxVariable (parameter)!,
@@ -736,7 +772,10 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 			parameter = new (
 				position: 0,
 				type: ReturnTypeForArray ("CoreGraphics.CGAffineTransform", isStruct: true),
-				name: "myParam") { BindAs = new ("Foundation.NSValue") };
+				name: "myParam")
+			{
+				BindAs = new (ReturnTypeForNSObject ("Foundation.NSValue")),
+			};
 
 			yield return [
 				GetBindFromAuxVariable (parameter)!,
@@ -746,7 +785,10 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 			parameter = new (
 				position: 0,
 				type: ReturnTypeForEnum ("CoreAnimation.CATransform3D", isSmartEnum: true),
-				name: "myParam") { BindAs = new ("Foundation.NSString"), };
+				name: "myParam")
+			{
+				BindAs = new (ReturnTypeForNSObject ("Foundation.NSString")),
+			};
 
 			yield return [
 				GetBindFromAuxVariable (parameter)!,
@@ -756,7 +798,10 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 			parameter = new Parameter (
 				position: 0,
 				type: ReturnTypeForArray ("MySmartEnum", isEnum: true, isSmartEnum: true),
-				name: "myParam") { BindAs = new ("Foundation.NSString"), };
+				name: "myParam")
+			{
+				BindAs = new (ReturnTypeForNSObject ("Foundation.NSString")),
+			};
 
 			yield return [
 				GetBindFromAuxVariable (parameter)!,

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
@@ -541,8 +541,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				new Parameter (
 					position: 0,
 					type: ReturnTypeForArray ("nint"),
-					name: "myParam")
-				{
+					name: "myParam") {
 					BindAs = new (ReturnTypeForNSObject ("Foundation.NSNumber")),
 				},
 				"var nsb_myParam = NSArray.FromNSObjects (obj => new NSNumber (obj), myParam);"
@@ -553,8 +552,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				new Parameter (
 					position: 0,
 					type: ReturnTypeForArray ("CoreGraphics.CGAffineTransform", isStruct: true),
-					name: "myParam")
-				{
+					name: "myParam") {
 					BindAs = new (ReturnTypeForNSObject ("Foundation.NSValue")),
 				},
 				"var nsb_myParam = NSArray.FromNSObjects (obj => new NSValue (obj), myParam);"
@@ -565,8 +563,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				new Parameter (
 					position: 0,
 					type: ReturnTypeForArray ("MySmartEnum", isEnum: true, isSmartEnum: true),
-					name: "myParam")
-				{
+					name: "myParam") {
 					BindAs = new (ReturnTypeForNSObject ("Foundation.NSString")),
 				},
 				"var nsb_myParam = NSArray.FromNSObjects (obj => obj.GetConstant(), myParam);"
@@ -597,8 +594,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				new Parameter (
 					position: 0,
 					type: ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_UInt64),
-					name: "myParam")
-				{
+					name: "myParam") {
 					BindAs = new (ReturnTypeForNSObject ("Foundation.NSNumber")),
 				},
 				"var nsb_myParam = NSNumber.FromUInt64 ((ulong) myParam);",
@@ -608,8 +604,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				new Parameter (
 					position: 0,
 					type: ReturnTypeForArray ("nint"),
-					name: "myParam")
-				{
+					name: "myParam") {
 					BindAs = new (ReturnTypeForNSObject ("Foundation.NSNumber")),
 				},
 				"var nsb_myParam = NSArray.FromNSObjects (obj => new NSNumber (obj), myParam);"
@@ -620,8 +615,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				new Parameter (
 					position: 0,
 					type: ReturnTypeForStruct ("CoreAnimation.CATransform3D"),
-					name: "myParam") 
-				{
+					name: "myParam") {
 					BindAs = new (ReturnTypeForNSObject ("Foundation.NSValue")),
 				},
 				"var nsb_myParam = NSValue.FromCATransform3D (myParam);",
@@ -631,8 +625,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				new Parameter (
 					position: 0,
 					type: ReturnTypeForArray ("CoreGraphics.CGAffineTransform", isStruct: true),
-					name: "myParam")
-				{
+					name: "myParam") {
 					BindAs = new (ReturnTypeForNSObject ("Foundation.NSValue")),
 				},
 				"var nsb_myParam = NSArray.FromNSObjects (obj => new NSValue (obj), myParam);"
@@ -643,8 +636,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				new Parameter (
 					position: 0,
 					type: ReturnTypeForEnum ("CoreAnimation.CATransform3D", isSmartEnum: true),
-					name: "myParam")
-				{
+					name: "myParam") {
 					BindAs = new (ReturnTypeForNSObject ("Foundation.NSString")),
 				},
 				"var nsb_myParam = myParam.GetConstant ();",
@@ -654,8 +646,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				new Parameter (
 					position: 0,
 					type: ReturnTypeForArray ("MySmartEnum", isEnum: true, isSmartEnum: true),
-					name: "myParam")
-				{
+					name: "myParam") {
 					BindAs = new (ReturnTypeForNSObject ("Foundation.NSString")),
 				},
 				"var nsb_myParam = NSArray.FromNSObjects (obj => obj.GetConstant(), myParam);"
@@ -733,8 +724,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 			Parameter parameter = new (
 				position: 0,
 				type: ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_UInt64),
-				name: "myParam")
-			{ 
+				name: "myParam") {
 				BindAs = new (ReturnTypeForNSObject ("Foundation.NSNumber")),
 			};
 
@@ -746,8 +736,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 			parameter = new (
 				position: 0,
 				type: ReturnTypeForArray ("nint"),
-				name: "myParam")
-			{
+				name: "myParam") {
 				BindAs = new (ReturnTypeForNSObject ("Foundation.NSNumber")),
 			};
 
@@ -759,8 +748,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 			parameter = new (
 				position: 0,
 				type: ReturnTypeForStruct ("CoreAnimation.CATransform3D"),
-				name: "myParam")
-			{
+				name: "myParam") {
 				BindAs = new (ReturnTypeForNSObject ("Foundation.NSValue")),
 			};
 
@@ -772,8 +760,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 			parameter = new (
 				position: 0,
 				type: ReturnTypeForArray ("CoreGraphics.CGAffineTransform", isStruct: true),
-				name: "myParam")
-			{
+				name: "myParam") {
 				BindAs = new (ReturnTypeForNSObject ("Foundation.NSValue")),
 			};
 
@@ -785,8 +772,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 			parameter = new (
 				position: 0,
 				type: ReturnTypeForEnum ("CoreAnimation.CATransform3D", isSmartEnum: true),
-				name: "myParam")
-			{
+				name: "myParam") {
 				BindAs = new (ReturnTypeForNSObject ("Foundation.NSString")),
 			};
 
@@ -798,8 +784,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 			parameter = new Parameter (
 				position: 0,
 				type: ReturnTypeForArray ("MySmartEnum", isEnum: true, isSmartEnum: true),
-				name: "myParam")
-			{
+				name: "myParam") {
 				BindAs = new (ReturnTypeForNSObject ("Foundation.NSString")),
 			};
 


### PR DESCRIPTION
Move from using a string to a typeinfo data so that we haver more details about the type that was used.