### PR TITLE
[devops] Use parameters instead of branch names to determine whether we're a PR or not.

### DIFF
--- a/tools/devops/automation/scripts/VSTS.psm1
+++ b/tools/devops/automation/scripts/VSTS.psm1
@@ -521,7 +521,7 @@ class BuildConfiguration {
             $tags.Add("cronjob")
         }
 
-        if ($configuration.PARENT_BUILD_BUILD_SOURCEBRANCH.StartsWith("refs/heads/dev/") -or $configuration.BuildReason -eq "PullRequest" -or (($configuration.BuildReason -eq "Manual") -and ($configuration.PARENT_BUILD_BUILD_SOURCEBRANCH -eq "merge")) ) {
+        if ($Env:IS_PR -eq "true" -or $configuration.BuildReason -eq "PullRequest" -or (($configuration.BuildReason -eq "Manual") -and ($configuration.PARENT_BUILD_BUILD_SOURCEBRANCH -eq "merge")) ) {
           Write-Host "Configuring build from PR."
 
           # retrieve the PR data to be able to fwd the labels from github

--- a/tools/devops/automation/templates/api-diff-stage.yml
+++ b/tools/devops/automation/templates/api-diff-stage.yml
@@ -51,6 +51,7 @@ stages:
         statusContext: 'VSTS: simulator tests' 
         uploadArtifacts: true
         use1ES: false
+        isPR: ${{ parameters.isPR }}
 
 - stage: generate_api_diff
   displayName: 'API diff'

--- a/tools/devops/automation/templates/common/configure.yml
+++ b/tools/devops/automation/templates/common/configure.yml
@@ -39,6 +39,11 @@ parameters:
   type: string
   default: ''
 
+- name: isPR
+  displayName: Is PR build
+  type: boolean
+  default: false
+
 steps:
 - template: checkout.yml
   parameters:
@@ -58,6 +63,7 @@ steps:
   env:
     GITHUB_TOKEN: $(GitHub.Token)
     ACCESSTOKEN: $(AzDoBuildAccess.Token)
+    IS_PR: ${{ parameters.isPR }}
   name: labels
   displayName: 'Configure build'
 


### PR DESCRIPTION
This way we correctly detect if we're a pull request when we're in a backport
pull request (where the branch name starts with backport-pr-*) or a dependency
update from maestro (where the branch name starts with darc-*).

Example failure:

https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=11130542&view=logs&s=0f8cf363-55a6-5c89-5a7b-27693abc5647&j=276491e5-a85e-51e3-6c38-98e261218d1a