### PR TITLE
[build] Shut down the build server after 'make all' as well.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ install-hook::
 		exit 1; \
 	fi
 
-install-hook::
+all-hook install-hook::
 	$(Q) $(MAKE) -C dotnet shutdown-build-server
 
 .PHONY: package release


### PR DESCRIPTION
Hopefully this will fix the build randomly hanging at the end of 'make all'.