### PR TITLE
[BGen] Simplify the BindAs generated code for NSNumber and NSValue.

### DIFF
--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -2922,7 +2922,7 @@ public partial class Generator : IMemberGatherer {
 					cast_a = $"{enumCast}Runtime.GetNSObject<{formattedReturnType}> (";
 					if (isNullable)
 						cast_b = $", {owns}){wrapper} ?? default ({formattedBindAsType})";
-					else 
+					else
 						cast_b = $", {owns})!{wrapper}";
 				}
 			} else {

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -2919,9 +2919,11 @@ public partial class Generator : IMemberGatherer {
 					}
 				} else {
 					var enumCast = (bindAsType.IsEnum && !minfo.type.IsArray) ? $"({formattedBindAsType}) " : string.Empty;
-					print ("{0} retvaltmp;", NativeHandleType);
-					cast_a = "((retvaltmp = ";
-					cast_b = $") == IntPtr.Zero ? default ({formattedBindAsType}) : ({enumCast}Runtime.GetNSObject<{formattedReturnType}> (retvaltmp, {owns})!{wrapper})){suffix}";
+					cast_a = $"{enumCast}Runtime.GetNSObject<{formattedReturnType}> (";
+					if (isNullable)
+						cast_b = $", {owns}){wrapper} ?? default ({formattedBindAsType})";
+					else 
+						cast_b = $", {owns})!{wrapper}";
 				}
 			} else {
 				cast_a = " Runtime.GetNSObject<" + TypeManager.FormatType (minfo?.type ?? declaringType, mi.ReturnType) + "> (";

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -2921,7 +2921,7 @@ public partial class Generator : IMemberGatherer {
 					var enumCast = (bindAsType.IsEnum && !minfo.type.IsArray) ? $"({formattedBindAsType}) " : string.Empty;
 					cast_a = $"{enumCast}Runtime.GetNSObject<{formattedReturnType}> (";
 					if (isNullable)
-						cast_b = $", {owns}){wrapper} ?? default ({formattedBindAsType})";
+						cast_b = $", {owns}){wrapper}";
 					else
 						cast_b = $", {owns})!{wrapper}";
 				}


### PR DESCRIPTION
The old generated code works but it is certainly interesting...

This changes affects both properties and methods that use the BindAsAttribute for their return type.

Properties:

The following shows an example of the new vs old code generated for property getters:

Old code:
```csharp
public virtual bool? IsCallerIdBlocked {
    [Export ("isCallerIdBlocked", ArgumentSemantic.Copy)]
    get {
        bool? ret;
        if (IsDirectBinding) {
            NativeHandle retvaltmp;
            ret = ((retvaltmp = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, Selector.GetHandle ("isCallerIdBlocked"))) == IntPtr.Zero ? default (bool?) : (Runtime.GetNSObject<NSNumber> (retvaltmp, false)!?.BoolValue));
        } else {
            NativeHandle retvaltmp;
            ret = ((retvaltmp = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.SuperHandle, Selector.GetHandle ("isCallerIdBlocked"))) == IntPtr.Zero ? default (bool?) : (Runtime.GetNSObject<NSNumber> (retvaltmp, false)!?.BoolValue));
        }
        return ret!;
    }
}
```
New code:
```csharp
public virtual bool? IsCallerIdBlocked {
    [Export ("isCallerIdBlocked", ArgumentSemantic.Copy)]
    get {
        bool? ret;
        if (IsDirectBinding) {
            ret = Runtime.GetNSObject<NSNumber> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, Selector.GetHandle ("isCallerIdBlocked")), false)?.BoolValue ?? default (bool?);
        } else {
            ret = Runtime.GetNSObject<NSNumber> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.SuperHandle, Selector.GetHandle ("isCallerIdBlocked")), false)?.BoolValue ?? default (bool?);
        }
        return ret!;
    }
}
```

Methods:

The following shows an example of the new vs old code generated for methods with a return type decoreatd with the attribute:

Old code:
```csharp
public static nuint GetRngSeed ()
{
    NativeHandle retvaltmp;
    return ((retvaltmp = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (class_ptr, Selector.GetHandle ("getRNGseed"))) == IntPtr.Zero ? default (nuint) : (Runtime.GetNSObject<NSNumber> (retvaltmp, false)!.NUIntValue));
}
```

New code:
```csharp
public static nuint GetRngSeed ()
{
    return Runtime.GetNSObject<NSNumber> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (class_ptr, Selector.GetHandle ("getRNGseed")), false)!.NUIntValue;
}
```

Both example have been chosen to show the diff between the generated code for a nullable value and a non-nullable one.