### PR TITLE
[ci] Publish VS workload zips (#22279)

### DIFF
--- a/dotnet/package/common.csproj
+++ b/dotnet/package/common.csproj
@@ -131,6 +131,8 @@
 
     <ItemGroup>
       <ItemsToPush Include="$(NupkgPath)\*.nupkg" />
+      <WorkloadArtifacts Include="$(NupkgPath)\*.zip" />
+      <ItemsToPush Include="@(WorkloadArtifacts)" PublishFlatContainer="true" RelativeBlobPath="macios/$(_PackageVersion)/%(Filename)%(Extension)" />
     </ItemGroup>
 
     <Error Condition="'@(ItemsToPush)' == ''" Text="No packages to push." />

--- a/scripts/generate-vs-workload/generate-vs-workload.cs
+++ b/scripts/generate-vs-workload/generate-vs-workload.cs
@@ -52,7 +52,7 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 	writer.WriteLine ($"<Project>");
 	writer.WriteLine ($"  <PropertyGroup>");
 	var allPlatforms = string.Join (".", platforms.Select (v => v.Item1).OrderBy (v => v));
-	writer.WriteLine ($"    <TargetName>Microsoft.NET.Sdk.{allPlatforms}.Workload.{tfm}.{xcodeName}</TargetName>");
+	writer.WriteLine ($"    <TargetName>{allPlatforms}.{tfm}.{xcodeName}</TargetName>");
 	// Find the iOS version, otherwise use the version of the first platform listed.
 	var iOSPlatform = platforms.Where (v => v.Item1 == "iOS");
 	var manifestBuildVersion = iOSPlatform.Any () ? iOSPlatform.First ().Item2 : platforms.First ().Item2;


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/commit/96d7858cce242c5eea76028f3f051bb9ffda793c

Adds the VS manifest zips needed by the workload versions VS insertion
pipeline to Maestro publishing.

The first update to VS that includes these changes will have to be done
manually, as the manifest names are also changing to work with the new
pipeline.