### PR TITLE
[RGen] Add factory method to create a NSArray.ArrayFromFunc call.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -175,7 +175,7 @@ static partial class BindingSyntaxFactory {
 	}
 	
 	/// <summary>
-	/// Generates a call to the NSArray.ArrayFromHandleFunc with the given arugments
+	/// Generates a call to the NSArray.ArrayFromHandleFunc with the given arguments.
 	/// </summary>
 	/// <param name="returnType">The generic return type of the call.</param>
 	/// <param name="arguments">An immutable array of arguments.</param>

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -173,4 +173,31 @@ static partial class BindingSyntaxFactory {
 					IdentifierName ("FromHandle").WithTrailingTrivia (Space)))
 			.WithArgumentList (argumentList);
 	}
+	
+	/// <summary>
+	/// Generates a call to the NSArray.ArrayFromHandleFunc with the given arugments
+	/// </summary>
+	/// <param name="returnType">The generic return type of the call.</param>
+	/// <param name="arguments">An immutable array of arguments.</param>
+	/// <returns>The invocation syntax for the method.</returns>
+	internal static InvocationExpressionSyntax NSArrayFromHandleFunc (string returnType,
+		ImmutableArray<ArgumentSyntax> arguments)
+	{
+		// generate: (arg1, arg2, arg3)
+		var argumentList = ArgumentList (
+			SeparatedList<ArgumentSyntax> (arguments.ToSyntaxNodeOrTokenArray ()));
+		// generate <returnType>
+		var genericsList = TypeArgumentList (
+			SingletonSeparatedList<TypeSyntax> (IdentifierName (returnType)));
+		
+		// generate NSArray.ArrayFromHandleFunc<returnType> (arg1, arg2, arg3)
+		return InvocationExpression (
+				MemberAccessExpression (
+					SyntaxKind.SimpleMemberAccessExpression,
+					IdentifierName ("NSArray"),
+					GenericName ("ArrayFromHandleFunc")
+						.WithTypeArgumentList(genericsList)
+						.WithTrailingTrivia (Space)))
+			.WithArgumentList (argumentList);
+	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -145,4 +145,35 @@ public class BindingSyntaxFactoryRuntimeTests {
 		var declaration = StringFromHandle (arguments);
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
 	}
+	
+	class TestDataNSArrayFromHandleFunc: IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			yield return [
+				"int",
+				ImmutableArray.Create (
+					Argument (IdentifierName ("arg1"))),
+				"NSArray.ArrayFromHandleFunc<int> (arg1)"
+			];
+
+			yield return [
+				"string",
+				ImmutableArray.Create (
+					Argument (IdentifierName ("arg1")),
+					Argument (IdentifierName ("arg2")),
+					Argument (IdentifierName ("arg3"))),
+				"NSArray.ArrayFromHandleFunc<string> (arg1, arg2, arg3)"
+			];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	
+	[Theory]
+	[ClassData (typeof (TestDataNSArrayFromHandleFunc))]
+	void NSArrayFromHandleFuncTests (string returnType, ImmutableArray<ArgumentSyntax> arguments, string expectedDeclaration)
+	{
+		var declaration = NSArrayFromHandleFunc (returnType, arguments);
+		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
+	}
 }


### PR DESCRIPTION
This call is used in several places for the BindAs/BindFrom attribute. The factory method allows to pass the expected return type and a list or arguments.