### PR TITLE
[RGen] Create factory method for the NSNumber factory methods.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.Extensions;
+using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Microsoft.Macios.Generator.Emitters;
@@ -53,9 +54,9 @@ static partial class BindingSyntaxFactory {
 	{
 		// (selector)
 		var args = ArgumentList (SingletonSeparatedList (
-					Argument (LiteralExpression (
-						SyntaxKind.StringLiteralExpression,
-						Literal (selector))))).NormalizeWhitespace ();
+			Argument (LiteralExpression (
+				SyntaxKind.StringLiteralExpression,
+				Literal (selector))))).NormalizeWhitespace ();
 
 		// Selector.GetHandle (selector)
 		return InvocationExpression (
@@ -120,16 +121,16 @@ static partial class BindingSyntaxFactory {
 		var argumentList = ArgumentList (SeparatedList<ArgumentSyntax> (args));
 		// generates: ObjCRuntime.Messaging.objc_msgSend (this.Handle, Selector.GetHandle (selector), args)
 		var invocation = InvocationExpression (
-			MemberAccessExpression (
-				SyntaxKind.SimpleMemberAccessExpression,
 				MemberAccessExpression (
 					SyntaxKind.SimpleMemberAccessExpression,
-					AliasQualifiedName (
-						IdentifierName (
-							Token (SyntaxKind.GlobalKeyword)),
-						IdentifierName ("ObjCRuntime")),
-					IdentifierName ("Messaging")),
-				IdentifierName (objcMsgSendMethod).WithTrailingTrivia (Space)))
+					MemberAccessExpression (
+						SyntaxKind.SimpleMemberAccessExpression,
+						AliasQualifiedName (
+							IdentifierName (
+								Token (SyntaxKind.GlobalKeyword)),
+							IdentifierName ("ObjCRuntime")),
+						IdentifierName ("Messaging")),
+					IdentifierName (objcMsgSendMethod).WithTrailingTrivia (Space)))
 			.WithArgumentList (argumentList);
 		return invocation;
 	}
@@ -147,10 +148,10 @@ static partial class BindingSyntaxFactory {
 
 		// generate: CFArray.StringArrayFromHandle (arg1, arg2, arg3)
 		return InvocationExpression (
-			MemberAccessExpression (
-				SyntaxKind.SimpleMemberAccessExpression,
-				IdentifierName ("CFArray"),
-				IdentifierName ("StringArrayFromHandle").WithTrailingTrivia (Space)))
+				MemberAccessExpression (
+					SyntaxKind.SimpleMemberAccessExpression,
+					IdentifierName ("CFArray"),
+					IdentifierName ("StringArrayFromHandle").WithTrailingTrivia (Space)))
 			.WithArgumentList (argumentList);
 	}
 
@@ -172,5 +173,40 @@ static partial class BindingSyntaxFactory {
 					IdentifierName ("CFString"),
 					IdentifierName ("FromHandle").WithTrailingTrivia (Space)))
 			.WithArgumentList (argumentList);
+	}
+
+	/// <summary>
+	/// Returns the method group needed to get a NSNumber from a handle.
+	/// </summary>
+	/// <param name="returnType">The type info of the return type.</param>
+	/// <returns>The member access to the correct NSNumber method.</returns>
+	internal static MemberAccessExpressionSyntax? NSNumerFromHandle (TypeInfo returnType)
+	{
+		var memberName = returnType switch {
+			// name must be before SpecialType or you'll get them wrong values because
+			// the type we want by name also have a valid special type, the tests should catch
+			// mistakes here
+			{ Name: "NFloat" or "nfloat" } => "ToNFloat",
+			{ Name: "nint" } => "ToNInt",
+			{ Name: "nuint" } => "ToNUInt",
+			{ SpecialType: SpecialType.System_Boolean } => "ToBool",
+			{ SpecialType: SpecialType.System_Byte } => "ToByte",
+			{ SpecialType: SpecialType.System_Double } => "ToDouble",
+			{ SpecialType: SpecialType.System_Single } => "ToFloat",
+			{ SpecialType: SpecialType.System_Int16 } => "ToInt16",
+			{ SpecialType: SpecialType.System_Int32 } => "ToInt32",
+			{ SpecialType: SpecialType.System_Int64 } => "ToInt64",
+			{ SpecialType: SpecialType.System_SByte } => "ToSByte",
+			{ SpecialType: SpecialType.System_UInt16 } => "ToUInt16",
+			{ SpecialType: SpecialType.System_UInt32 } => "ToUInt32",
+			{ SpecialType: SpecialType.System_UInt64 } => "ToUInt64",
+			_ => null,
+		};
+		if (memberName is null) 
+			return null;
+		return MemberAccessExpression (
+			SyntaxKind.SimpleMemberAccessExpression,
+			IdentifierName ("NSNumber"),
+			IdentifierName (memberName));
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -6,9 +6,11 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.DataModel;
 using Xunit;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using static Microsoft.Macios.Generator.Emitters.BindingSyntaxFactory;
+using static Microsoft.Macios.Generator.Tests.TestDataFactory;
 
 namespace Microsoft.Macios.Generator.Tests.Emitters;
 
@@ -144,5 +146,76 @@ public class BindingSyntaxFactoryRuntimeTests {
 	{
 		var declaration = StringFromHandle (arguments);
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
+	}
+	
+	class TestDataNSNumerFromHandleTests : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			
+			yield return [
+				ReturnTypeForBool (),
+				"NSNumber.ToBool"
+			];
+			
+			yield return [
+				ReturnTypeForInt (),
+				"NSNumber.ToInt32"
+			];
+
+			yield return [
+				ReturnTypeForInt (isUnsigned: true),
+				"NSNumber.ToUInt32"
+			];
+			
+			yield return [
+				ReturnTypeForShort (),
+				"NSNumber.ToInt16"
+			];
+
+			yield return [
+				ReturnTypeForShort (isUnsigned: true),
+				"NSNumber.ToUInt16"
+			];
+			
+			yield return [
+				ReturnTypeForLong (),
+				"NSNumber.ToInt64"
+			];
+
+			yield return [
+				ReturnTypeForLong (isUnsigned: true),
+				"NSNumber.ToUInt64"
+			];
+			
+			yield return [
+				ReturnTypeForNInt (),
+				"NSNumber.ToNInt"
+			];
+
+			yield return [
+				ReturnTypeForNInt (isUnsigned: true),
+				"NSNumber.ToNUInt"
+			];
+			
+			yield return [
+				ReturnTypeForDouble (),
+				"NSNumber.ToDouble"
+			];
+			
+			yield return [
+				ReturnTypeForFloat (),
+				"NSNumber.ToFloat"
+			];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	
+	[Theory]
+	[ClassData (typeof (TestDataNSNumerFromHandleTests))]
+	void NSNumerFromHandleTests (TypeInfo returnType, string expectedDeclaration)
+	{
+		var declaration = NSNumerFromHandle (returnType);
+		Assert.Equal (expectedDeclaration, declaration?.ToFullString ());
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
@@ -83,7 +83,268 @@ static class TestDataFactory {
 					$"System.Numerics.IMinMaxValue<{typeName}>",
 					$"System.Numerics.ISignedNumber<{typeName}>"
 				],
-			MetadataName = "Int32",
+			MetadataName = metadataName,
+		};
+		return type;
+	}
+	
+	public static TypeInfo ReturnTypeForShort (bool isNullable = false, bool keepInterfaces = false,
+		bool isUnsigned = false)
+	{
+		var typeName = isUnsigned ? "ushort" : "short";
+		var metadataName = isUnsigned ? "UInt16" : "Int16";
+		var type = new TypeInfo (
+			name: typeName,
+			specialType: isUnsigned ? SpecialType.System_UInt16 : SpecialType.System_Int16,
+			isBlittable: !isNullable,
+			isNullable: isNullable,
+			isStruct: true
+		) {
+			Parents = ["System.ValueType", "object"],
+			Interfaces = isNullable && !keepInterfaces
+				? []
+				: [
+					"System.IComparable",
+					$"System.IComparable<{typeName}>",
+					"System.IConvertible",
+					$"System.IEquatable<{typeName}>",
+					"System.IFormattable",
+					$"System.IParsable<{typeName}>",
+					"System.ISpanFormattable",
+					$"System.ISpanParsable<{typeName}>",
+					"System.IUtf8SpanFormattable",
+					$"System.IUtf8SpanParsable<{typeName}>",
+					$"System.Numerics.IAdditionOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IAdditiveIdentity<{typeName}, {typeName}>",
+					$"System.Numerics.IBinaryInteger<{typeName}>",
+					$"System.Numerics.IBinaryNumber<{typeName}>",
+					$"System.Numerics.IBitwiseOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IComparisonOperators<{typeName}, {typeName}, bool>",
+					$"System.Numerics.IEqualityOperators<{typeName}, {typeName}, bool>",
+					$"System.Numerics.IDecrementOperators<{typeName}>",
+					$"System.Numerics.IDivisionOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IIncrementOperators<{typeName}>",
+					$"System.Numerics.IModulusOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IMultiplicativeIdentity<{typeName}, {typeName}>",
+					$"System.Numerics.IMultiplyOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.INumber<{typeName}>",
+					$"System.Numerics.INumberBase<{typeName}>",
+					$"System.Numerics.ISubtractionOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IUnaryNegationOperators<{typeName}, {typeName}>",
+					$"System.Numerics.IUnaryPlusOperators<{typeName}, {typeName}>",
+					$"System.Numerics.IShiftOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IMinMaxValue<{typeName}>",
+					$"System.Numerics.ISignedNumber<{typeName}>"
+				],
+			MetadataName = metadataName,
+		};
+		return type;
+	}
+	
+	public static TypeInfo ReturnTypeForLong (bool isNullable = false, bool keepInterfaces = false,
+		bool isUnsigned = false)
+	{
+		var typeName = isUnsigned ? "ulong" : "long";
+		var metadataName = isUnsigned ? "UInt64" : "Int64";
+		var type = new TypeInfo (
+			name: typeName,
+			specialType: isUnsigned ? SpecialType.System_UInt64 : SpecialType.System_Int64,
+			isBlittable: !isNullable,
+			isNullable: isNullable,
+			isStruct: true
+		) {
+			Parents = ["System.ValueType", "object"],
+			Interfaces = isNullable && !keepInterfaces
+				? []
+				: [
+					"System.IComparable",
+					$"System.IComparable<{typeName}>",
+					"System.IConvertible",
+					$"System.IEquatable<{typeName}>",
+					"System.IFormattable",
+					$"System.IParsable<{typeName}>",
+					"System.ISpanFormattable",
+					$"System.ISpanParsable<{typeName}>",
+					"System.IUtf8SpanFormattable",
+					$"System.IUtf8SpanParsable<{typeName}>",
+					$"System.Numerics.IAdditionOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IAdditiveIdentity<{typeName}, {typeName}>",
+					$"System.Numerics.IBinaryInteger<{typeName}>",
+					$"System.Numerics.IBinaryNumber<{typeName}>",
+					$"System.Numerics.IBitwiseOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IComparisonOperators<{typeName}, {typeName}, bool>",
+					$"System.Numerics.IEqualityOperators<{typeName}, {typeName}, bool>",
+					$"System.Numerics.IDecrementOperators<{typeName}>",
+					$"System.Numerics.IDivisionOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IIncrementOperators<{typeName}>",
+					$"System.Numerics.IModulusOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IMultiplicativeIdentity<{typeName}, {typeName}>",
+					$"System.Numerics.IMultiplyOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.INumber<{typeName}>",
+					$"System.Numerics.INumberBase<{typeName}>",
+					$"System.Numerics.ISubtractionOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IUnaryNegationOperators<{typeName}, {typeName}>",
+					$"System.Numerics.IUnaryPlusOperators<{typeName}, {typeName}>",
+					$"System.Numerics.IShiftOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IMinMaxValue<{typeName}>",
+					$"System.Numerics.ISignedNumber<{typeName}>"
+				],
+			MetadataName = metadataName,
+		};
+		return type;
+	}
+	
+	public static TypeInfo ReturnTypeForDouble (bool isNullable = false, bool keepInterfaces = false)
+	{
+		var typeName = "double";
+		var type = new TypeInfo (
+			name: typeName,
+			specialType: SpecialType.System_Double,
+			isBlittable: !isNullable,
+			isNullable: isNullable,
+			isStruct: true
+		) {
+			Parents = ["System.ValueType", "object"],
+			Interfaces = isNullable && !keepInterfaces
+				? []
+				: [
+					"System.IComparable",
+					$"System.IComparable<{typeName}>",
+					"System.IConvertible",
+					$"System.IEquatable<{typeName}>",
+					"System.IFormattable",
+					$"System.IParsable<{typeName}>",
+					"System.ISpanFormattable",
+					$"System.ISpanParsable<{typeName}>",
+					"System.IUtf8SpanFormattable",
+					$"System.IUtf8SpanParsable<{typeName}>",
+					$"System.Numerics.IAdditionOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IAdditiveIdentity<{typeName}, {typeName}>",
+					$"System.Numerics.IBinaryInteger<{typeName}>",
+					$"System.Numerics.IBinaryNumber<{typeName}>",
+					$"System.Numerics.IBitwiseOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IComparisonOperators<{typeName}, {typeName}, bool>",
+					$"System.Numerics.IEqualityOperators<{typeName}, {typeName}, bool>",
+					$"System.Numerics.IDecrementOperators<{typeName}>",
+					$"System.Numerics.IDivisionOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IIncrementOperators<{typeName}>",
+					$"System.Numerics.IModulusOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IMultiplicativeIdentity<{typeName}, {typeName}>",
+					$"System.Numerics.IMultiplyOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.INumber<{typeName}>",
+					$"System.Numerics.INumberBase<{typeName}>",
+					$"System.Numerics.ISubtractionOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IUnaryNegationOperators<{typeName}, {typeName}>",
+					$"System.Numerics.IUnaryPlusOperators<{typeName}, {typeName}>",
+					$"System.Numerics.IShiftOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IMinMaxValue<{typeName}>",
+					$"System.Numerics.ISignedNumber<{typeName}>"
+				],
+			MetadataName = "Double",
+		};
+		return type;
+	}
+	
+	public static TypeInfo ReturnTypeForFloat (bool isNullable = false, bool keepInterfaces = false)
+	{
+		var typeName = "float";
+		var type = new TypeInfo (
+			name: typeName,
+			specialType: SpecialType.System_Single,
+			isBlittable: !isNullable,
+			isNullable: isNullable,
+			isStruct: true
+		) {
+			Parents = ["System.ValueType", "object"],
+			Interfaces = isNullable && !keepInterfaces
+				? []
+				: [
+					"System.IComparable",
+					$"System.IComparable<{typeName}>",
+					"System.IConvertible",
+					$"System.IEquatable<{typeName}>",
+					"System.IFormattable",
+					$"System.IParsable<{typeName}>",
+					"System.ISpanFormattable",
+					$"System.ISpanParsable<{typeName}>",
+					"System.IUtf8SpanFormattable",
+					$"System.IUtf8SpanParsable<{typeName}>",
+					$"System.Numerics.IAdditionOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IAdditiveIdentity<{typeName}, {typeName}>",
+					$"System.Numerics.IBinaryInteger<{typeName}>",
+					$"System.Numerics.IBinaryNumber<{typeName}>",
+					$"System.Numerics.IBitwiseOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IComparisonOperators<{typeName}, {typeName}, bool>",
+					$"System.Numerics.IEqualityOperators<{typeName}, {typeName}, bool>",
+					$"System.Numerics.IDecrementOperators<{typeName}>",
+					$"System.Numerics.IDivisionOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IIncrementOperators<{typeName}>",
+					$"System.Numerics.IModulusOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IMultiplicativeIdentity<{typeName}, {typeName}>",
+					$"System.Numerics.IMultiplyOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.INumber<{typeName}>",
+					$"System.Numerics.INumberBase<{typeName}>",
+					$"System.Numerics.ISubtractionOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IUnaryNegationOperators<{typeName}, {typeName}>",
+					$"System.Numerics.IUnaryPlusOperators<{typeName}, {typeName}>",
+					$"System.Numerics.IShiftOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IMinMaxValue<{typeName}>",
+					$"System.Numerics.ISignedNumber<{typeName}>"
+				],
+			MetadataName = "Float",
+		};
+		return type;
+	}
+	
+	public static TypeInfo ReturnTypeForNInt (bool isNullable = false, bool keepInterfaces = false,
+		bool isUnsigned = false)
+	{
+		var typeName = isUnsigned ? "nuint" : "nint";
+		var metadataName = isUnsigned ? "UIntPtr" : "IntPtr";
+		var type = new TypeInfo (
+			name: typeName,
+			specialType: isUnsigned ? SpecialType.System_UInt32 : SpecialType.System_Int32,
+			isBlittable: !isNullable,
+			isNullable: isNullable,
+			isStruct: true
+		) {
+			Parents = ["System.ValueType", "object"],
+			Interfaces = isNullable && !keepInterfaces
+				? []
+				: [
+					"System.IComparable",
+					$"System.IComparable<{typeName}>",
+					"System.IConvertible",
+					$"System.IEquatable<{typeName}>",
+					"System.IFormattable",
+					$"System.IParsable<{typeName}>",
+					"System.ISpanFormattable",
+					$"System.ISpanParsable<{typeName}>",
+					"System.IUtf8SpanFormattable",
+					$"System.IUtf8SpanParsable<{typeName}>",
+					$"System.Numerics.IAdditionOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IAdditiveIdentity<{typeName}, {typeName}>",
+					$"System.Numerics.IBinaryInteger<{typeName}>",
+					$"System.Numerics.IBinaryNumber<{typeName}>",
+					$"System.Numerics.IBitwiseOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IComparisonOperators<{typeName}, {typeName}, bool>",
+					$"System.Numerics.IEqualityOperators<{typeName}, {typeName}, bool>",
+					$"System.Numerics.IDecrementOperators<{typeName}>",
+					$"System.Numerics.IDivisionOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IIncrementOperators<{typeName}>",
+					$"System.Numerics.IModulusOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IMultiplicativeIdentity<{typeName}, {typeName}>",
+					$"System.Numerics.IMultiplyOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.INumber<{typeName}>",
+					$"System.Numerics.INumberBase<{typeName}>",
+					$"System.Numerics.ISubtractionOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IUnaryNegationOperators<{typeName}, {typeName}>",
+					$"System.Numerics.IUnaryPlusOperators<{typeName}, {typeName}>",
+					$"System.Numerics.IShiftOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IMinMaxValue<{typeName}>",
+					$"System.Numerics.ISignedNumber<{typeName}>"
+				],
+			MetadataName = metadataName,
 		};
 		return type;
 	}


### PR DESCRIPTION
This new factory method will return the member access to the correct NSNumber factory method. This is later used in the code generation when dealing with NSNumber backed BindAs/BindFrom attributes.