### PR TITLE
[RGen] Fix bug that was using the wrong struct to parse an attribute.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -173,7 +173,7 @@ static partial class BindingSyntaxFactory {
 					IdentifierName ("FromHandle").WithTrailingTrivia (Space)))
 			.WithArgumentList (argumentList);
 	}
-	
+
 	/// <summary>
 	/// Generates a call to the NSArray.ArrayFromHandleFunc with the given arguments.
 	/// </summary>
@@ -189,14 +189,14 @@ static partial class BindingSyntaxFactory {
 		// generate <returnType>
 		var genericsList = TypeArgumentList (
 			SingletonSeparatedList<TypeSyntax> (IdentifierName (returnType)));
-		
+
 		// generate NSArray.ArrayFromHandleFunc<returnType> (arg1, arg2, arg3)
 		return InvocationExpression (
 				MemberAccessExpression (
 					SyntaxKind.SimpleMemberAccessExpression,
 					IdentifierName ("NSArray"),
 					GenericName ("ArrayFromHandleFunc")
-						.WithTypeArgumentList(genericsList)
+						.WithTypeArgumentList (genericsList)
 						.WithTrailingTrivia (Space)))
 			.WithArgumentList (argumentList);
 	}

--- a/src/rgen/Microsoft.Macios.Transformer/AttributesNames.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/AttributesNames.cs
@@ -329,7 +329,7 @@ static class AttributesNames {
 	/// <summary>
 	/// Flags the object as being thread safe.
 	/// </summary>
-	[BindingAttribute(typeof(BackingFieldTypeData), AttributeTargets.All)]
+	[BindingAttribute(typeof(ThreadSafeData), AttributeTargets.All)]
 	public const string ThreadSafeAttribute = "ThreadSafeAttribute";
 
 	/// <summary>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -145,8 +145,8 @@ public class BindingSyntaxFactoryRuntimeTests {
 		var declaration = StringFromHandle (arguments);
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
 	}
-	
-	class TestDataNSArrayFromHandleFunc: IEnumerable<object []> {
+
+	class TestDataNSArrayFromHandleFunc : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
 			yield return [
@@ -168,7 +168,7 @@ public class BindingSyntaxFactoryRuntimeTests {
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
-	
+
 	[Theory]
 	[ClassData (typeof (TestDataNSArrayFromHandleFunc))]
 	void NSArrayFromHandleFuncTests (string returnType, ImmutableArray<ArgumentSyntax> arguments, string expectedDeclaration)


### PR DESCRIPTION
There was an error (yy probably) in which we used the wrong struct to parse the threadsafe attribute.