### PR TITLE
Update .NET 8/Xcode 16.0 ref to 18.0.8319

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -31,21 +31,21 @@
       <Sha>7ea2381200e5ca70cf67efc887d9cd693d82b77f</Sha>
     </Dependency>
     <!-- This is a subscription of the .NET 8/Xcode 16.0 versions of our packages -->
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net8.0_18.0" Version="18.0.8314">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net8.0_18.0" Version="18.0.8319">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>8354d6d971c635925ef7b26da8b04305b5b3035a</Sha>
+      <Sha>0ee28379dd5e85c830bad0270d064bbcec467647</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net8.0_15.0" Version="15.0.8314">
+    <Dependency Name="Microsoft.macOS.Sdk.net8.0_15.0" Version="15.0.8319">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>8354d6d971c635925ef7b26da8b04305b5b3035a</Sha>
+      <Sha>0ee28379dd5e85c830bad0270d064bbcec467647</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net8.0_18.0" Version="18.0.8314">
+    <Dependency Name="Microsoft.iOS.Sdk.net8.0_18.0" Version="18.0.8319">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>8354d6d971c635925ef7b26da8b04305b5b3035a</Sha>
+      <Sha>0ee28379dd5e85c830bad0270d064bbcec467647</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net8.0_18.0" Version="18.0.8314">
+    <Dependency Name="Microsoft.tvOS.Sdk.net8.0_18.0" Version="18.0.8319">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>8354d6d971c635925ef7b26da8b04305b5b3035a</Sha>
+      <Sha>0ee28379dd5e85c830bad0270d064bbcec467647</Sha>
     </Dependency>
     <!-- This is a subscription of the .NET 8/Xcode 15.0 versions of our packages -->
     <Dependency Name="Microsoft.MacCatalyst.Sdk.net8.0_17.0" Version="17.0.8523">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,10 +19,10 @@
     <EmscriptenWorkloadVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest80100Version)</EmscriptenWorkloadVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- This is a subscription of the .NET 8 versions of our packages -->
-    <MicrosoftMacCatalystSdknet80_180PackageVersion>18.0.8314</MicrosoftMacCatalystSdknet80_180PackageVersion>
-    <MicrosoftmacOSSdknet80_150PackageVersion>15.0.8314</MicrosoftmacOSSdknet80_150PackageVersion>
-    <MicrosoftiOSSdknet80_180PackageVersion>18.0.8314</MicrosoftiOSSdknet80_180PackageVersion>
-    <MicrosofttvOSSdknet80_180PackageVersion>18.0.8314</MicrosofttvOSSdknet80_180PackageVersion>
+    <MicrosoftMacCatalystSdknet80_180PackageVersion>18.0.8319</MicrosoftMacCatalystSdknet80_180PackageVersion>
+    <MicrosoftmacOSSdknet80_150PackageVersion>15.0.8319</MicrosoftmacOSSdknet80_150PackageVersion>
+    <MicrosoftiOSSdknet80_180PackageVersion>18.0.8319</MicrosoftiOSSdknet80_180PackageVersion>
+    <MicrosofttvOSSdknet80_180PackageVersion>18.0.8319</MicrosofttvOSSdknet80_180PackageVersion>
     <!-- This is a subscription to the .NET 8/Xcode 15.0 versions of our packages -->
     <MicrosoftMacCatalystSdknet80_170PackageVersion>17.0.8523</MicrosoftMacCatalystSdknet80_170PackageVersion>
     <MicrosoftmacOSSdknet80_140PackageVersion>14.0.8523</MicrosoftmacOSSdknet80_140PackageVersion>


### PR DESCRIPTION
Changes: http://github.com/dotnet/macios/compare/8354d6d971c635925ef7b26da8b04305b5b3035a...0ee28379dd5e85c830bad0270d064bbcec467647

Updates the previous .NET 8/Xcode 16.0 versions to the latest package
versions that are available in VS.