### PR TITLE
[RGen] Return the correct NSNumber static method when we have an array.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -56,7 +56,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// The special type enum of the type info. This is used to differentiate nint from IntPtr and other.
 	/// </summary>
 	public SpecialType SpecialType { get; } = SpecialType.None;
-	
+
 	/// <summary>
 	/// True if the parameter is nullable.
 	/// </summary>
@@ -71,7 +71,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// Returns if the return type is a smart enum.
 	/// </summary>
 	public bool IsSmartEnum { get; }
-	
+
 	/// <summary>
 	/// If the type is an array, it returns the special type of the underlying type.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -6,7 +6,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.CodeAnalysis;
-using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Extensions;
 
 namespace Microsoft.Macios.Generator.DataModel;
@@ -57,7 +56,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// The special type enum of the type info. This is used to differentiate nint from IntPtr and other.
 	/// </summary>
 	public SpecialType SpecialType { get; } = SpecialType.None;
-
+	
 	/// <summary>
 	/// True if the parameter is nullable.
 	/// </summary>
@@ -72,10 +71,16 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// Returns if the return type is a smart enum.
 	/// </summary>
 	public bool IsSmartEnum { get; }
+	
+	/// <summary>
+	/// If the type is an array, it returns the special type of the underlying type.
+	/// </summary>
+	public SpecialType? ArrayElementType { get; init; }
 
 	/// <summary>
 	/// Returns if the return type is an array type.
 	/// </summary>
+	[MemberNotNullWhen (true, nameof (ArrayElementType))]
 	public bool IsArray { get; }
 
 	/// <summary>
@@ -209,6 +214,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		IsWrapped = symbol.IsWrapped (isNSObject);
 		if (symbol is IArrayTypeSymbol arraySymbol) {
 			IsArray = true;
+			ArrayElementType = arraySymbol.ElementType.SpecialType;
 			ArrayElementTypeIsWrapped = arraySymbol.ElementType.IsWrapped ();
 		}
 

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -238,8 +238,14 @@ static partial class BindingSyntaxFactory {
 	/// <returns>The member access to the correct NSNumber method.</returns>
 	internal static MemberAccessExpressionSyntax? NSNumberFromHandle (TypeInfo returnType)
 	{
+		// create a tuple to store the name and special type depending if it is an array 
+		// or a non array type
+		var info = returnType.IsArray 
+			? (Name: returnType.Name, SpecialType: returnType.ArrayElementType) 
+			: (Name: returnType.Name, SpecialType: returnType.SpecialType);
+
 #pragma warning disable format
-		var memberName = returnType switch {
+		var memberName = info switch {
 			// name must be before SpecialType or you'll get them wrong values because
 			// the type we want by name also have a valid special type, the tests should catch
 			// mistakes here

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -240,8 +240,8 @@ static partial class BindingSyntaxFactory {
 	{
 		// create a tuple to store the name and special type depending if it is an array 
 		// or a non array type
-		var info = returnType.IsArray 
-			? (Name: returnType.Name, SpecialType: returnType.ArrayElementType) 
+		var info = returnType.IsArray
+			? (Name: returnType.Name, SpecialType: returnType.ArrayElementType)
 			: (Name: returnType.Name, SpecialType: returnType.SpecialType);
 
 #pragma warning disable format

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -4,13 +4,14 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.Macios.Generator.DataModel;
 using Xunit;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using static Microsoft.Macios.Generator.Emitters.BindingSyntaxFactory;
 using static Microsoft.Macios.Generator.Tests.TestDataFactory;
+using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
 
 namespace Microsoft.Macios.Generator.Tests.Emitters;
 
@@ -315,6 +316,21 @@ public class BindingSyntaxFactoryRuntimeTests {
 			yield return [
 				ReturnTypeForFloat (),
 				"NSNumber.ToFloat"
+			];
+
+			yield return [
+				ReturnTypeForArray ("int", underlyingType: SpecialType.System_Int32),
+				"NSNumber.ToInt32"
+			];
+			
+			yield return [
+				ReturnTypeForArray ("uint", underlyingType: SpecialType.System_UInt32),
+				"NSNumber.ToUInt32"
+			];
+			
+			yield return [
+				ReturnTypeForArray ("nint", underlyingType: SpecialType.System_IntPtr),
+				"NSNumber.ToNInt"
 			];
 		}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -322,12 +322,12 @@ public class BindingSyntaxFactoryRuntimeTests {
 				ReturnTypeForArray ("int", underlyingType: SpecialType.System_Int32),
 				"NSNumber.ToInt32"
 			];
-			
+
 			yield return [
 				ReturnTypeForArray ("uint", underlyingType: SpecialType.System_UInt32),
 				"NSNumber.ToUInt32"
 			];
-			
+
 			yield return [
 				ReturnTypeForArray ("nint", underlyingType: SpecialType.System_IntPtr),
 				"NSNumber.ToNInt"

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
@@ -478,7 +478,8 @@ static class TestDataFactory {
 		bool isEnum = false,
 		bool isSmartEnum = false,
 		bool isStruct = false,
-		bool isNSObject = false)
+		bool isNSObject = false,
+		SpecialType? underlyingType = null)
 		=> new (
 			name: type,
 			isNullable: isNullable,
@@ -489,6 +490,7 @@ static class TestDataFactory {
 			isStruct: isStruct
 		) {
 			EnumUnderlyingType = isEnum ? SpecialType.System_Int32 : null,
+			ArrayElementType = underlyingType,
 			ArrayElementTypeIsWrapped = isNSObject,
 			Parents = ["System.Array", "object"],
 			Interfaces = [


### PR DESCRIPTION
Array types a special because we have to track the array element type rathern that the actual SpecialType of the array (which is SpecialType.None).

We add a new property to our data model to track the special type of the element and we create a helper tuple to keep the switch expression clean. This could have been done without the helper tuple, but the code look a lot worse, the compiler is smart enough to remove that extra tuple.