### PR TITLE
[Rgen] Split the naming logic form the emitters.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/EnumEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/EnumEmitter.cs
@@ -17,7 +17,8 @@ namespace Microsoft.Macios.Generator.Emitters;
 
 class EnumEmitter : ICodeEmitter {
 
-	public string GetSymbolName (in Binding binding) => $"{binding.Name}Extensions";
+	public string GetSymbolName (in Binding binding) 
+		=> Nomenclator.GetSmartEnumExtensionClassName (binding.Name);
 	public IEnumerable<string> UsingStatements => ["Foundation", "ObjCRuntime", "System"];
 
 	void EmitEnumFieldAtIndex (TabbedWriter<StringWriter> classBlock, in Binding binding, int index)

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/EnumEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/EnumEmitter.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Macios.Generator.Emitters;
 
 class EnumEmitter : ICodeEmitter {
 
-	public string GetSymbolName (in Binding binding) 
+	public string GetSymbolName (in Binding binding)
 		=> Nomenclator.GetSmartEnumExtensionClassName (binding.Name);
 	public IEnumerable<string> UsingStatements => ["Foundation", "ObjCRuntime", "System"];
 

--- a/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
@@ -15,5 +15,5 @@ static class Nomenclator {
 	/// </summary>
 	/// <param name="enumName">The name of the smart enum.</param>
 	/// <returns>The name of the extension class to be generated for the given smart enum.</returns>
-	public static string GetSmartEnumExtensionClassName (string enumName) => $"{enumName}Extensions";	
+	public static string GetSmartEnumExtensionClassName (string enumName) => $"{enumName}Extensions";
 }

--- a/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Macios.Generator;
+
+/// <summary>
+/// Nomenclator: A person, generally a public official, who announces the names of guests at a party or other
+/// social gathering or ceremony.
+///
+/// In this case, the Nomenclator is used to generate the names of the bindings.
+/// </summary>
+static class Nomenclator {
+	/// <summary>
+	/// Returns the name to be used by the extension classes for smart enumerators.
+	/// </summary>
+	/// <param name="enumName">The name of the smart enum.</param>
+	/// <returns>The name of the extension class to be generated for the given smart enum.</returns>
+	public static string GetSmartEnumExtensionClassName (string enumName) => $"{enumName}Extensions";	
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/NomenclatorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/NomenclatorTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 namespace Microsoft.Macios.Generator.Tests;
 
 public class NomenclatorTests {
-	
+
 	[Theory]
 	[InlineData ("AVCaptureDeviceType", "AVCaptureDeviceTypeExtensions")]
 	[InlineData ("GKError", "GKErrorExtensions")]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/NomenclatorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/NomenclatorTests.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Xunit;
+
+namespace Microsoft.Macios.Generator.Tests;
+
+public class NomenclatorTests {
+	
+	[Theory]
+	[InlineData ("AVCaptureDeviceType", "AVCaptureDeviceTypeExtensions")]
+	[InlineData ("GKError", "GKErrorExtensions")]
+	public void GetSmartEnumExtensionClassNameTests (string enumName, string expectedName)
+		=> Assert.Equal (Nomenclator.GetSmartEnumExtensionClassName (enumName), expectedName);
+}


### PR DESCRIPTION
We will want to be able to generate code that references to the generated classes. Rather than having a pattern placed all over the project, we create a static class that given a string it will return the name to be used by the emitters.

This, for example, will later be useful when we want to call the extension methods for a smart enum.