### PR TITLE
[tests] Set 'IlcTreatWarningsAsErrors=false' in csproj instead of from xharness for tests.

### DIFF
--- a/tests/common/shared-dotnet.csproj
+++ b/tests/common/shared-dotnet.csproj
@@ -65,6 +65,8 @@
 	<PropertyGroup Condition="'$(PublishAot)' == 'true' And '$(_IsPublishing)' == 'true'">
 		<!-- Define NATIVEAOT when using NativeAOT -->
 		<DefineConstants>$(DefineConstants);NATIVEAOT</DefineConstants>
+		<!-- We're enabling warnaserror by default, but we're not warning-free for ILC (especially for NUnit), so disable warnaserror for ILC - https://github.com/xamarin/xamarin-macios/issues/19911 -->
+		<IlcTreatWarningsAsErrors>false</IlcTreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<!-- Trimmer options -->

--- a/tests/xharness/Jenkins/TestVariationsFactory.cs
+++ b/tests/xharness/Jenkins/TestVariationsFactory.cs
@@ -232,7 +232,6 @@ namespace Xharness.Jenkins {
 						if (publishaot) {
 							clone.Xml.SetProperty ("PublishAot", "true", last: false);
 							clone.Xml.SetProperty ("_IsPublishing", "true", last: false); // quack like "dotnet publish", otherwise PublishAot=true has no effect.
-							clone.Xml.SetProperty ("IlcTreatWarningsAsErrors", "false", last: false); // We're enabling warnaserror by default, but we're not warning-free for ILC (especially for NUnit), so disable warnaserror for ILC - https://github.com/xamarin/xamarin-macios/issues/19911
 						}
 						if (!string.IsNullOrEmpty (test_variation)) {
 							clone.Xml.SetProperty ("TestVariation", test_variation);


### PR DESCRIPTION
This way it's set when building tests from the command line as well.