### PR TITLE
[RGen] Add support for the Nomenclator for trampolines.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -150,6 +151,11 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// True if the type represents a delegate.
 	/// </summary>
 	public bool IsDelegate { get; init; }
+	
+	/// <summary>
+	/// True if the symbol represents a generic type.
+	/// </summary>
+	public bool IsGenericType { get; init; }
 
 	readonly ImmutableArray<string> parents = [];
 	public ImmutableArray<string> Parents {
@@ -163,6 +169,12 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		get => interfaces;
 		init => interfaces = value;
 	}
+
+
+	/// <summary>
+	/// The type arguments of the generic type.
+	/// </summary>
+	public ImmutableArray<string> TypeArguments { get; init; } = [];
 
 	internal TypeInfo (string name, SpecialType specialType)
 	{
@@ -223,6 +235,13 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 
 		// store the enum special type, useful when generate code that needs to cast
 		EnumUnderlyingType = namedTypeSymbol?.EnumUnderlyingType?.SpecialType;
+		if (namedTypeSymbol is not null) {
+			IsGenericType = namedTypeSymbol.IsGenericType;
+			TypeArguments = [
+				..namedTypeSymbol.TypeArguments
+					.Select (x => x.ToDisplayString ())
+			];
+		}
 
 		if (!IsReferenceType && IsNullable && namedTypeSymbol is not null) {
 			// get the type argument for nullable, which we know is the data that was boxed and use it to 

--- a/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+using Microsoft.Macios.Generator.DataModel;
+
 namespace Microsoft.Macios.Generator;
 
 /// <summary>
@@ -9,11 +12,55 @@ namespace Microsoft.Macios.Generator;
 ///
 /// In this case, the Nomenclator is used to generate the names of the bindings.
 /// </summary>
-static class Nomenclator {
+class Nomenclator {
+	
+	// keep track of the generic versions of a trampoline, we will use the fully qualified name
+	// of the type to keep track of the generic versions.
+	readonly Dictionary<string, int> trampolinesGenericVersions = new ();
+
 	/// <summary>
 	/// Returns the name to be used by the extension classes for smart enumerators.
 	/// </summary>
 	/// <param name="enumName">The name of the smart enum.</param>
 	/// <returns>The name of the extension class to be generated for the given smart enum.</returns>
 	public static string GetSmartEnumExtensionClassName (string enumName) => $"{enumName}Extensions";
+	
+	/// <summary>
+	/// Returns the name to be used for a trampoline.
+	/// </summary>
+	/// <param name="typeInfo">The type info whose trampoline name we require.</param>
+	/// <returns>The name of the trampoline to be used for the given type.</returns>
+	public string GetTrampolineName (TypeInfo typeInfo)
+	{
+		// The following algo is used to generate the same trampoline name that bgen used to generate.
+		// for that we need to understand how bgen generates the name:
+		// old code:
+		//
+		// var trampolineName = typeInfo.Name.Replace ("`", "Arity");
+		// if (typeInfo.IsGenericType) {
+		// 	var gdef = typeInfo.GetGenericTypeDefinition ();
+		//
+		// 	if (!trampolinesGenericVersions.ContainsKey (gdef))
+		// 		trampolinesGenericVersions.Add (gdef, 0);
+		//
+		// 	trampolineName = trampolineName + "V" + trampolinesGenericVersions [gdef]++;
+		// }
+		// return trampolineName;
+		
+		// trampoline name will th e the name of the type + the arity + the lenght of the generic types
+		// else it will be the trampoline name 
+		var trampolineName = typeInfo.IsGenericType
+			? $"{typeInfo.Name[..typeInfo.Name.IndexOf ('<')]}Arity{typeInfo.TypeArguments.Length}"
+			: typeInfo.Name;
+		
+		if (!typeInfo.IsGenericType) 
+			return trampolineName;
+		
+		// TryAdd will only insert 0 if it is not already present, reduces the dict access to a single operation
+		// rather than a contain + add
+		trampolinesGenericVersions.TryAdd (typeInfo.Name, 0);
+		trampolineName = trampolineName + "V" + trampolinesGenericVersions [typeInfo.Name]++;
+
+		return trampolineName;
+	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/NomenclatorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/NomenclatorTests.cs
@@ -1,15 +1,66 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.DataModel;
+using Xamarin.Tests;
+using Xamarin.Utils;
 using Xunit;
 
 namespace Microsoft.Macios.Generator.Tests;
 
-public class NomenclatorTests {
-
+public class NomenclatorTests : BaseGeneratorTestClass {
+	
 	[Theory]
 	[InlineData ("AVCaptureDeviceType", "AVCaptureDeviceTypeExtensions")]
 	[InlineData ("GKError", "GKErrorExtensions")]
 	public void GetSmartEnumExtensionClassNameTests (string enumName, string expectedName)
 		=> Assert.Equal (Nomenclator.GetSmartEnumExtensionClassName (enumName), expectedName);
+	
+	[Theory]
+	[AllSupportedPlatforms]
+	public void GetTrampolineNameGeneric (ApplePlatform platform)
+	{
+		var nomenclator = new Nomenclator ();
+		
+		// write a sample code to retrieve the roslyn symbol and type info so that 
+		// we can test the nomenclator.
+		var code = @"
+using System;
+using System.Collections.Generic;
+
+namespace Test;
+
+public class GenericTrampoline<T> where T : class {
+	void DidAccelerateSeveral (object accelerometer, object second, object last);
 }
+
+public class Example {
+	public 	GenericTrampoline<string> Trampoline { get; set; }
+}
+";
+		
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: code);
+		
+		Assert.Single (syntaxTrees);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ()
+			.OfType<PropertyDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		Assert.NotNull (semanticModel);
+		Assert.True (Property.TryCreate (declaration, semanticModel, out var property));
+		Assert.NotNull (property);
+		var type = property.Value.ReturnType;
+		
+		var name1 = nomenclator.GetTrampolineName (type);
+		var name2 = nomenclator.GetTrampolineName (type);
+		// compare names and ensure that the correct number is used
+		Assert.Equal ("GenericTrampolineArity1V0", name1);
+		Assert.Equal ("GenericTrampolineArity1V1", name2);
+		Assert.NotEqual (name1, name2);
+	}
+}
+	


### PR DESCRIPTION
Use the same naming logic that we find in bgen but addapted to the data model that we use in rgen.

Both the algorithm and the test are a copy of the bgen implementation so that the generated code uses the same naming conventions.