### PR TITLE
[net10.0] [nuget-msi-convert] Disable improved VS component IDs

### DIFF
--- a/scripts/generate-vs-workload/generate-vs-workload.cs
+++ b/scripts/generate-vs-workload/generate-vs-workload.cs
@@ -58,7 +58,7 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 	var manifestBuildVersion = iOSPlatform.Any () ? iOSPlatform.First ().Item2 : platforms.First ().Item2;
 	writer.WriteLine ($"    <ManifestBuildVersion>{manifestBuildVersion}</ManifestBuildVersion>");
 	writer.WriteLine ($"    <EnableSideBySideManifests>true</EnableSideBySideManifests>");
-	writer.WriteLine ($"    <UseVisualStudioComponentPrefix>true</UseVisualStudioComponentPrefix>");
+	writer.WriteLine ($"    <UseVisualStudioComponentPrefix>false</UseVisualStudioComponentPrefix>");
 	writer.WriteLine ($"  </PropertyGroup>");
 	writer.WriteLine ($"  <ItemGroup>");
 	writer.WriteLine ($"    <!-- Shorten package names to avoid long path caching issues in Visual Studio -->");


### PR DESCRIPTION
Context: https://github.com/dotnet/macios/commit/04f4de35ebd598282b098bb60c37775de0f7cc3c

I believe we still plan to change these component names in .NET 10, but we should disable this for now while working on a draft .NET 10 VS PR.