### PR TITLE
[actions] Run the global.json bumping action for dotnet/arcade bumps as well.

### DIFF
--- a/.github/workflows/bump-global-json.yml
+++ b/.github/workflows/bump-global-json.yml
@@ -10,7 +10,7 @@ jobs:
     # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
     permissions:
       contents: write
-    if: contains(github.event.pull_request.title, 'Update dependencies from dotnet/sdk') && github.actor == 'dotnet-maestro[bot]'
+    if: contains(github.event.pull_request.title, 'Update dependencies from dotnet/') && github.actor == 'dotnet-maestro[bot]'
     steps:
     - name: 'Checkout repo'
       uses: actions/checkout@v4


### PR DESCRIPTION
Example PR where this didn't happen: https://github.com/dotnet/macios/pull/22381