### PR TITLE
[dev/filipnavara/handle-gchole] Address PR feedback

### DIFF
--- a/src/CoreText/CTParagraphStyle.cs
+++ b/src/CoreText/CTParagraphStyle.cs
@@ -374,12 +374,16 @@ namespace CoreText {
 
 		static CTParagraphStyleSpecifierValue CreateValue (CTParagraphStyleSpecifier spec, IEnumerable<CTTextTab> value)
 		{
+			// The analyzer cannot deal with arrays, we manually keep alive the whole array below
+#pragma warning disable RBI0014
 			var handles = new List<NativeHandle> ();
 			foreach (var ts in value) {
 				handles.Add (ts.Handle);
-				GC.KeepAlive (ts);
 			}
-			return new CTParagraphStyleSpecifierIntPtrsValue (spec, handles.ToArray ());
+			CTParagraphStyleSpecifierValue result = new CTParagraphStyleSpecifierIntPtrsValue (spec, handles.ToArray ());
+			GC.KeepAlive (value);
+			return result;
+#pragma warning restore RBI0014
 		}
 
 		static CTParagraphStyleSpecifierValue CreateValue (CTParagraphStyleSpecifier spec, byte value)

--- a/src/CoreText/CTStringAttributes.cs
+++ b/src/CoreText/CTStringAttributes.cs
@@ -247,13 +247,15 @@ namespace CoreText {
 #endif
 		public CGColor? BackgroundColor {
 			get {
-				var h = IntPtr.Zero;
 				var x = CTStringAttributeKey.BackgroundColor;
 				if (x is not null) {
-					h = CFDictionary.GetValue (Dictionary.Handle, x.Handle);
+					var h = CFDictionary.GetValue (Dictionary.Handle, x.Handle);
+					CGColor result = new CGColor (h, false);
 					GC.KeepAlive (x);
+					return result;
+				} else {
+					return null;
 				}
-				return h == IntPtr.Zero ? null : new CGColor (h, false);
 			}
 			set {
 				var x = CTStringAttributeKey.BackgroundColor;

--- a/src/ObjCRuntime/Class.cs
+++ b/src/ObjCRuntime/Class.cs
@@ -156,9 +156,7 @@ namespace ObjCRuntime {
 			if (right is null)
 				return false;
 
-			bool result = Handle == right.Handle;
-			GC.KeepAlive (right);
-			return result;
+			return Handle == right.Handle;
 		}
 
 		public override int GetHashCode ()
@@ -233,9 +231,7 @@ namespace ObjCRuntime {
 			if (@class is null)
 				return null;
 
-			var result = Lookup (@class.Handle, true)!;
-			GC.KeepAlive (@class);
-			return result;
+			return Lookup (@class.Handle, true)!;
 		}
 
 		internal static Type Lookup (IntPtr klass)

--- a/src/ObjCRuntime/DisposableObject.cs
+++ b/src/ObjCRuntime/DisposableObject.cs
@@ -116,10 +116,7 @@ namespace ObjCRuntime {
 				return b is null;
 			else if (b is null)
 				return false;
-			bool result = a.Handle == b.Handle;
-			GC.KeepAlive (a);
-			GC.KeepAlive (b);
-			return result;
+			return a.Handle == b.Handle;
 		}
 
 		public static bool operator != (DisposableObject? a, DisposableObject? b)
@@ -128,10 +125,7 @@ namespace ObjCRuntime {
 				return b is not null;
 			else if (b is null)
 				return true;
-			bool result = a.Handle != b.Handle;
-			GC.KeepAlive (a);
-			GC.KeepAlive (b);
-			return result;
+			return a.Handle != b.Handle;
 		}
 #endif
 	}

--- a/src/ObjCRuntime/RegistrarHelper.cs
+++ b/src/ObjCRuntime/RegistrarHelper.cs
@@ -426,12 +426,15 @@ namespace ObjCRuntime {
 #endif
 				return;
 			}
+			// The handle is captured and returned to caller, so the caller is
+			// responsible for keeping the object alive.
+#pragma warning disable RBI0014
 			IntPtr rv = value.GetHandle ();
-			GC.KeepAlive (value);
 #if TRACE
 			Runtime.NSLog ($"INativeObject_managed_to_native (0x{(*ptr).ToString ("x")}, ? != ?): 0x{rv.ToString ("x")} => {value?.GetType ()}");
 #endif
 			*ptr = rv;
+#pragma warning restore RBI0014
 		}
 	}
 }

--- a/src/UIKit/UIAppearance.cs
+++ b/src/UIKit/UIAppearance.cs
@@ -27,9 +27,7 @@ namespace UIKit {
 			UIAppearance ao = other as UIAppearance;
 			if (ao is null)
 				return false;
-			bool result = ao.Handle == Handle;
-			GC.KeepAlive (ao);
-			return result;
+			return ao.Handle == Handle;
 		}
 
 		public override int GetHashCode ()
@@ -43,11 +41,7 @@ namespace UIKit {
 				return ReferenceEquals (b, null);
 			else if (ReferenceEquals (b, null))
 				return false;
-
-			bool result = a.Handle == b.Handle;
-			GC.KeepAlive (a);
-			GC.KeepAlive (b);
-			return result;
+			return a.Handle == b.Handle;
 		}
 
 		public static bool operator != (UIAppearance a, UIAppearance b)

--- a/src/UIKit/UIConfigurationColorTransformer.cs
+++ b/src/UIKit/UIConfigurationColorTransformer.cs
@@ -57,10 +57,7 @@ namespace UIKit {
 			var descriptor = (BlockLiteral*) block;
 			var del = (UIConfigurationColorTransformerHandler) (descriptor->Target);
 			var retval = del is null ? null : del (Runtime.GetNSObject<UIColor> (color)!);
-			// FIXME: Should this run DangerousRetain + DangerousAutorelease?
-#pragma warning disable RBI0014
-			return retval.GetHandle ();
-#pragma warning restore RBI0014
+			return Runtime.RetainAndAutoreleaseNSObject (retval);
 		}
 	} /* class SDUIConfigurationColorTransformerHandler */
 

--- a/src/UIKit/UIFont.cs
+++ b/src/UIKit/UIFont.cs
@@ -358,10 +358,7 @@ namespace UIKit {
 				return ((object) f2) is null;
 			else if ((object) f2 is null)
 				return false;
-			bool result = f1.Handle == f2.Handle;
-			GC.KeepAlive (f1);
-			GC.KeepAlive (f2);
-			return result;
+			return f1.Handle == f2.Handle;
 		}
 
 		public static bool operator != (UIFont f1, UIFont f2)

--- a/src/UIKit/UIGestureRecognizer.cs
+++ b/src/UIKit/UIGestureRecognizer.cs
@@ -57,7 +57,6 @@ namespace UIKit {
 		public UIGestureRecognizer (Selector sel, Token token) : this (token, sel)
 		{
 			recognizers [token] = sel.Handle;
-			GC.KeepAlive (sel);
 			MarkDirty ();
 		}
 

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/NativeObjectHandleAnalyzer.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/NativeObjectHandleAnalyzer.cs
@@ -147,7 +147,7 @@ public class NativeObjectHandleAnalyzer : DiagnosticAnalyzer {
 
 		// Skip over this.Handle == other.Handle checks
 		if (memberAccess.Parent is BinaryExpressionSyntax binaryParent &&
-		    binaryParent.Kind() is SyntaxKind.EqualsExpression or SyntaxKind.NotEqualsExpression) {
+			binaryParent.Kind () is SyntaxKind.EqualsExpression or SyntaxKind.NotEqualsExpression) {
 			return;
 		}
 

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/NativeObjectHandleAnalyzer.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/NativeObjectHandleAnalyzer.cs
@@ -7,6 +7,29 @@ using System.Linq;
 
 namespace Microsoft.Macios.Bindings.Analyzer;
 
+/// <summary>
+/// Analyzer to ensure that native objects are kept alive for the duration of accessing them by their Handle.
+/// </summary>
+/// <remarks>
+/// Common pattern used in the manual bindings is to call a native method and pass objects using their
+/// handle like this:
+/// <code>
+/// var x = nw_framer_create_options (protocolDefinition.Handle);
+/// </code>
+/// If <c>protocolDefinition</c> is a local variable or method argument that is no longer accessed after
+/// the call then the .NET runtime may consider it eligible for garbage collection. Such garbage collection
+/// could run the object finalizer and render the <c>Handle</c> invalid while the native call is still in
+/// progress. In order to avoid this race condition the bindings have to keep the <c>protocolDefinition</c>
+/// variable alive for the garbage collector. This can be done by either accessing the same variable
+/// later in the method, or explicitly calling <c>GC.KeepAlive (protocolDefinition);</c>. This analyzer
+/// detects cases where such access is not performed and issues an error.
+/// 
+/// Current shortcommings of the analyzer include:
+/// <list type="bullet">
+/// <item><description>Handles stored inside an array are not tracked</description></item>
+/// <item><description>Only nearest scope is considered when checking if the variable is kept alive</description></item>
+/// </list>
+/// </remarks>
 [DiagnosticAnalyzer (LanguageNames.CSharp)]
 public class NativeObjectHandleAnalyzer : DiagnosticAnalyzer {
 	internal static readonly DiagnosticDescriptor RBI0014 = new (
@@ -116,6 +139,17 @@ public class NativeObjectHandleAnalyzer : DiagnosticAnalyzer {
 
 		if (!IsINativeObject (varType))
 			return;
+
+		// Exclude Class and Selector types, they are implicitly kept alive
+		if (varType.ContainingNamespace.Name == "ObjCRuntime" && varType.Name is "Class" or "Selector") {
+			return;
+		}
+
+		// Skip over this.Handle == other.Handle checks
+		if (memberAccess.Parent is BinaryExpressionSyntax binaryParent &&
+		    binaryParent.Kind() is SyntaxKind.EqualsExpression or SyntaxKind.NotEqualsExpression) {
+			return;
+		}
 
 		// Ignore variables that are wrapped in `using (existingVariable)` block. These are
 		// not excluded by the `localSymbol.IsUsing` condition above.

--- a/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/NativeObjectHandleAnalyzerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/NativeObjectHandleAnalyzerTests.cs
@@ -211,6 +211,19 @@ public class NativeObjectHandleAnalyzerTests : BaseGeneratorWithAnalyzerTestClas
 					void Method(Class foo) { _ = foo.DangerousRetain().DangerousAutorelease().Handle; }
 				}
 				"""];
+			
+			// Equals implementation
+			yield return [
+				"""
+				using ObjCRuntime;
+
+				class Test : INativeObject
+				{
+					NativeHandle Handle { get; }
+					bool Equals(Test other) { return this.Handle == other.Handle; }
+				}
+				"""];
+			
 
 			// TODO: Test ThrowOnNull, GetConstant
 		}

--- a/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/NativeObjectHandleAnalyzerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/NativeObjectHandleAnalyzerTests.cs
@@ -211,7 +211,7 @@ public class NativeObjectHandleAnalyzerTests : BaseGeneratorWithAnalyzerTestClas
 					void Method(Class foo) { _ = foo.DangerousRetain().DangerousAutorelease().Handle; }
 				}
 				"""];
-			
+
 			// Equals implementation
 			yield return [
 				"""
@@ -223,7 +223,7 @@ public class NativeObjectHandleAnalyzerTests : BaseGeneratorWithAnalyzerTestClas
 					bool Equals(Test other) { return this.Handle == other.Handle; }
 				}
 				"""];
-			
+
 
 			// TODO: Test ThrowOnNull, GetConstant
 		}


### PR DESCRIPTION
Update the analyzer to ignore the following cases:
- `a.Handle ==/!= b.Handle` equality comparisons
- `Class`/`Selector` is considered non-collectible

Address feedback