### PR TITLE
[Rgen] Move the DelegateInfo struct as part of the type info.

### DIFF
--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/DataModel/Parameter.Analyzer.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/DataModel/Parameter.Analyzer.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Macios.Generator.Attributes;
+
+namespace Microsoft.Macios.Generator.DataModel;
+
+readonly partial struct Parameter {
+	
+	/// <summary>
+	/// Returns the bind from data if present in the binding.
+	/// </summary>
+	public BindFromData? BindAs { get; init; }
+	
+}

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/DataModel/Parameter.Analyzer.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/DataModel/Parameter.Analyzer.cs
@@ -6,10 +6,10 @@ using Microsoft.Macios.Generator.Attributes;
 namespace Microsoft.Macios.Generator.DataModel;
 
 readonly partial struct Parameter {
-	
+
 	/// <summary>
 	/// Returns the bind from data if present in the binding.
 	/// </summary>
 	public BindFromData? BindAs { get; init; }
-	
+
 }

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Microsoft.Macios.Bindings.Analyzer.csproj
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Microsoft.Macios.Bindings.Analyzer.csproj
@@ -66,8 +66,30 @@
         <Compile Include="../Microsoft.Macios.Generator/Attributes/UnsupportedOSPlatformData.cs" >
             <Link>Generator/Attributes/UnsupportedOSPlatformData.cs</Link>
         </Compile>
+        <Compile Include="../Microsoft.Macios.Generator/DataModel/AttributeCodeChange.cs" >
+            <Link>DataModel/AttributeCodeChange.cs</Link>
+        </Compile>
+        <Compile Include="../Microsoft.Macios.Generator/DataModel/AttributesEqualityComparer.cs" >
+            <Link>DataModel/AttributesEqualityComparer.cs</Link>
+        </Compile>
+        
         <Compile Include="../Microsoft.Macios.Generator/DataModel/TypeInfo.cs" >
             <Link>DataModel/TypeInfo.cs</Link>
+        </Compile>
+        <Compile Include="../Microsoft.Macios.Generator/DataModel/DelegateInfo.cs" >
+            <Link>DataModel/DelegateInfo.cs</Link>
+        </Compile>
+        <Compile Include="../Microsoft.Macios.Generator/DataModel/DelegateParameter.cs" >
+            <Link>DataModel/DelegateParameter.cs</Link>
+        </Compile>
+        <Compile Include="../Microsoft.Macios.Generator/DataModel/Parameter.cs" >
+            <Link>DataModel/Parameter.cs</Link>
+        </Compile>
+        <Compile Include="../Microsoft.Macios.Generator/DataModel/ParameterEqualityComparer.cs" >
+            <Link>DataModel/ParameterEqualityComparer.cs</Link>
+        </Compile>
+        <Compile Include="../Microsoft.Macios.Generator/DataModel/ReferenceKind.cs" >
+            <Link>DataModel/ReferenceKind.cs</Link>
         </Compile>
         <Compile Include="../Microsoft.Macios.Generator/Extensions/ApplePlatformExtensions.cs" >
             <Link>Generator/Extensions/ApplePlatformExtensions.cs</Link>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Binding.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Binding.Generator.cs
@@ -81,7 +81,7 @@ readonly partial struct Binding {
 				if (method.ReturnType.IsDelegate)
 					yield return method.ReturnType;
 				foreach (var parameter in method.Parameters) {
-					if (parameter.IsDelegate)
+					if (parameter.Type.IsDelegate)
 						yield return parameter.Type;
 				}
 			}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.Generator.cs
@@ -44,12 +44,6 @@ readonly partial struct Parameter {
 	public static bool TryCreate (IParameterSymbol symbol, ParameterSyntax declaration, RootContext context,
 		[NotNullWhen (true)] out Parameter? parameter)
 	{
-		DelegateInfo? delegateInfo = null;
-		if (symbol.Type is INamedTypeSymbol namedTypeSymbol
-			&& namedTypeSymbol.DelegateInvokeMethod is not null) {
-			DelegateInfo.TryCreate (namedTypeSymbol.DelegateInvokeMethod, out delegateInfo);
-		}
-
 		parameter = new (symbol.Ordinal, new (symbol.Type, context.Compilation), symbol.Name) {
 			BindAs = symbol.GetBindFromData (),
 			IsOptional = symbol.IsOptional,
@@ -57,7 +51,6 @@ readonly partial struct Parameter {
 			IsThis = symbol.IsThis,
 			DefaultValue = (symbol.HasExplicitDefaultValue) ? symbol.ExplicitDefaultValue?.ToString () : null,
 			ReferenceKind = symbol.RefKind.ToReferenceKind (),
-			Delegate = delegateInfo,
 			Attributes = declaration.GetAttributeCodeChanges (context.SemanticModel),
 		};
 		return true;

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.cs
@@ -57,17 +57,6 @@ readonly partial struct Parameter : IEquatable<Parameter> {
 	public ReferenceKind ReferenceKind { get; init; }
 
 	/// <summary>
-	/// If the parameter is a delegate. The method information of the invoke.
-	/// </summary>
-	public DelegateInfo? Delegate { get; init; } = null;
-
-	/// <summary>
-	/// True if the parameter is a delegate.
-	/// </summary>
-	//[MemberNotNullWhen (true, nameof (DelegateMethod))]
-	public bool IsDelegate => Delegate is not null;
-
-	/// <summary>
 	/// List of attributes attached to the parameter.
 	/// </summary>
 	public ImmutableArray<AttributeCodeChange> Attributes { get; init; } = [];
@@ -100,7 +89,7 @@ readonly partial struct Parameter : IEquatable<Parameter> {
 			return false;
 		if (BindAs != other.BindAs)
 			return false;
-		if (Delegate != other.Delegate)
+		if (Type.Delegate != other.Type.Delegate)
 			return false;
 
 		var attributeComparer = new AttributesEqualityComparer ();
@@ -125,7 +114,7 @@ readonly partial struct Parameter : IEquatable<Parameter> {
 		hashCode.Add (IsThis);
 		hashCode.Add (DefaultValue);
 		hashCode.Add ((int) ReferenceKind);
-		hashCode.Add (Delegate);
+		hashCode.Add (Type.Delegate);
 		hashCode.Add (BindAs);
 		return hashCode.ToHashCode ();
 	}
@@ -155,7 +144,7 @@ readonly partial struct Parameter : IEquatable<Parameter> {
 		sb.Append ($"DefaultValue: {DefaultValue}, ");
 		sb.Append ($"ReferenceKind: {ReferenceKind}, ");
 		sb.Append ($"BindAs: {BindAs?.ToString () ?? "null"}, ");
-		sb.Append ($"Delegate: {Delegate?.ToString () ?? "null"} }}");
+		sb.Append ($"Delegate: {Type.Delegate?.ToString () ?? "null"} }}");
 		return sb.ToString ();
 	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -152,7 +152,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// </summary>
 	[MemberNotNullWhen (true, nameof (Delegate))]
 	public bool IsDelegate { get; init; }
-	
+
 	/// <summary>
 	/// If the parameter is a delegate. The method information of the invoke.
 	/// </summary>
@@ -247,10 +247,10 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 				.. namedTypeSymbol.TypeArguments
 					.Select (x => x.ToDisplayString ())
 			];
-			
-		if (namedTypeSymbol.DelegateInvokeMethod is not null &&
-			DelegateInfo.TryCreate (namedTypeSymbol.DelegateInvokeMethod, out var delegateInfo))
-			Delegate = delegateInfo;
+
+			if (namedTypeSymbol.DelegateInvokeMethod is not null &&
+				DelegateInfo.TryCreate (namedTypeSymbol.DelegateInvokeMethod, out var delegateInfo))
+				Delegate = delegateInfo;
 		}
 
 		if (!IsReferenceType && IsNullable && namedTypeSymbol is not null) {

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -150,7 +150,13 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// <summary>
 	/// True if the type represents a delegate.
 	/// </summary>
+	[MemberNotNullWhen (true, nameof (Delegate))]
 	public bool IsDelegate { get; init; }
+	
+	/// <summary>
+	/// If the parameter is a delegate. The method information of the invoke.
+	/// </summary>
+	public DelegateInfo? Delegate { get; init; } = null;
 
 	/// <summary>
 	/// True if the symbol represents a generic type.
@@ -241,6 +247,10 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 				.. namedTypeSymbol.TypeArguments
 					.Select (x => x.ToDisplayString ())
 			];
+			
+		if (namedTypeSymbol.DelegateInvokeMethod is not null &&
+			DelegateInfo.TryCreate (namedTypeSymbol.DelegateInvokeMethod, out var delegateInfo))
+			Delegate = delegateInfo;
 		}
 
 		if (!IsReferenceType && IsNullable && namedTypeSymbol is not null) {

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Parameter.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Parameter.Transformer.cs
@@ -19,12 +19,6 @@ readonly partial struct Parameter {
 	public static bool TryCreate (IParameterSymbol symbol, ParameterSyntax declaration, SemanticModel semanticModel,
 		[NotNullWhen (true)] out Parameter? parameter)
 	{
-		DelegateInfo? delegateInfo = null;
-		if (symbol.Type is INamedTypeSymbol namedTypeSymbol
-			&& namedTypeSymbol.DelegateInvokeMethod is not null) {
-			DelegateInfo.TryCreate (namedTypeSymbol.DelegateInvokeMethod, out delegateInfo);
-		}
-
 		// retrieve the parameter attributes because those might affect the parameter type, for example, the 
 		// NullAllowed attribute can change the parameter type to be nullable.
 		var parameterAttrs = symbol.GetAttributeData ();
@@ -34,7 +28,6 @@ readonly partial struct Parameter {
 			IsThis = symbol.IsThis,
 			DefaultValue = (symbol.HasExplicitDefaultValue) ? symbol.ExplicitDefaultValue?.ToString () : null,
 			ReferenceKind = symbol.RefKind.ToReferenceKind (),
-			Delegate = delegateInfo,
 			Attributes = declaration.GetAttributeCodeChanges (semanticModel),
 			AttributesDictionary = parameterAttrs,
 		};

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/DelegateInfoTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/DelegateInfoTests.cs
@@ -43,16 +43,16 @@ namespace NS {
 					parameters: [
 						new (
 							position: 0,
-							type: ReturnTypeForAction (),
+							type: ReturnTypeForAction (
+								delegateInfo: new (
+									type: "System.Action",
+									name: "Invoke",
+									returnType: "void",
+									parameters: []
+								)
+							),
 							name: "cb"
-						) {
-							Delegate = new (
-								type: "System.Action",
-								name: "Invoke",
-								returnType: "void",
-								parameters: []
-							)
-						}
+						)
 					]
 				)
 			];
@@ -82,22 +82,23 @@ namespace NS {
 					parameters: [
 						new (
 							position: 0,
-							type: ReturnTypeForAction ("string"),
+							type: ReturnTypeForAction (
+								delegateInfo: new (
+									type: "System.Action<string>",
+									name: "Invoke",
+									returnType: "void",
+									parameters: [
+										new (
+											position: 0,
+											type: "string",
+											name: "obj",
+											isBlittable: false
+										),
+									]
+								),
+								"string"),
 							name: "cb"
-						) {
-							Delegate = new (
-								type: "System.Action<string>",
-								name: "Invoke",
-								returnType: "void",
-								parameters: [
-									new (
-										position: 0,
-										type: "string",
-										name: "obj",
-										isBlittable: false
-									),
-								])
-						}
+						)
 					]
 				)
 			];
@@ -127,24 +128,25 @@ namespace NS {
 					parameters: [
 						new (
 							position: 0,
-							type: ReturnTypeForAction ("string?"),
+							type: ReturnTypeForAction (
+								delegateInfo: new (
+									type: "System.Action<string?>",
+									name: "Invoke",
+									returnType: "void",
+									parameters: [
+										new (
+											position: 0,
+											type: "string",
+											name: "obj",
+											isBlittable: false
+										) {
+											IsNullable = true
+										},
+									]
+								),
+								"string?"),
 							name: "cb"
-						) {
-							Delegate = new (
-								type: "System.Action<string?>",
-								name: "Invoke",
-								returnType: "void",
-								parameters: [
-									new (
-										position: 0,
-										type: "string",
-										name: "obj",
-										isBlittable: false
-									) {
-										IsNullable = true
-									},
-								])
-						}
+						)
 					]
 				)
 			];
@@ -174,28 +176,29 @@ namespace NS {
 					parameters: [
 						new (
 							position: 0,
-							type: ReturnTypeForAction ("string", "string"),
+							type: ReturnTypeForAction (
+								delegateInfo: new (
+									type: "System.Action<string, string>",
+									name: "Invoke",
+									returnType: "void",
+									parameters: [
+										new (
+											position: 0,
+											type: "string",
+											name: "arg1",
+											isBlittable: false
+										),
+										new (
+											position: 1,
+											type: "string",
+											name: "arg2",
+											isBlittable: false
+										),
+									]
+								),
+								"string", "string"),
 							name: "cb"
-						) {
-							Delegate = new (
-								type: "System.Action<string, string>",
-								name: "Invoke",
-								returnType: "void",
-								parameters: [
-									new (
-										position: 0,
-										type: "string",
-										name: "arg1",
-										isBlittable: false
-									),
-									new (
-										position: 1,
-										type: "string",
-										name: "arg2",
-										isBlittable: false
-									),
-								])
-						}
+						)
 					]
 				)
 			];
@@ -225,21 +228,23 @@ namespace NS {
 					parameters: [
 						new (
 							position: 0,
-							type: ReturnTypeForFunc ("string", "string"),
+							type: ReturnTypeForFunc (
+								delegateInfo: new (
+									type: "System.Func<string, string>",
+									name: "Invoke",
+									returnType: "string",
+									parameters: [
+										new (
+											position: 0,
+											type: "string",
+											name: "arg",
+											isBlittable: false
+										),
+									]
+								),
+								"string", "string"),
 							name: "cb"
 						) {
-							Delegate = new (
-								type: "System.Func<string, string>",
-								name: "Invoke",
-								returnType: "string",
-								parameters: [
-									new (
-										position: 0,
-										type: "string",
-										name: "arg",
-										isBlittable: false
-									),
-								])
 						}
 					]
 				)
@@ -270,28 +275,29 @@ namespace NS {
 					parameters: [
 						new (
 							position: 0,
-							type: ReturnTypeForFunc ("string", "string", "string"),
+							type: ReturnTypeForFunc (
+								delegateInfo: new (
+									type: "System.Func<string, string, string>",
+									name: "Invoke",
+									returnType: "string",
+									parameters: [
+										new (
+											position: 0,
+											type: "string",
+											name: "arg1",
+											isBlittable: false
+										),
+										new (
+											position: 1,
+											type: "string",
+											name: "arg2",
+											isBlittable: false
+										),
+									]
+								),
+								"string", "string", "string"),
 							name: "cb"
-						) {
-							Delegate = new (
-								type: "System.Func<string, string, string>",
-								name: "Invoke",
-								returnType: "string",
-								parameters: [
-									new (
-										position: 0,
-										type: "string",
-										name: "arg1",
-										isBlittable: false
-									),
-									new (
-										position: 1,
-										type: "string",
-										name: "arg2",
-										isBlittable: false
-									),
-								])
-						}
+						)
 					]
 				)
 			];
@@ -323,38 +329,41 @@ namespace NS {
 					parameters: [
 						new (
 							position: 0,
-							type: ReturnTypeForDelegate ("NS.MyClass.Callback"),
+							type: ReturnTypeForDelegate (
+								"NS.MyClass.Callback",
+								delegateInfo: new (
+									type: "NS.MyClass.Callback",
+									name: "Invoke",
+									returnType: "int?",
+									parameters: [
+										new (
+											position: 0,
+											type: "string",
+											name: "name",
+											isBlittable: false
+										),
+										new (
+											position: 1,
+											type: "string",
+											name: "middleName",
+											isBlittable: false
+										) {
+											IsNullable = true
+										},
+										new (
+											position: 2,
+											type: "string",
+											name: "surname",
+											isBlittable: false
+										) {
+											IsParams = true,
+											IsArray = true,
+										},
+									]
+								)
+							),
 							name: "cb"
 						) {
-							Delegate = new (
-								type: "NS.MyClass.Callback",
-								name: "Invoke",
-								returnType: "int?",
-								parameters: [
-									new (
-										position: 0,
-										type: "string",
-										name: "name",
-										isBlittable: false
-									),
-									new (
-										position: 1,
-										type: "string",
-										name: "middleName",
-										isBlittable: false
-									) {
-										IsNullable = true
-									},
-									new (
-										position: 2,
-										type: "string",
-										name: "surname",
-										isBlittable: false
-									) {
-										IsParams = true,
-										IsArray = true,
-									},
-								])
 						}
 					]
 				)

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
@@ -3,6 +3,7 @@
 
 #pragma warning disable APL0003
 using Microsoft.CodeAnalysis;
+using Microsoft.Macios.Generator.DataModel;
 using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
 
 namespace Microsoft.Macios.Generator.Tests;
@@ -505,7 +506,7 @@ static class TestDataFactory {
 			]
 		};
 
-	public static TypeInfo ReturnTypeForAction ()
+	public static TypeInfo ReturnTypeForAction (DelegateInfo? delegateInfo = null)
 		=> new (
 			name: "System.Action",
 			isNullable: false,
@@ -513,6 +514,8 @@ static class TestDataFactory {
 			isArray: false,
 			isReferenceType: true
 		) {
+			IsDelegate = true,
+			Delegate = delegateInfo,
 			Parents = [
 				"System.MulticastDelegate",
 				"System.Delegate",
@@ -524,7 +527,7 @@ static class TestDataFactory {
 			]
 		};
 
-	public static TypeInfo ReturnTypeForAction (params string [] parameters)
+	public static TypeInfo ReturnTypeForAction (DelegateInfo? delegateInfo = null, params string [] parameters)
 		=> new (
 			name: $"System.Action<{string.Join (", ", parameters)}>",
 			isNullable: false,
@@ -532,6 +535,8 @@ static class TestDataFactory {
 			isArray: false,
 			isReferenceType: true
 		) {
+			IsDelegate = true,
+			Delegate = delegateInfo,
 			Parents = [
 				"System.MulticastDelegate",
 				"System.Delegate",
@@ -543,7 +548,7 @@ static class TestDataFactory {
 			]
 		};
 
-	public static TypeInfo ReturnTypeForFunc (params string [] parameters)
+	public static TypeInfo ReturnTypeForFunc (DelegateInfo? delegateInfo = null, params string [] parameters)
 		=> new (
 			name: $"System.Func<{string.Join (", ", parameters)}>",
 			isNullable: false,
@@ -551,6 +556,8 @@ static class TestDataFactory {
 			isArray: false,
 			isReferenceType: true
 		) {
+			IsDelegate = true,
+			Delegate = delegateInfo,
 			Parents = [
 				"System.MulticastDelegate",
 				"System.Delegate",
@@ -562,7 +569,7 @@ static class TestDataFactory {
 			]
 		};
 
-	public static TypeInfo ReturnTypeForDelegate (string delegateName)
+	public static TypeInfo ReturnTypeForDelegate (string delegateName, DelegateInfo? delegateInfo = null)
 		=> new (
 			name: delegateName,
 			isNullable: false,
@@ -570,6 +577,8 @@ static class TestDataFactory {
 			isArray: false,
 			isReferenceType: true
 		) {
+			IsDelegate = true,
+			Delegate = delegateInfo,
 			Parents = [
 				"System.MulticastDelegate",
 				"System.Delegate",


### PR DESCRIPTION
This is done to accommodate the fact that we want to be able to generate the trampoline code from a TypeInfo because it's the most general struct that is both used for parameters and return types.

This later will allow use to have factory methods similar to the ones we have that target the trampoline code generation.