### PR TITLE
Fix the DotNetInstallScriptBackupUrl to point to new location

### DIFF
--- a/tests/dotnet/Windows/InstallDotNet.csproj
+++ b/tests/dotnet/Windows/InstallDotNet.csproj
@@ -62,7 +62,7 @@
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
     <DotNetInstallScriptUrl>https://dot.net/v1/dotnet-install.ps1</DotNetInstallScriptUrl>
     <!-- the main url often doesn't work, so have a backup url (the main url redirects to this one, and main url has a cache timeout of 1 year, so it should be fairly safe) -->
-    <DotNetInstallScriptBackupUrl>https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1</DotNetInstallScriptBackupUrl>
+    <DotNetInstallScriptBackupUrl>https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.ps1</DotNetInstallScriptBackupUrl>
     <DotNetInstallScriptName>dotnet-install.ps1</DotNetInstallScriptName>
     <DotNetInstallScriptPath>$(DotNetOutputPath)$(DotNetInstallScriptName)</DotNetInstallScriptPath>
     <DotNetInstallCommand>&amp; '$(DotNetInstallScriptPath)' -Version $(MicrosoftDotnetSdkInternalPackageVersion) -InstallDir '$(DotNetDirectory)' -Verbose</DotNetInstallCommand>
@@ -72,7 +72,7 @@
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('osx'))">
     <DotNetInstallScriptUrl>https://dot.net/v1/dotnet-install.sh</DotNetInstallScriptUrl>
     <!-- the main url often doesn't work, so have a backup url (the main url redirects to this one, and main url has a cache timeout of 1 year, so it should be fairly safe) -->
-    <DotNetInstallScriptBackupUrl>https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh</DotNetInstallScriptBackupUrl>
+    <DotNetInstallScriptBackupUrl>https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.sh</DotNetInstallScriptBackupUrl>
     <DotNetInstallScriptName>dotnet-install.sh</DotNetInstallScriptName>
     <DotNetInstallScriptPath>$(DotNetOutputPath)$(DotNetInstallScriptName)</DotNetInstallScriptPath>
     <DotNetInstallCommand>bash '$(DotNetInstallScriptPath)' --version $(MicrosoftDotnetSdkInternalPackageVersion) --install-dir '$(DotNetDirectory)' --verbose</DotNetInstallCommand>


### PR DESCRIPTION
With the CDN changes the old location wasn't correct anymore.

Fixes https://github.com/dotnet/macios/issues/21418 (the other items there were already done)