### PR TITLE
[Rgen] Generalize NSArray.FromNSObject to later use it for other code generation.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -562,17 +562,10 @@ static partial class BindingSyntaxFactory {
 			.WithExpressionBody (constructor.WithLeadingTrivia (Space));
 
 		// generate: NSArray.FromNSObjects (o => new NSNumber (o), shape);
-		var factoryInvocation = InvocationExpression (MemberAccessExpression (
-			SyntaxKind.SimpleMemberAccessExpression,
-			IdentifierName ("NSArray"),
-			IdentifierName ("FromNSObjects").WithTrailingTrivia (Space))).WithArgumentList (
-			ArgumentList (
-				SeparatedList<ArgumentSyntax> (
-					new SyntaxNodeOrToken [] {
-						Argument (lambdaExpression),
-						Token (SyntaxKind.CommaToken),
-						Argument (IdentifierName (parameter.Name).WithLeadingTrivia (Space))
-					})));
+		var factoryInvocation = NSArrayFromNSObjects ([
+			Argument (lambdaExpression), 
+			Argument (IdentifierName (parameter.Name))
+		]); 
 
 		var declarator =
 			VariableDeclarator (Identifier (variableName).WithLeadingTrivia (Space).WithTrailingTrivia (Space))

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -563,9 +563,9 @@ static partial class BindingSyntaxFactory {
 
 		// generate: NSArray.FromNSObjects (o => new NSNumber (o), shape);
 		var factoryInvocation = NSArrayFromNSObjects ([
-			Argument (lambdaExpression), 
+			Argument (lambdaExpression),
 			Argument (IdentifierName (parameter.Name))
-		]); 
+		]);
 
 		var declarator =
 			VariableDeclarator (Identifier (variableName).WithLeadingTrivia (Space).WithTrailingTrivia (Space))

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -348,6 +348,23 @@ static partial class BindingSyntaxFactory {
 	}
 
 	/// <summary>
+	/// Factory method that returns the expression for the NSArray.FromNSObjects invocation.
+	/// </summary>
+	/// <param name="arguments">The arguments to be used with the invocation.</param>
+	/// <returns>The NSArray.FromNSObjects invocation.</returns>
+	internal static InvocationExpressionSyntax NSArrayFromNSObjects (ImmutableArray<ArgumentSyntax> arguments)
+	{
+		var argumentList = ArgumentList (
+			SeparatedList<ArgumentSyntax> (arguments.ToSyntaxNodeOrTokenArray ()));
+
+		return InvocationExpression (MemberAccessExpression (
+			SyntaxKind.SimpleMemberAccessExpression,
+			IdentifierName ("NSArray"),
+			IdentifierName ("FromNSObjects").WithTrailingTrivia (Space)))
+			.WithArgumentList (argumentList);
+	}
+
+	/// <summary>
 	/// Returns the enum extension method needed to get the value of the enum from a NativeHandle.
 	/// </summary>
 	/// <param name="enumType">The type info of the enum type.</param>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -407,7 +407,7 @@ public class BindingSyntaxFactoryRuntimeTests {
 		var str = declaration.ToString ();
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
 	}
-	
+
 	class TestDataNSArrayFromNSObjects : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -407,5 +407,34 @@ public class BindingSyntaxFactoryRuntimeTests {
 		var str = declaration.ToString ();
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
 	}
+	
+	class TestDataNSArrayFromNSObjects : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			yield return [
+				ImmutableArray.Create (
+					Argument (IdentifierName ("arg1"))),
+				"NSArray.FromNSObjects (arg1)"
+			];
+
+			yield return [
+				ImmutableArray.Create (
+					Argument (IdentifierName ("arg1")),
+					Argument (IdentifierName ("arg2")),
+					Argument (IdentifierName ("arg3"))),
+				"NSArray.FromNSObjects (arg1, arg2, arg3)"
+			];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[ClassData (typeof (TestDataNSArrayFromNSObjects))]
+	void NSArrayFromNSObjectsTests (ImmutableArray<ArgumentSyntax> arguments, string expectedDeclaration)
+	{
+		var declaration = NSArrayFromNSObjects (arguments);
+		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
+	}
 
 }


### PR DESCRIPTION
The NSArray.FromNSObject is used in several parts of the code generation, for example trampolines will use it too. We generalize the call so that we can easily do function composition to generate the code.