### PR TITLE
[Bgen] Use GetHandle in the trampoline NSArray code.

### DIFF
--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -587,7 +587,7 @@ public partial class Generator : IMemberGatherer {
 
 		if (mi.ReturnType.IsArray && TypeManager.IsWrappedType (mi.ReturnType.GetElementType ())) {
 			returntype = NativeHandleType;
-			returnformat = "return NSArray.FromNSObjects({0}).Handle;";
+			returnformat = "return NSArray.FromNSObjects({0}).GetHandle ();";
 		} else if (TypeManager.IsWrappedType (mi.ReturnType)) {
 			returntype = Generator.NativeHandleType;
 			returnformat = "return {0}.GetHandle ();";


### PR DESCRIPTION
We used to generate:

```csharp
return NSArray.FromNSObjects(retval).Handle;
```

We now generate:

```csharp
return NSArray.FromNSObjects(retval).GetHandle ();
```