### PR TITLE
[Rgen] Extract the CFString.CreateNative expression to be reused.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -250,14 +250,9 @@ static partial class BindingSyntaxFactory {
 			return null;
 
 		// generates: CFString.CreateNative ({parameter.Name});
-		var cfstringFactoryInvocation = InvocationExpression (
-				MemberAccessExpression (
-					SyntaxKind.SimpleMemberAccessExpression,
-					IdentifierName ("CFString"),
-					IdentifierName ("CreateNative").WithTrailingTrivia (Space))
-			)
-			.WithArgumentList (ArgumentList (SingletonSeparatedList (
-				Argument (IdentifierName (parameter.Name)))));
+		var cfstringFactoryInvocation = StringCreateNative ([
+			Argument (IdentifierName (parameter.Name)),
+		]);
 
 		// generates {var} = CFString.CreateNative ({parameter.Name});
 		var declarator =

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -174,13 +174,13 @@ static partial class BindingSyntaxFactory {
 					IdentifierName ("FromHandle").WithTrailingTrivia (Space)))
 			.WithArgumentList (argumentList);
 	}
-	
+
 	/// <summary>
 	/// Generates the expression to call the CFString.CreateNative method.
 	/// </summary>
 	/// <param name="arguments">The argument list for the invocation.</param>
 	/// <returns>The expression to call the CFString.CreateNative method with the provided args.</returns>
-	internal static InvocationExpressionSyntax StringCreateNative (ImmutableArray<ArgumentSyntax> arguments) 
+	internal static InvocationExpressionSyntax StringCreateNative (ImmutableArray<ArgumentSyntax> arguments)
 	{
 		var argumentList = ArgumentList (
 			SeparatedList<ArgumentSyntax> (arguments.ToSyntaxNodeOrTokenArray ()));

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -174,6 +174,23 @@ static partial class BindingSyntaxFactory {
 					IdentifierName ("FromHandle").WithTrailingTrivia (Space)))
 			.WithArgumentList (argumentList);
 	}
+	
+	/// <summary>
+	/// Generates the expression to call the CFString.CreateNative method.
+	/// </summary>
+	/// <param name="arguments">The argument list for the invocation.</param>
+	/// <returns>The expression to call the CFString.CreateNative method with the provided args.</returns>
+	internal static InvocationExpressionSyntax StringCreateNative (ImmutableArray<ArgumentSyntax> arguments) 
+	{
+		var argumentList = ArgumentList (
+			SeparatedList<ArgumentSyntax> (arguments.ToSyntaxNodeOrTokenArray ()));
+		return InvocationExpression (
+				MemberAccessExpression (
+					SyntaxKind.SimpleMemberAccessExpression,
+					IdentifierName ("CFString"),
+					IdentifierName ("CreateNative").WithTrailingTrivia (Space))
+			).WithArgumentList (argumentList);
+	}
 
 	/// <summary>
 	/// Returns the method group needed to get a NSValue from a handle.


### PR DESCRIPTION
The expression is needed to write the trampolines, extract it from the current methods that use it to be reused.

No need for tests since we already have test that exercise the method.