### PR TITLE
[Rgen] Add ternary IntPtr.Zero check expression factory.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -390,4 +390,36 @@ static partial class BindingSyntaxFactory {
 	internal static InvocationExpressionSyntax SmartEnumGetValue (in TypeInfo enumType,
 		ImmutableArray<ArgumentSyntax> arguments)
 		=> SmartEnumGetValue (enumType, arguments, enumType.IsNullable);
+
+	/// <summary>
+	/// Generate a ternary expression that checks if the variable is IntPtr.Zero and returns null or the expression
+	/// </summary>
+	/// <param name="variableName">The variable to check against IntPtr.Zero.</param>
+	/// <param name="expressionSyntax">The expression to use on false.</param>
+	/// <param name="suppressNullableWarning">If we should suppress the nullable warning if the true case.</param>
+	/// <returns>The ternary expression.</returns>
+	internal static ExpressionSyntax IntPtrZeroCheck (string variableName, ExpressionSyntax expressionSyntax,
+		bool suppressNullableWarning = false)
+	{
+		// generate: null or null! depending if we want to suppress the nullable warning
+		ExpressionSyntax nullExpression = suppressNullableWarning
+			? PostfixUnaryExpression (
+				SyntaxKind.SuppressNullableWarningExpression,
+				LiteralExpression (
+					SyntaxKind.NullLiteralExpression))
+			: LiteralExpression (
+				SyntaxKind.NullLiteralExpression);
+		
+		// generate: (variableName == IntPtr.Zero) ? null : expressionSyntax
+		return ConditionalExpression (
+			BinaryExpression (
+				SyntaxKind.EqualsExpression,
+				IdentifierName (variableName).WithTrailingTrivia (Space),
+				MemberAccessExpression (
+					SyntaxKind.SimpleMemberAccessExpression,
+					IdentifierName ("IntPtr").WithLeadingTrivia (Space),
+					IdentifierName ("Zero").WithTrailingTrivia (Space))),
+			nullExpression.WithLeadingTrivia (Space).WithTrailingTrivia (Space), 
+			expressionSyntax.WithLeadingTrivia (Space));
+	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -409,7 +409,7 @@ static partial class BindingSyntaxFactory {
 					SyntaxKind.NullLiteralExpression))
 			: LiteralExpression (
 				SyntaxKind.NullLiteralExpression);
-		
+
 		// generate: (variableName == IntPtr.Zero) ? null : expressionSyntax
 		return ConditionalExpression (
 			BinaryExpression (
@@ -419,7 +419,7 @@ static partial class BindingSyntaxFactory {
 					SyntaxKind.SimpleMemberAccessExpression,
 					IdentifierName ("IntPtr").WithLeadingTrivia (Space),
 					IdentifierName ("Zero").WithTrailingTrivia (Space))),
-			nullExpression.WithLeadingTrivia (Space).WithTrailingTrivia (Space), 
+			nullExpression.WithLeadingTrivia (Space).WithTrailingTrivia (Space),
 			expressionSyntax.WithLeadingTrivia (Space));
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -407,5 +407,41 @@ public class BindingSyntaxFactoryRuntimeTests {
 		var str = declaration.ToString ();
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
 	}
+	
+	class TestDataIntPtrZeroCheck : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			yield return [
+				"enumPtr",
+				SmartEnumGetValue (
+					ReturnTypeForEnum ("AVFoundation.AVCaptureSystemPressureLevel", isSmartEnum: true),
+					[Argument (IdentifierName ("enumPtr"))]
+					),
+				false,	
+				"enumPtr == IntPtr.Zero ? null : global::AVFoundation.AVCaptureSystemPressureLevelExtensions.GetValue (enumPtr)"
+			];
+			
+			yield return [
+				"enumPtr",
+				SmartEnumGetValue (
+					ReturnTypeForEnum ("AVFoundation.AVCaptureSystemPressureLevel", isSmartEnum: true),
+					[Argument (IdentifierName ("enumPtr"))]
+					),
+				true,	
+				"enumPtr == IntPtr.Zero ? null! : global::AVFoundation.AVCaptureSystemPressureLevelExtensions.GetValue (enumPtr)"
+			];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[ClassData (typeof (TestDataIntPtrZeroCheck))]
+	void IntPtrZeroCheckTests (string variableName, ExpressionSyntax falseExpression, bool suppressNullableWarning, string expectedDeclaration)
+	{
+		var declaration = IntPtrZeroCheck (variableName, falseExpression, suppressNullableWarning);
+		var str = declaration.ToString ();
+		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
+	}
 
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -407,7 +407,7 @@ public class BindingSyntaxFactoryRuntimeTests {
 		var str = declaration.ToString ();
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
 	}
-	
+
 	class TestDataIntPtrZeroCheck : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -417,17 +417,17 @@ public class BindingSyntaxFactoryRuntimeTests {
 					ReturnTypeForEnum ("AVFoundation.AVCaptureSystemPressureLevel", isSmartEnum: true),
 					[Argument (IdentifierName ("enumPtr"))]
 					),
-				false,	
+				false,
 				"enumPtr == IntPtr.Zero ? null : global::AVFoundation.AVCaptureSystemPressureLevelExtensions.GetValue (enumPtr)"
 			];
-			
+
 			yield return [
 				"enumPtr",
 				SmartEnumGetValue (
 					ReturnTypeForEnum ("AVFoundation.AVCaptureSystemPressureLevel", isSmartEnum: true),
 					[Argument (IdentifierName ("enumPtr"))]
 					),
-				true,	
+				true,
 				"enumPtr == IntPtr.Zero ? null! : global::AVFoundation.AVCaptureSystemPressureLevelExtensions.GetValue (enumPtr)"
 			];
 		}


### PR DESCRIPTION
Allows to create the expression:

```csharp
x == IntPtr.Zero ? null : expr;
```
The above expression is very common when generating bindings that are nullable.