### PR TITLE
[RGen] Generate code for the return type of a trampoline delegate.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/AttributesNames.cs
+++ b/src/rgen/Microsoft.Macios.Generator/AttributesNames.cs
@@ -24,7 +24,7 @@ static class AttributesNames {
 	public const string SupportedOSPlatformAttribute = "System.Runtime.Versioning.SupportedOSPlatformAttribute";
 	public const string UnsupportedOSPlatformAttribute = "System.Runtime.Versioning.UnsupportedOSPlatformAttribute";
 	public const string ObsoletedOSPlatformAttribute = "System.Runtime.Versioning.ObsoletedOSPlatformAttribute";
-	public const string NativeEnumAttribute = "ObjCRuntime.NativeAttribute";
+	public const string NativeAttribute = "ObjCRuntime.NativeAttribute";
 
 	public static readonly string [] BindingTypes = [
 		BindingCategoryAttribute,

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
@@ -20,7 +20,6 @@ readonly partial struct TypeInfo {
 
 	internal TypeInfo (ITypeSymbol symbol, Compilation compilation) : this (symbol)
 	{
-		IsNativeEnum = symbol.HasAttribute (AttributesNames.NativeEnumAttribute);
 		NeedsStret = symbol.NeedsStret (compilation);
 	}
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -238,6 +238,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		IsInterface = symbol.TypeKind == TypeKind.Interface;
 		IsDelegate = symbol.TypeKind == TypeKind.Delegate;
 		IsNativeIntegerType = symbol.IsNativeIntegerType;
+		IsNativeEnum = symbol.HasAttribute (AttributesNames.NativeAttribute);
 
 		// data that we can get from the symbol without being INamedType
 		symbol.GetInheritance (
@@ -380,9 +381,9 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 			// IsNativeEnum: Depends on the enum backing field kind.
 			// GeneralEnum: Depends on the EnumUnderlyingType
 
-			{ IsSmartEnum: true } => NativeHandle, 
 			{ IsNativeEnum: true, EnumUnderlyingType: SpecialType.System_Int64 } => IntPtr, 
 			{ IsNativeEnum: true, EnumUnderlyingType: SpecialType.System_UInt64 } => UIntPtr, 
+			{ IsSmartEnum: true } => NativeHandle, 
 			{ IsEnum: true, EnumUnderlyingType: not null } => EnumUnderlyingType.GetKeyword (),
 
 			// special type that is a keyword (none would be a ref type)

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -206,7 +206,7 @@ static partial class BindingSyntaxFactory {
 					IdentifierName ("CreateNative").WithTrailingTrivia (Space))
 			).WithArgumentList (argumentList);
 	}
-	
+
 	/// <summary>
 	/// Generates the expression to call the CFString.CreateNative method.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -65,7 +65,7 @@ static partial class BindingSyntaxFactory {
 	/// </summary>
 	/// <param name="selector">The selector whose handle we want to retrieve.</param>
 	/// <returns>The expression to retrieve a selector handle.</returns>
-	public static InvocationExpressionSyntax GetHandle (string selector)
+	public static InvocationExpressionSyntax SelectorGetHandle (string selector)
 	{
 		// (selector)
 		var args = ArgumentList (SingletonSeparatedList (
@@ -115,7 +115,7 @@ static partial class BindingSyntaxFactory {
 		// the first two arguments are the selector and the handle, we add those by hand
 		args [0] = Argument (ThisHandle ());
 		args [1] = Token (SyntaxKind.CommaToken).WithTrailingTrivia (Space);
-		args [2] = Argument (GetHandle (selector));
+		args [2] = Argument (SelectorGetHandle (selector));
 
 		// we need to add the commas and the arguments provided by the user of the api
 		if (parameters.Length > 0) {
@@ -203,6 +203,23 @@ static partial class BindingSyntaxFactory {
 				MemberAccessExpression (
 					SyntaxKind.SimpleMemberAccessExpression,
 					IdentifierName ("CFString"),
+					IdentifierName ("CreateNative").WithTrailingTrivia (Space))
+			).WithArgumentList (argumentList);
+	}
+	
+	/// <summary>
+	/// Generates the expression to call the CFString.CreateNative method.
+	/// </summary>
+	/// <param name="arguments">The argument list for the invocation.</param>
+	/// <returns>The expression to call the CFString.CreateNative method with the provided args.</returns>
+	internal static InvocationExpressionSyntax NStringCreateNative (ImmutableArray<ArgumentSyntax> arguments)
+	{
+		var argumentList = ArgumentList (
+			SeparatedList<ArgumentSyntax> (arguments.ToSyntaxNodeOrTokenArray ()));
+		return InvocationExpression (
+				MemberAccessExpression (
+					SyntaxKind.SimpleMemberAccessExpression,
+					IdentifierName ("NFString"),
 					IdentifierName ("CreateNative").WithTrailingTrivia (Space))
 			).WithArgumentList (argumentList);
 	}

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
+
+namespace Microsoft.Macios.Generator.Emitters;
+
+static partial class BindingSyntaxFactory {
+	/// <summary>
+	/// Returns the statement with the return type of the invoke method for the given type info delegate.
+	/// </summary>
+	/// <param name="typeInfo"></param>
+	/// <param name="auxVariableName"></param>
+	/// <returns></returns>
+	internal static ExpressionSyntax? GetTrampolineInvokeReturnType (TypeInfo typeInfo, string auxVariableName)
+	{
+		// ignore those types that are not delegates or that are a delegate with a void return type
+		if (!typeInfo.IsDelegate || typeInfo.Delegate.ReturnType.IsVoid)
+			return null;
+
+#pragma warning disable format
+		// based on the return type of the delegate we build a statement that will return the expected value
+		return typeInfo.Delegate.ReturnType switch {
+
+			//  NSArray.FromNSObjects(auxVariable).GetHandle ()
+			{ IsArray: true, ArrayElementTypeIsWrapped: true }
+				=> GetHandle (NSArrayFromNSObjects ([Argument (IdentifierName (auxVariableName))])),
+
+			// auxVariable.GetHandle ()
+			{ IsArray: false, IsWrapped: true }
+				=> GetHandle (IdentifierName(auxVariableName)),
+			
+			//  NSString.CreateNative (auxVariable, true);
+			{ SpecialType: SpecialType.System_String }
+				=> NStringCreateNative ([Argument (IdentifierName(auxVariableName)), BoolArgument (true)]),
+			
+			// (UIntPtr) (ulong) myParam 
+			{ IsNativeEnum: true }
+				=> CastToNative (auxVariableName, typeInfo.Delegate.ReturnType),
+			
+			// auxVariable.GetHandle ()
+			{ IsINativeObject: true }
+				=> GetHandle (IdentifierName (auxVariableName)),
+			
+			// auxVariable ? (byte) 1 : (byte) 0; 
+			{ SpecialType: SpecialType.System_Boolean } 
+				=> CastToByte (auxVariableName, typeInfo.Delegate.ReturnType),
+			
+			_ => null
+
+		};
+#pragma warning restore format
+	}
+}

--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/XamarinAvailabilityData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/XamarinAvailabilityData.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
+using Microsoft.Macios.Generator;
 using Microsoft.Macios.Generator.Attributes;
 using Xamarin.Utils;
 

--- a/src/rgen/Microsoft.Macios.Transformer/AttributesNames.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/AttributesNames.cs
@@ -5,7 +5,8 @@
 using Microsoft.Macios.Transformer.Attributes;
 using Microsoft.Macios.Transformer.Generator;
 
-namespace Microsoft.Macios.Transformer;
+// Use the same namemspace as the generator, that way we can share the code but use different attribute names
+namespace Microsoft.Macios.Generator;
 
 static class AttributesNames {
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -21,9 +21,9 @@ public class BindingSyntaxFactoryRuntimeTests {
 	[InlineData ("Test", "Selector.GetHandle (\"Test\")")]
 	[InlineData ("name", "Selector.GetHandle (\"name\")")]
 	[InlineData ("setName:", "Selector.GetHandle (\"setName:\")")]
-	void GetHandleTest (string selector, string expectedDeclaration)
+	void SelectorGetHandleTests (string selector, string expectedDeclaration)
 	{
-		var declaration = GetHandle (selector);
+		var declaration = SelectorGetHandle (selector);
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -14,7 +14,7 @@ using static Microsoft.Macios.Generator.Emitters.BindingSyntaxFactory;
 namespace Microsoft.Macios.Generator.Tests.Emitters;
 
 public class BindingSyntaxFactoryTrampolineTests : BaseGeneratorTestClass {
-	
+
 	class TestDataGetTrampolineInvokeReturnType : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -53,7 +53,7 @@ namespace NS {
 				nsObjectResult,
 				"auxVariable.GetHandle ()"
 			];
-			
+
 			const string systemStringResult = @"
 using System;
 
@@ -104,7 +104,7 @@ namespace NS {
 				boolReturnType,
 				"auxVariable ? (byte) 1 : (byte) 0"
 			];
-			
+
 			const string nativeEnum = @"
 using System;
 using ObjCBindings;
@@ -130,7 +130,7 @@ namespace NS {
 				nativeEnum,
 				"(IntPtr) (long) auxVariable",
 			];
-			
+
 			const string unsignedNativeEnum = @"
 using System;
 using ObjCBindings;
@@ -176,7 +176,7 @@ namespace NS {
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
-	
+
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataGetTrampolineInvokeReturnType>]
 	void GetTrampolineInvokeReturnTypeTests (ApplePlatform platform, string inputText, string? expectedExpression)

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -1,0 +1,200 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.DataModel;
+using Xamarin.Tests;
+using Xamarin.Utils;
+using Xunit;
+using static Microsoft.Macios.Generator.Emitters.BindingSyntaxFactory;
+
+namespace Microsoft.Macios.Generator.Tests.Emitters;
+
+public class BindingSyntaxFactoryTrampolineTests : BaseGeneratorTestClass {
+	
+	class TestDataGetTrampolineInvokeReturnType : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			const string arrayNSObjectResult = @"
+using System;
+using Foundation;
+
+namespace NS {
+
+	public delegate NSString [] Callback ();
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				arrayNSObjectResult,
+				"NSArray.FromNSObjects (auxVariable).GetHandle ()"
+			];
+
+			const string nsObjectResult = @"
+using System;
+using Foundation;
+
+namespace NS {
+
+	public delegate NSString Callback ();
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				nsObjectResult,
+				"auxVariable.GetHandle ()"
+			];
+			
+			const string systemStringResult = @"
+using System;
+
+namespace NS {
+
+	public delegate string Callback ();
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				systemStringResult,
+				"NFString.CreateNative (auxVariable, true)"
+			];
+
+			const string nullableSystemStringResult = @"
+using System;
+
+namespace NS {
+
+	public delegate string? Callback ();
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				nullableSystemStringResult,
+				"NFString.CreateNative (auxVariable, true)"
+			];
+
+			const string boolReturnType = @"
+using System;
+
+namespace NS {
+
+	public delegate bool Callback ();
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				boolReturnType,
+				"auxVariable ? (byte) 1 : (byte) 0"
+			];
+			
+			const string nativeEnum = @"
+using System;
+using ObjCBindings;
+using ObjCRuntime;
+
+namespace NS {
+
+	[Native (""GKErrorCode"")]
+	[BindingType<SmartEnum> (Flags = SmartEnum.ErrorCode, ErrorDomain = ""GKErrorDomain"")]
+	public enum NativeSampleEnum : long {
+		None = 0,
+		Unknown = 1,
+	}
+
+	public delegate NativeSampleEnum Callback()
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				nativeEnum,
+				"(IntPtr) (long) auxVariable",
+			];
+			
+			const string unsignedNativeEnum = @"
+using System;
+using ObjCBindings;
+using ObjCRuntime;
+
+namespace NS {
+
+	[Native (""GKErrorCode"")]
+	[BindingType<SmartEnum> (Flags = SmartEnum.ErrorCode, ErrorDomain = ""GKErrorDomain"")]
+	public enum NativeSampleEnum : ulong {
+		None = 0,
+		Unknown = 1,
+	}
+
+	public delegate NativeSampleEnum Callback()
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				unsignedNativeEnum,
+				"(UIntPtr) (ulong) auxVariable",
+			];
+
+			const string intReturnType = @"
+using System;
+
+namespace NS {
+	public delegate int Callback()
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				intReturnType,
+				null!
+			];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataGetTrampolineInvokeReturnType>]
+	void GetTrampolineInvokeReturnTypeTests (ApplePlatform platform, string inputText, string? expectedExpression)
+	{
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
+		Assert.Single (syntaxTrees);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ().OfType<MethodDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		Assert.True (Method.TryCreate (declaration, semanticModel, out var changes));
+		Assert.NotNull (changes);
+		// we know the first parameter of the method is the delegate
+		Assert.Single (changes.Value.Parameters);
+		var parameter = changes.Value.Parameters [0];
+		var auxVariableName = "auxVariable";
+		var expression = GetTrampolineInvokeReturnType (parameter.Type, auxVariableName);
+		Assert.Equal (expectedExpression, expression?.ToString ());
+	}
+}

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/AsyncDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/AsyncDataTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator;
 using Microsoft.Macios.Transformer.Attributes;
 using Xamarin.Tests;
 using Xamarin.Utils;

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/BackingFieldTypeDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/BackingFieldTypeDataTests.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator;
 using Microsoft.Macios.Generator.Extensions;
 using Microsoft.Macios.Transformer.Attributes;
 using Xamarin.Tests;

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/BaseTypeDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/BaseTypeDataTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator;
 using Microsoft.Macios.Transformer.Attributes;
 using Xamarin.Tests;
 using Xamarin.Utils;

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/BindAsDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/BindAsDataTests.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator;
 using Microsoft.Macios.Generator.Extensions;
 using Microsoft.Macios.Transformer.Attributes;
 using Xamarin.Tests;

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/BindDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/BindDataTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator;
 using Microsoft.Macios.Transformer.Attributes;
 using Xamarin.Tests;
 using Xamarin.Utils;

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/CoreImageFilterDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/CoreImageFilterDataTests.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator;
 using Microsoft.Macios.Generator.Extensions;
 using Microsoft.Macios.Transformer.Attributes;
 using Xamarin.Tests;

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/CoreImageFilterPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/CoreImageFilterPropertyTests.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator;
 using Microsoft.Macios.Generator.Extensions;
 using Microsoft.Macios.Transformer.Attributes;
 using Xamarin.Tests;

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/ErrorDomainDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/ErrorDomainDataTests.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator;
 using Microsoft.Macios.Generator.Extensions;
 using Microsoft.Macios.Transformer.Attributes;
 using Xamarin.Tests;

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/ExportDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/ExportDataTests.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator;
 using Microsoft.Macios.Generator.Extensions;
 using Microsoft.Macios.Transformer.Attributes;
 using ObjCRuntime;

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/FieldDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/FieldDataTests.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator;
 using Microsoft.Macios.Generator.Extensions;
 using Microsoft.Macios.Transformer.Attributes;
 using Xamarin.Tests;

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/NativeDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/NativeDataTests.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator;
 using Microsoft.Macios.Generator.Extensions;
 using Microsoft.Macios.Transformer.Attributes;
 using Xamarin.Tests;

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/NotificationDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/NotificationDataTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator;
 using Microsoft.Macios.Transformer.Attributes;
 using Xamarin.Tests;
 using Xamarin.Utils;

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/SnippetDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/SnippetDataTests.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator;
 using Microsoft.Macios.Generator.Extensions;
 using Microsoft.Macios.Transformer.Attributes;
 using Xamarin.Tests;

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/StrongDictionaryDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/StrongDictionaryDataTests.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator;
 using Microsoft.Macios.Generator.Extensions;
 using Microsoft.Macios.Transformer.Attributes;
 using Xamarin.Tests;

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/ThreadSafeDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/ThreadSafeDataTests.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator;
 using Microsoft.Macios.Generator.Extensions;
 using Microsoft.Macios.Transformer.Attributes;
 using Xamarin.Tests;


### PR DESCRIPTION
Based on the return type of a delegate we need to generate code to convert the native return type of the trampoline to that used by the managed delegate.

This new function takes the type info of the return type of the delegate and the name of the aux variable and generates the correct conversion.