### PR TITLE
[Rgen] Move most of the naming logic to the Nomenclator.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.Generator.cs
@@ -11,7 +11,7 @@ using Microsoft.Macios.Generator.Extensions;
 namespace Microsoft.Macios.Generator.DataModel;
 
 readonly partial struct Parameter {
-	
+
 	/// <summary>
 	/// Returns the bind from data if present in the binding.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.Generator.cs
@@ -11,18 +11,7 @@ using Microsoft.Macios.Generator.Extensions;
 namespace Microsoft.Macios.Generator.DataModel;
 
 readonly partial struct Parameter {
-
-	public enum VariableType {
-		BlockLiteral,
-		Handle,
-		NSArray,
-		NSString,
-		NSStringStruct,
-		PrimitivePointer,
-		StringPointer,
-		BindFrom,
-	}
-
+	
 	/// <summary>
 	/// Returns the bind from data if present in the binding.
 	/// </summary>
@@ -54,27 +43,5 @@ readonly partial struct Parameter {
 			Attributes = declaration.GetAttributeCodeChanges (context.SemanticModel),
 		};
 		return true;
-	}
-
-	/// <summary>
-	/// Returns the name of the aux variable that would have needed for the given parameter. Use the
-	/// variable type to name it.
-	/// </summary>
-	/// <param name="variableType">The type of aux variable.</param>
-	/// <returns>The name of the aux variable to use.</returns>
-	public string? GetNameForVariableType (VariableType variableType)
-	{
-		var cleanedName = Name.Replace ("@", "");
-		return variableType switch {
-			VariableType.BlockLiteral => $"block_ptr_{cleanedName}",
-			VariableType.Handle => $"{cleanedName}__handle__",
-			VariableType.NSArray => $"nsa_{cleanedName}",
-			VariableType.NSString => $"ns{cleanedName}",
-			VariableType.NSStringStruct => $"_s{cleanedName}",
-			VariableType.PrimitivePointer => $"converted_{cleanedName}",
-			VariableType.StringPointer => $"_p{cleanedName}",
-			VariableType.BindFrom => $"nsb_{cleanedName}",
-			_ => null
-		};
 	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
@@ -12,7 +12,7 @@ readonly partial struct TypeInfo {
 	/// True if the type needs to use a stret call.
 	/// </summary>
 	public bool NeedsStret { get; init; }
-	
+
 	internal TypeInfo (ITypeSymbol symbol, Compilation compilation) : this (symbol)
 	{
 		IsNativeEnum = symbol.HasAttribute (AttributesNames.NativeEnumAttribute);

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
@@ -12,12 +12,7 @@ readonly partial struct TypeInfo {
 	/// True if the type needs to use a stret call.
 	/// </summary>
 	public bool NeedsStret { get; init; }
-
-	/// <summary>
-	/// Get the name of the variable for the type when it is used as a return value.
-	/// </summary>
-	public string ReturnVariableName => "ret"; // nothing fancy for now
-
+	
 	internal TypeInfo (ITypeSymbol symbol, Compilation compilation) : this (symbol)
 	{
 		IsNativeEnum = symbol.HasAttribute (AttributesNames.NativeEnumAttribute);

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -189,7 +189,7 @@ static partial class BindingSyntaxFactory {
 		if (!parameter.Type.IsNSObject && !parameter.Type.IsINativeObject)
 			return null;
 
-		var variableName = Nomenclator.GetNameForVariableType(parameter.Name, Nomenclator.VariableType.Handle);
+		var variableName = Nomenclator.GetNameForVariableType (parameter.Name, Nomenclator.VariableType.Handle);
 		if (variableName is null)
 			return null;
 		// decide about the factory based on the need of a null check 

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -145,7 +145,7 @@ static partial class BindingSyntaxFactory {
 					Argument (IdentifierName (parameter.Name)))));
 
 		// variable name
-		var variableName = parameter.GetNameForVariableType (Parameter.VariableType.NSArray);
+		var variableName = Nomenclator.GetNameForVariableType (parameter.Name, Nomenclator.VariableType.NSArray);
 		if (variableName is null)
 			return null;
 		var declarator = VariableDeclarator (Identifier (variableName));
@@ -189,7 +189,7 @@ static partial class BindingSyntaxFactory {
 		if (!parameter.Type.IsNSObject && !parameter.Type.IsINativeObject)
 			return null;
 
-		var variableName = parameter.GetNameForVariableType (Parameter.VariableType.Handle);
+		var variableName = Nomenclator.GetNameForVariableType(parameter.Name, Nomenclator.VariableType.Handle);
 		if (variableName is null)
 			return null;
 		// decide about the factory based on the need of a null check 
@@ -245,7 +245,7 @@ static partial class BindingSyntaxFactory {
 		if (parameter.Type.Name != "string")
 			return null;
 
-		var variableName = parameter.GetNameForVariableType (Parameter.VariableType.NSString);
+		var variableName = Nomenclator.GetNameForVariableType (parameter.Name, Nomenclator.VariableType.NSString);
 		if (variableName is null)
 			return null;
 
@@ -325,7 +325,7 @@ static partial class BindingSyntaxFactory {
 		if (factoryMethod is null)
 			return null;
 
-		var variableName = parameter.GetNameForVariableType (Parameter.VariableType.BindFrom);
+		var variableName = Nomenclator.GetNameForVariableType (parameter.Name, Nomenclator.VariableType.BindFrom);
 		if (variableName is null)
 			return null;
 
@@ -414,7 +414,7 @@ static partial class BindingSyntaxFactory {
 		if (factoryMethod is null)
 			return null;
 
-		var variableName = parameter.GetNameForVariableType (Parameter.VariableType.BindFrom);
+		var variableName = Nomenclator.GetNameForVariableType (parameter.Name, Nomenclator.VariableType.BindFrom);
 		if (variableName is null)
 			return null;
 
@@ -444,7 +444,7 @@ static partial class BindingSyntaxFactory {
 		if (!parameter.Type.IsSmartEnum)
 			return null;
 
-		var variableName = parameter.GetNameForVariableType (Parameter.VariableType.BindFrom);
+		var variableName = Nomenclator.GetNameForVariableType (parameter.Name, Nomenclator.VariableType.BindFrom);
 		if (variableName is null)
 			return null;
 
@@ -475,7 +475,7 @@ static partial class BindingSyntaxFactory {
 		if (!parameter.Type.IsArray)
 			return null;
 
-		var variableName = parameter.GetNameForVariableType (Parameter.VariableType.BindFrom);
+		var variableName = Nomenclator.GetNameForVariableType (parameter.Name, Nomenclator.VariableType.BindFrom);
 		if (variableName is null)
 			return null;
 
@@ -673,7 +673,7 @@ static partial class BindingSyntaxFactory {
 	internal static (string Name, LocalDeclarationStatementSyntax Declaration) GetReturnValueAuxVariable (in TypeInfo returnType)
 	{
 		var typeSyntax = returnType.GetIdentifierSyntax ();
-		var variableName = returnType.ReturnVariableName;
+		var variableName = Nomenclator.GetReturnVariableName (returnType);
 		// generates Type ret; The GetIdentifierSyntax will ensure that the correct type and nullable annotation is used
 		var declaration = LocalDeclarationStatement (
 			VariableDeclaration (typeSyntax.WithTrailingTrivia (Space))

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Property.cs
@@ -67,8 +67,8 @@ static partial class BindingSyntaxFactory {
 		if (property.UseTempReturn) {
 			// get the getter invocation and assign it to the return variable 
 			return (
-				Send: ExpressionStatement (AssignVariable (property.ReturnType.ReturnVariableName, getterSend)),
-				SendSuper: ExpressionStatement (AssignVariable (property.ReturnType.ReturnVariableName, getterSuperSend))
+				Send: ExpressionStatement (AssignVariable (Nomenclator.GetReturnVariableName (property.ReturnType), getterSend)),
+				SendSuper: ExpressionStatement (AssignVariable (Nomenclator.GetReturnVariableName (property.ReturnType), getterSuperSend))
 			);
 		}
 		// this is the simplest case, we just need to call the method and return the result, for that we

--- a/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Macios.Generator;
 /// In this case, the Nomenclator is used to generate the names of the bindings.
 /// </summary>
 class Nomenclator {
-	
+
 	public enum VariableType {
 		BlockLiteral,
 		Handle,
@@ -97,7 +97,7 @@ class Nomenclator {
 			_ => null
 		};
 	}
-	
+
 	/// <summary>
 	/// Get the name of the variable for the type when it is used as a return value.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
@@ -13,6 +13,17 @@ namespace Microsoft.Macios.Generator;
 /// In this case, the Nomenclator is used to generate the names of the bindings.
 /// </summary>
 class Nomenclator {
+	
+	public enum VariableType {
+		BlockLiteral,
+		Handle,
+		NSArray,
+		NSString,
+		NSStringStruct,
+		PrimitivePointer,
+		StringPointer,
+		BindFrom,
+	}
 
 	// keep track of the generic versions of a trampoline, we will use the fully qualified name
 	// of the type to keep track of the generic versions.
@@ -63,4 +74,33 @@ class Nomenclator {
 
 		return trampolineName;
 	}
+
+	/// <summary>
+	/// Returns the name of the aux variable that would have needed for the given parameter. Use the
+	/// variable type to name it.
+	/// </summary>
+	/// <param name="nameHint">Hint of the name for the variable.</param>
+	/// <param name="variableType">The type of aux variable.</param>
+	/// <returns>The name of the aux variable to use.</returns>
+	public static string? GetNameForVariableType (string nameHint, VariableType variableType)
+	{
+		var cleanedName = nameHint.Replace ("@", "");
+		return variableType switch {
+			VariableType.BlockLiteral => $"block_ptr_{cleanedName}",
+			VariableType.Handle => $"{cleanedName}__handle__",
+			VariableType.NSArray => $"nsa_{cleanedName}",
+			VariableType.NSString => $"ns{cleanedName}",
+			VariableType.NSStringStruct => $"_s{cleanedName}",
+			VariableType.PrimitivePointer => $"converted_{cleanedName}",
+			VariableType.StringPointer => $"_p{cleanedName}",
+			VariableType.BindFrom => $"nsb_{cleanedName}",
+			_ => null
+		};
+	}
+	
+	/// <summary>
+	/// Get the name of the variable for the type when it is used as a return value.
+	/// </summary>
+	/// <param name="typeInfo">The type info whose name we want for the return type.</param>
+	public static string GetReturnVariableName (in TypeInfo typeInfo) => "ret"; // nothing fancy for now
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ParameterTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ParameterTests.cs
@@ -10,28 +10,7 @@ using static Microsoft.Macios.Generator.Tests.TestDataFactory;
 namespace Microsoft.Macios.Generator.Tests.DataModel;
 
 public class ParameterTests {
-
-	class TestDataGetVariableName : IEnumerable<object []> {
-		public IEnumerator<object []> GetEnumerator ()
-		{
-			var exampleParameter = new Parameter (0, ReturnTypeForBool (), "firstParameter");
-			yield return [exampleParameter, Parameter.VariableType.Handle, $"{exampleParameter.Name}__handle__"];
-			yield return [exampleParameter, Parameter.VariableType.BlockLiteral, $"block_ptr_{exampleParameter.Name}"];
-			yield return [exampleParameter, Parameter.VariableType.PrimitivePointer, $"converted_{exampleParameter.Name}"];
-			yield return [exampleParameter, Parameter.VariableType.NSArray, $"nsa_{exampleParameter.Name}"];
-			yield return [exampleParameter, Parameter.VariableType.NSString, $"ns{exampleParameter.Name}"];
-			yield return [exampleParameter, Parameter.VariableType.NSStringStruct, $"_s{exampleParameter.Name}"];
-			yield return [exampleParameter, Parameter.VariableType.BindFrom, $"nsb_{exampleParameter.Name}"];
-		}
-
-		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
-	}
-
-	[Theory]
-	[ClassData (typeof (TestDataGetVariableName))]
-	void GetNameForVariableTypeTests (Parameter parameter, Parameter.VariableType variableType, string expectedName)
-		=> Assert.Equal (expectedName, parameter.GetNameForVariableType (variableType));
-
+	
 	class TestDataNeedsNullCheckTests : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ParameterTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ParameterTests.cs
@@ -10,7 +10,7 @@ using static Microsoft.Macios.Generator.Tests.TestDataFactory;
 namespace Microsoft.Macios.Generator.Tests.DataModel;
 
 public class ParameterTests {
-	
+
 	class TestDataNeedsNullCheckTests : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/NomenclatorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/NomenclatorTests.cs
@@ -65,7 +65,7 @@ public class Example {
 		Assert.Equal ("GenericTrampolineArity1V1", name2);
 		Assert.NotEqual (name1, name2);
 	}
-	
+
 	class TestDataGetVariableName : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/NomenclatorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/NomenclatorTests.cs
@@ -1,12 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.DataModel;
 using Xamarin.Tests;
 using Xamarin.Utils;
 using Xunit;
+using static Microsoft.Macios.Generator.Tests.TestDataFactory;
 
 namespace Microsoft.Macios.Generator.Tests;
 
@@ -62,5 +65,26 @@ public class Example {
 		Assert.Equal ("GenericTrampolineArity1V1", name2);
 		Assert.NotEqual (name1, name2);
 	}
+	
+	class TestDataGetVariableName : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			var exampleParameter = new Parameter (0, ReturnTypeForBool (), "firstParameter");
+			yield return [exampleParameter, Nomenclator.VariableType.Handle, $"{exampleParameter.Name}__handle__"];
+			yield return [exampleParameter, Nomenclator.VariableType.BlockLiteral, $"block_ptr_{exampleParameter.Name}"];
+			yield return [exampleParameter, Nomenclator.VariableType.PrimitivePointer, $"converted_{exampleParameter.Name}"];
+			yield return [exampleParameter, Nomenclator.VariableType.NSArray, $"nsa_{exampleParameter.Name}"];
+			yield return [exampleParameter, Nomenclator.VariableType.NSString, $"ns{exampleParameter.Name}"];
+			yield return [exampleParameter, Nomenclator.VariableType.NSStringStruct, $"_s{exampleParameter.Name}"];
+			yield return [exampleParameter, Nomenclator.VariableType.BindFrom, $"nsb_{exampleParameter.Name}"];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[ClassData (typeof (TestDataGetVariableName))]
+	void GetNameForVariableTypeTests (Parameter parameter, Nomenclator.VariableType variableType, string expectedName)
+		=> Assert.Equal (expectedName, Nomenclator.GetNameForVariableType (parameter.Name, variableType));
 }
 


### PR DESCRIPTION
This way we have all the naming in a single location and it is easier to make sure that we do name variables in a consistent manner.

This also removes the need of some of the special code for the generator in the data model.