### PR TITLE
[RGen] Add a flag to know if a type represents a Objc protocol.

### DIFF
--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/BindingTypeSemanticAnalyzer.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/BindingTypeSemanticAnalyzer.cs
@@ -263,11 +263,11 @@ public class BindingTypeSemanticAnalyzer : DiagnosticAnalyzer, IBindingTypeAnaly
 	public ImmutableArray<Diagnostic> Analyze (string matchedAttribute, PlatformName _,
 		BaseTypeDeclarationSyntax declarationNode, INamedTypeSymbol symbol)
 		=> matchedAttribute switch {
-			AttributesNames.BindingClassAttribute => ValidateClass (declarationNode, symbol),
-			AttributesNames.BindingCategoryAttribute => ValidateCategory (declarationNode, symbol),
-			AttributesNames.BindingProtocolAttribute => ValidateProtocol (declarationNode, symbol),
-			AttributesNames.BindingSmartEnumAttribute => ValidateSmartEnum (declarationNode, symbol),
-			AttributesNames.BindingStrongDictionaryAttribute => ValidateStrongDictionary (declarationNode, symbol),
+			AttributesNames.ClassAttribute => ValidateClass (declarationNode, symbol),
+			AttributesNames.CategoryAttribute => ValidateCategory (declarationNode, symbol),
+			AttributesNames.ProtocolAttribute => ValidateProtocol (declarationNode, symbol),
+			AttributesNames.SmartEnumAttribute => ValidateSmartEnum (declarationNode, symbol),
+			AttributesNames.StrongDictionaryAttribute => ValidateStrongDictionary (declarationNode, symbol),
 			_ => throw new InvalidOperationException ($"Not recognized attribute {matchedAttribute}.")
 		};
 }

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/SmartEnumsAnalyzer.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/SmartEnumsAnalyzer.cs
@@ -130,7 +130,7 @@ public class SmartEnumsAnalyzer : DiagnosticAnalyzer, IBindingTypeAnalyzer<EnumD
 	void AnalysisContext (SyntaxNodeAnalysisContext context)
 		=> this.AnalyzeBindingType (context);
 
-	static readonly HashSet<string> attributes = [AttributesNames.BindingSmartEnumAttribute];
+	static readonly HashSet<string> attributes = [AttributesNames.SmartEnumAttribute];
 	public IReadOnlySet<string> AttributeNames => attributes;
 
 	public ImmutableArray<Diagnostic> Analyze (string matchedAttribute, PlatformName platformName, EnumDeclarationSyntax declarationNode,

--- a/src/rgen/Microsoft.Macios.Generator/AttributesNames.cs
+++ b/src/rgen/Microsoft.Macios.Generator/AttributesNames.cs
@@ -9,13 +9,13 @@ namespace Microsoft.Macios.Generator;
 /// </summary>
 static class AttributesNames {
 
-	public const string BindingCategoryAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.Category>";
-	public const string BindingClassAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.Class>";
-	public const string BindingCoreImageFilterAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.CoreImageFilter>";
-	public const string BindingSmartEnumAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.SmartEnum>";
+	public const string CategoryAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.Category>";
+	public const string ClassAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.Class>";
+	public const string CoreImageFilterAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.CoreImageFilter>";
+	public const string SmartEnumAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.SmartEnum>";
 	public const string BindFromAttribute = "ObjCBindings.BindFromAttribute";
-	public const string BindingProtocolAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.Protocol>";
-	public const string BindingStrongDictionaryAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.StrongDictionary>";
+	public const string ProtocolAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.Protocol>";
+	public const string StrongDictionaryAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.StrongDictionary>";
 	public const string FieldAttribute = "ObjCBindings.FieldAttribute";
 	public const string EnumFieldAttribute = "ObjCBindings.FieldAttribute<ObjCBindings.EnumValue>";
 	public const string FieldPropertyAttribute = "ObjCBindings.FieldAttribute<ObjCBindings.Property>";
@@ -27,12 +27,12 @@ static class AttributesNames {
 	public const string NativeAttribute = "ObjCRuntime.NativeAttribute";
 
 	public static readonly string [] BindingTypes = [
-		BindingCategoryAttribute,
-		BindingClassAttribute,
-		BindingProtocolAttribute,
-		BindingStrongDictionaryAttribute,
-		BindingCoreImageFilterAttribute,
-		BindingSmartEnumAttribute,
+		CategoryAttribute,
+		ClassAttribute,
+		ProtocolAttribute,
+		StrongDictionaryAttribute,
+		CoreImageFilterAttribute,
+		SmartEnumAttribute,
 	];
 
 
@@ -40,19 +40,19 @@ static class AttributesNames {
 	{
 		var type = typeof (T);
 		if (type == typeof (ObjCBindings.Category)) {
-			return BindingCategoryAttribute;
+			return CategoryAttribute;
 		}
 		if (type == typeof (ObjCBindings.Class)) {
-			return BindingClassAttribute;
+			return ClassAttribute;
 		}
 		if (type == typeof (ObjCBindings.Protocol)) {
-			return BindingProtocolAttribute;
+			return ProtocolAttribute;
 		}
 		if (type == typeof (ObjCBindings.StrongDictionary)) {
-			return BindingStrongDictionaryAttribute;
+			return StrongDictionaryAttribute;
 		}
 		if (type == typeof (ObjCBindings.SmartEnum)) {
-			return BindingSmartEnumAttribute;
+			return SmartEnumAttribute;
 		}
 
 		return null;

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -174,7 +174,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// True if the symbol represents a generic type.
 	/// </summary>
 	public bool IsGenericType { get; init; }
-	
+
 	/// <summary>
 	/// True if the type represents a ObjC protocol.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -174,6 +174,11 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// True if the symbol represents a generic type.
 	/// </summary>
 	public bool IsGenericType { get; init; }
+	
+	/// <summary>
+	/// True if the type represents a ObjC protocol.
+	/// </summary>
+	public bool IsProtocol { get; init; }
 
 	readonly ImmutableArray<string> parents = [];
 	/// <summary>
@@ -239,6 +244,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		IsDelegate = symbol.TypeKind == TypeKind.Delegate;
 		IsNativeIntegerType = symbol.IsNativeIntegerType;
 		IsNativeEnum = symbol.HasAttribute (AttributesNames.NativeAttribute);
+		IsProtocol = symbol.HasAttribute (AttributesNames.ProtocolAttribute);
 
 		// data that we can get from the symbol without being INamedType
 		symbol.GetInheritance (
@@ -318,6 +324,8 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 			return false;
 		if (Delegate != other.Delegate)
 			return false;
+		if (IsProtocol != other.IsProtocol)
+			return false;
 
 		// compare base classes and interfaces, order does not matter at all
 		var listComparer = new CollectionComparer<string> ();
@@ -338,7 +346,32 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// <inheritdoc/>
 	public override int GetHashCode ()
 	{
-		return HashCode.Combine (FullyQualifiedName, IsNullable, IsBlittable, IsSmartEnum, IsArray, IsReferenceType, IsVoid);
+		var hashCode = new HashCode ();
+		hashCode.Add (FullyQualifiedName);
+		hashCode.Add (SpecialType);
+		hashCode.Add (MetadataName);
+		hashCode.Add (IsNullable);
+		hashCode.Add (IsBlittable);
+		hashCode.Add (IsSmartEnum);
+		hashCode.Add (IsArray);
+		hashCode.Add (IsReferenceType);
+		hashCode.Add (IsStruct);
+		hashCode.Add (IsVoid);
+		hashCode.Add (EnumUnderlyingType);
+		hashCode.Add (IsInterface);
+		hashCode.Add (IsNativeIntegerType);
+		hashCode.Add (IsNativeEnum);
+		hashCode.Add (Delegate);
+		hashCode.Add (IsProtocol);
+		foreach (var parent in parents) {
+			hashCode.Add (parent);
+		}
+
+		foreach (var @interface in interfaces) {
+			hashCode.Add (@interface);
+		}
+
+		return hashCode.ToHashCode ();
 	}
 
 	public static bool operator == (TypeInfo left, TypeInfo right)
@@ -415,13 +448,15 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		sb.Append ($"IsArray: {IsArray}, ");
 		sb.Append ($"IsReferenceType: {IsReferenceType}, ");
 		sb.Append ($"IsStruct: {IsStruct}, ");
-		sb.Append ($"IsVoid : {IsVoid}, ");
-		sb.Append ($"IsNSObject : {IsNSObject}, ");
+		sb.Append ($"IsVoid: {IsVoid}, ");
+		sb.Append ($"IsNSObject: {IsNSObject}, ");
 		sb.Append ($"IsDictionaryContainer: {IsDictionaryContainer}, ");
 		sb.Append ($"IsNativeObject: {IsINativeObject}, ");
 		sb.Append ($"IsInterface: {IsInterface}, ");
 		sb.Append ($"IsNativeIntegerType: {IsNativeIntegerType}, ");
 		sb.Append ($"IsNativeEnum: {IsNativeEnum}, ");
+		sb.Append ($"IsProtocol: {IsProtocol}, ");
+		sb.Append ($"Delegate: {Delegate?.ToString () ?? "null"}, ");
 		sb.Append ($"EnumUnderlyingType: '{EnumUnderlyingType?.ToString () ?? "null"}', ");
 		sb.Append ("Parents: [");
 		sb.AppendJoin (", ", parents);

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Generator.cs
@@ -71,7 +71,7 @@ static partial class TypeSymbolExtensions {
 		// a type is a smart enum if its type is a enum one AND it was decorated with the
 		// binding type attribute
 		return symbol.TypeKind == TypeKind.Enum
-			   && symbol.HasAttribute (AttributesNames.BindingSmartEnumAttribute);
+			   && symbol.HasAttribute (AttributesNames.SmartEnumAttribute);
 	}
 
 	/// <summary>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/AttributesNamesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/AttributesNamesTests.cs
@@ -34,10 +34,10 @@ public class AttributesNamesTests {
 	[Theory]
 	[InlineData (StringComparison.Ordinal, null)]
 	[InlineData (EnumValue.Default, null)]
-	[InlineData (Category.Default, AttributesNames.BindingCategoryAttribute)]
-	[InlineData (Class.Default, AttributesNames.BindingClassAttribute)]
-	[InlineData (Protocol.Default, AttributesNames.BindingProtocolAttribute)]
-	[InlineData (StrongDictionary.Default, AttributesNames.BindingStrongDictionaryAttribute)]
+	[InlineData (Category.Default, AttributesNames.CategoryAttribute)]
+	[InlineData (Class.Default, AttributesNames.ClassAttribute)]
+	[InlineData (Protocol.Default, AttributesNames.ProtocolAttribute)]
+	[InlineData (StrongDictionary.Default, AttributesNames.StrongDictionaryAttribute)]
 	public void GetBindingTypeAttributeName<T> (T @enum, string? expectedName) where T : Enum
 	{
 		Assert.NotNull (@enum);

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumDeclarationCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumDeclarationCodeChangesTests.cs
@@ -45,7 +45,7 @@ public enum AVCaptureDeviceType {
 		Assert.Equal ("AVFoundation.AVCaptureDeviceType", codeChanges.FullyQualifiedSymbol);
 		Assert.Equal (BindingType.SmartEnum, codeChanges.BindingType);
 		Assert.Single (codeChanges.Attributes);
-		Assert.Equal (AttributesNames.BindingSmartEnumAttribute, codeChanges.Attributes [0].Name);
+		Assert.Equal (AttributesNames.SmartEnumAttribute, codeChanges.Attributes [0].Name);
 		Assert.Empty (codeChanges.EnumMembers);
 		Assert.Equal (BindingType.SmartEnum, codeChanges.BindingType);
 	}
@@ -80,7 +80,7 @@ public enum AVCaptureDeviceType {
 		Assert.Equal ("AVFoundation.AVCaptureDeviceType", codeChanges.FullyQualifiedSymbol);
 		Assert.Equal (BindingType.SmartEnum, codeChanges.BindingType);
 		Assert.Single (codeChanges.Attributes);
-		Assert.Equal (AttributesNames.BindingSmartEnumAttribute, codeChanges.Attributes [0].Name);
+		Assert.Equal (AttributesNames.SmartEnumAttribute, codeChanges.Attributes [0].Name);
 		Assert.Equal (BindingType.SmartEnum, codeChanges.BindingType);
 		// validate that we have the 3 members and their attrs
 		Assert.Equal (3, codeChanges.EnumMembers.Length);
@@ -123,7 +123,7 @@ public enum AVCaptureDeviceType {
 		Assert.Equal ("AVFoundation.AVCaptureDeviceType", codeChanges.FullyQualifiedSymbol);
 		Assert.Equal (BindingType.SmartEnum, codeChanges.BindingType);
 		Assert.Single (codeChanges.Attributes);
-		Assert.Equal (AttributesNames.BindingSmartEnumAttribute, codeChanges.Attributes [0].Name);
+		Assert.Equal (AttributesNames.SmartEnumAttribute, codeChanges.Attributes [0].Name);
 		Assert.Empty (codeChanges.EnumMembers);
 		Assert.Equal (BindingType.SmartEnum, codeChanges.BindingType);
 	}
@@ -159,7 +159,7 @@ public enum AVCaptureDeviceType {
 		Assert.Equal ("AVFoundation.AVCaptureDeviceType", codeChanges.FullyQualifiedSymbol);
 		Assert.Equal (BindingType.SmartEnum, codeChanges.BindingType);
 		Assert.Single (codeChanges.Attributes);
-		Assert.Equal (AttributesNames.BindingSmartEnumAttribute, codeChanges.Attributes [0].Name);
+		Assert.Equal (AttributesNames.SmartEnumAttribute, codeChanges.Attributes [0].Name);
 		Assert.Equal (BindingType.SmartEnum, codeChanges.BindingType);
 		// validate that we have the 3 members and their attrs
 		Assert.Equal (2, codeChanges.EnumMembers.Length);

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests/FromDeclarationTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests/FromDeclarationTests.cs
@@ -959,6 +959,53 @@ public class TestClass {
 					BindAs = new (ReturnTypeForNSObject ("Foundation.NSNumber")),
 				}
 			];
+			
+			const string protocolProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace Test;
+
+using ObjCBindings;
+
+[BindingType<Protocol>]
+public partial interface ITestProtocol {
+}
+
+public class TestClass {
+
+	[Export<Property>(""name"")]
+	public ITestProtocol Name { get; }
+}
+";
+			yield return [
+				protocolProperty,
+				new Property (
+					name: "Name",
+					returnType: ReturnTypeForInterface ("Test.ITestProtocol", isProtocol: true),
+					symbolAvailability: new (),
+					attributes: [
+						new (name: "ObjCBindings.ExportAttribute<ObjCBindings.Property>", arguments: ["name"]),
+					],
+					modifiers: [
+						SyntaxFactory.Token (kind: SyntaxKind.PublicKeyword),
+					],
+					accessors: [
+						new (
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
+							modifiers: []
+						)
+					]
+				) {
+					NeedsBackingField = true,
+					RequiresDirtyCheck = true,
+					ExportPropertyData = new (selector: "name"),
+				}
+			];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator ()

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests/FromDeclarationTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests/FromDeclarationTests.cs
@@ -959,7 +959,7 @@ public class TestClass {
 					BindAs = new (ReturnTypeForNSObject ("Foundation.NSNumber")),
 				}
 			];
-			
+
 			const string protocolProperty = @"
 using System;
 using Foundation;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
@@ -434,13 +434,17 @@ static class TestDataFactory {
 			isNullable: isNullable
 		);
 
-	public static TypeInfo ReturnTypeForInterface (string interfaceName)
+	public static TypeInfo ReturnTypeForInterface (string interfaceName, bool isNullable = false, bool isProtocol = false)
 		=> new (
 			name: interfaceName,
+			isNullable: isNullable,
+			isArray: false,
 			isReferenceType: true
 		) {
-			Parents = [],
 			IsInterface = true,
+			IsProtocol = isProtocol,
+			Parents = [],
+			Interfaces = []
 		};
 
 	public static TypeInfo ReturnTypeForStruct (string structName, bool isBlittable = false)
@@ -626,7 +630,7 @@ static class TestDataFactory {
 			Parents = ["object"],
 			Interfaces = ["ObjCRuntime.INativeObject"]
 		};
-
+	
 	public static TypeInfo ReturnTypeForNSString (bool isNullable = false)
 		=> new (
 			name: "Foundation.NSString",

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
@@ -630,7 +630,7 @@ static class TestDataFactory {
 			Parents = ["object"],
 			Interfaces = ["ObjCRuntime.INativeObject"]
 		};
-	
+
 	public static TypeInfo ReturnTypeForNSString (bool isNullable = false)
 		=> new (
 			name: "Foundation.NSString",


### PR DESCRIPTION
This will later allow use to make decisions when generating code. To add this new flag we did the following:

* Make the variables that store the attribute names in the Generator and Transformer be the same. This way we make sharing the logic easier.
* Check if the protocol attr is present on a symbol when we retrieve its info.
* Clean the HashCode and ToString methods to reflect the new data.
* Add a new test on the property tests to assert that we indeed get the new flag set correctly.