### PR TITLE
[LockedCameraCapture] Ignore this framework.

### DIFF
--- a/tests/xtro-sharpie/Makefile
+++ b/tests/xtro-sharpie/Makefile
@@ -62,6 +62,7 @@ $(XIOS_PCH): .stamp-check-sharpie
 	-exclude FactoryOTALogger \
 	-exclude FactoryOTANetworkUtils \
 	-exclude AssetsLibrary \
+	-exclude LockedCameraCapture \
 	-exclude Matter \
 	-exclude _CoreNFC_UIKit \
 	-i ThreadNetwork/THClient.h \
@@ -75,6 +76,7 @@ $(XTVOS_PCH): .stamp-check-sharpie
 	$(SHARPIE) sdk-db --xcode $(XCODE) -s appletvos$(TVOS_SDK_VERSION) -a $(XTVOS_ARCH) \
 		-modules false \
 		-exclude BrowserEngineCore \
+		-exclude LockedCameraCapture \
 		-exclude Matter \
 
 XMACOS_ARCH = x86_64
@@ -87,6 +89,7 @@ $(XMACOS_PCH): .stamp-check-sharpie
 		-exclude AccessorySetupKit \
 		-exclude BrowserEngineCore \
 		-exclude JavaNativeFoundation \
+		-exclude LockedCameraCapture \
 		-exclude Matter \
 		-exclude ParavirtualizedGraphics \
 		$(CORETELEPHONY_HEADERS) \
@@ -117,6 +120,7 @@ $(XMACCATALYST_PCH): .stamp-check-sharpie
 	-exclude IOBluetoothUI \
 	-exclude JavaNativeFoundation \
 	-exclude LDAP \
+	-exclude LockedCameraCapture \
 	-exclude Matter \
 	-exclude Python \
 	-exclude Quartz \

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-LockedCameraCapture.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-LockedCameraCapture.todo
@@ -1,3 +1,0 @@
-!missing-field! LockedCameraCaptureVersionNumber not bound
-!missing-field! LockedCameraCaptureVersionString not bound
-!missing-field! NSUserActivityTypeLockedCameraCapture not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-LockedCameraCapture.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-LockedCameraCapture.ignore
@@ -1,4 +1,0 @@
-# This is a Swift-only frameworks, with only version APIs available in Objective-C, so we're not binding it in Objective-C
-!missing-field! LockedCameraCaptureVersionNumber not bound
-!missing-field! LockedCameraCaptureVersionString not bound
-!missing-field! NSUserActivityTypeLockedCameraCapture not bound


### PR DESCRIPTION
At the moment there's nothing useful for us here, seems to be a Swift-only
framework.