### PR TITLE
[rgen] Enable analysis of generated code in the native object handle analyzer.

### DIFF
--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/NativeObjectHandleAnalyzer.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/NativeObjectHandleAnalyzer.cs
@@ -48,7 +48,7 @@ public class NativeObjectHandleAnalyzer : DiagnosticAnalyzer {
 
 	public override void Initialize (AnalysisContext context)
 	{
-		context.ConfigureGeneratedCodeAnalysis (GeneratedCodeAnalysisFlags.None);
+		context.ConfigureGeneratedCodeAnalysis (GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
 		context.EnableConcurrentExecution ();
 		context.RegisterSyntaxNodeAction (AnalyzeNode, SyntaxKind.SimpleMemberAccessExpression);
 	}


### PR DESCRIPTION
This currently reports ~55k errors.