### PR TITLE
[tests] Verify that everything in the ObjCBindings namespace is experimental.

### DIFF
--- a/tests/cecil-tests/PreviewApi.cs
+++ b/tests/cecil-tests/PreviewApi.cs
@@ -18,6 +18,7 @@ namespace Cecil.Tests {
 	public class PreviewApi {
 		[TestCase ("CryptoTokenKit", "APL0001", "10.0")]
 		// [TestCase ("FSKit", "APL0002", "11.0")]
+		[TestCase ("ObjCBindings", "APL0003", "99.0")]
 		public void EverythingInNamespace (string ns, string expectedDiagnosticId, string stableInDotNetVersion)
 		{
 			// Verify that all types in the given namespace have an Experimental attribute.


### PR DESCRIPTION
It's undetermined when it'll be made non-experimental, so tentatively plan for
.NET 99.0.