### PR TITLE
[devops] Don't report the test results from the Windows tests.

### DIFF
--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -390,34 +390,6 @@ steps:
   continueOnError: true
   condition: succeededOrFailed()
 
-# Make sure to report any errors
-- pwsh: |
-    Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\$Env:BUILD_REPOSITORY_TITLE\tools\devops\automation\scripts\MaciosCI.psd1
-    $githubComments = New-GitHubCommentsObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $(GitHub.Token) -Hash $Env:COMMENT_HASH
-
-    if (Test-Path -Path "$Env:GITHUB_FAILURE_COMMENT_FILE" -PathType Leaf)  {
-      $githubComments.NewCommentFromFile("${{ parameters.statusContext }} failed", ":x:", "$Env:GITHUB_FAILURE_COMMENT_FILE", "windows tests")
-    } elseif ("$($Env:AGENT_JOBSTATUS)" -ne "Succeeded") {
-      $message = ":x: $($Env:AGENT_JOBSTATUS) :x:"
-      $githubComments.NewCommentFromMessage("${{ parameters.statusContext }} failed", ":x:", $message, "windows tests")
-    } else {
-      $message = ":white_check_mark: **All** ${{ parameters.statusContext }} passed."
-      $githubComments.NewCommentFromMessage("${{ parameters.statusContext }} passed", ":computer:", $message, "windows tests")
-    }
-  displayName: 'Report results to GitHub'
-  timeoutInMinutes: 5
-  condition: always() # in particular we care if something failed, but let's always run just in case
-  continueOnError: true
-  env:
-    CONTEXT: ${{ parameters.statusContext }}
-    GITHUB_TOKEN: $(GitHub.Token)
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    TEST_BOT: $(Agent.Name)
-    ${{ if eq(parameters.repositoryAlias, 'self') }}:
-      COMMENT_HASH: $(fix_commit.GIT_HASH)
-    ${{ else }}:
-      COMMENT_HASH: $(Build.SourceVersion)
-
 - pwsh: |
     Remove-Item "$(ID_RSA_PATH)"
   displayName: "Remove secrets"


### PR DESCRIPTION
We include them in the aggregate test results for all tests, so there's no
need to report the Windows tests specifically as well.