### PR TITLE
[Bgen] Ensure that GC.KeepAlive is called in extension methods.

### DIFF
--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -2901,9 +2901,9 @@ public partial class Generator : IMemberGatherer {
 
 	void GenerateInvoke (bool stret, bool supercall, MethodInfo mi, MemberInformation minfo, string selector, string args, Type category_type, bool aligned)
 	{
-		var isInsanceMethod = category_type is null && !minfo.is_extension_method &&
+		var isInstanceMethod = category_type is null && !minfo.is_extension_method &&
 								  !minfo.is_protocol_implementation_method;
-		string target_name = isInsanceMethod ? "this" : "This";
+		string target_name = isInstanceMethod ? "this" : "This";
 		string handle = supercall ? ".SuperHandle" : ".Handle";
 
 		// If we have supercall == false, we can be a Bind method that has a [Target]
@@ -2990,7 +2990,7 @@ public partial class Generator : IMemberGatherer {
 				print (postproc.ToString ());
 		}
 
-		if (!isInsanceMethod) {
+		if (!isInstanceMethod) {
 			// if this is a extension of any kind, ensure that we keep alive the this parameter
 			// so that it is not collected before the msg send call has completed.
 			print ("GC.KeepAlive (This);");

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -3570,7 +3570,7 @@ public partial class Generator : IMemberGatherer {
 			}
 		} else if (minfo.is_ctor && minfo.is_protocol_member) {
 			print ("// {0} is protocol {1} ", mi.Name, minfo.is_protocol_member);
-			// special case be cause constructors in protocol memners will be converted to factory methods
+			// special case because constructors in protocol members will be converted to factory methods
 			print ($"T? ret;");
 		}
 
@@ -3688,7 +3688,7 @@ public partial class Generator : IMemberGatherer {
 			// special case since ctrs in protocol members become create methods
 			print ("return ret;");
 		} else if (mi.ReturnType != TypeCache.System_Void && mi.Name != "Constructor") {
-			// general case if we do return and we are not a construc ctor.
+			// general case if we do return and we are not a constructor.
 			print ("return ret;");
 		}
 		if (minfo.is_ctor)

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -2899,9 +2899,11 @@ public partial class Generator : IMemberGatherer {
 		}
 	}
 
-	void GenerateInvoke (bool stret, bool supercall, MethodInfo mi, MemberInformation minfo, string selector, string args, bool assign_to_temp, Type category_type, bool aligned)
+	void GenerateInvoke (bool stret, bool supercall, MethodInfo mi, MemberInformation minfo, string selector, string args, Type category_type, bool aligned)
 	{
-		string target_name = (category_type is null && !minfo.is_extension_method && !minfo.is_protocol_implementation_method) ? "this" : "This";
+		var isInsanceMethod = category_type is null && !minfo.is_extension_method &&
+		                          !minfo.is_protocol_implementation_method; 
+		string target_name = isInsanceMethod ? "this" : "This";
 		string handle = supercall ? ".SuperHandle" : ".Handle";
 
 		// If we have supercall == false, we can be a Bind method that has a [Target]
@@ -2988,7 +2990,7 @@ public partial class Generator : IMemberGatherer {
 				print (postproc.ToString ());
 		}
 
-		if (target_name == "This") {
+		if (!isInsanceMethod) {
 			// if this is a extension of any kind, ensure that we keep alive the this parameter
 			// so that it is not collected before the msg send call has completed.
 			print ("GC.KeepAlive (This);");
@@ -3005,15 +3007,15 @@ public partial class Generator : IMemberGatherer {
 			if (x64_stret) {
 				print ("if (global::ObjCRuntime.Runtime.IsARM64CallingConvention) {");
 				indent++;
-				GenerateInvoke (false, supercall, mi, minfo, selector, args, assign_to_temp, category_type, false);
+				GenerateInvoke (false, supercall, mi, minfo, selector, args, category_type, false);
 				indent--;
 				print ("} else {");
 				indent++;
-				GenerateInvoke (x64_stret, supercall, mi, minfo, selector, args, assign_to_temp, category_type, aligned && x64_stret);
+				GenerateInvoke (x64_stret, supercall, mi, minfo, selector, args, category_type, aligned && x64_stret);
 				indent--;
 				print ("}");
 			} else {
-				GenerateInvoke (false, supercall, mi, minfo, selector, args, assign_to_temp, category_type, false);
+				GenerateInvoke (false, supercall, mi, minfo, selector, args, category_type, false);
 			}
 			return;
 		}
@@ -3028,37 +3030,37 @@ public partial class Generator : IMemberGatherer {
 				// First check for arm64
 				print ("if (global::ObjCRuntime.Runtime.IsARM64CallingConvention) {");
 				indent++;
-				GenerateInvoke (false, supercall, mi, minfo, selector, args, assign_to_temp, category_type, false);
+				GenerateInvoke (false, supercall, mi, minfo, selector, args, category_type, false);
 				indent--;
 				// If we're not arm64, but we're 64-bit, then we're x86_64
 				print ("} else if (IntPtr.Size == 8) {");
 				indent++;
-				GenerateInvoke (x64_stret, supercall, mi, minfo, selector, args, assign_to_temp, category_type, aligned && x64_stret);
+				GenerateInvoke (x64_stret, supercall, mi, minfo, selector, args, category_type, aligned && x64_stret);
 				indent--;
 				// if we're not 64-bit, but we're on device, then we're 32-bit arm
 				print ("} else if (Runtime.Arch == Arch.DEVICE) {");
 				indent++;
-				GenerateInvoke (arm_stret, supercall, mi, minfo, selector, args, assign_to_temp, category_type, aligned && arm_stret);
+				GenerateInvoke (arm_stret, supercall, mi, minfo, selector, args, category_type, aligned && arm_stret);
 				indent--;
 				// if we're none of the above, we're x86
 				print ("} else {");
 				indent++;
-				GenerateInvoke (x86_stret, supercall, mi, minfo, selector, args, assign_to_temp, category_type, aligned && x86_stret);
+				GenerateInvoke (x86_stret, supercall, mi, minfo, selector, args, category_type, aligned && x86_stret);
 				indent--;
 				print ("}");
 			} else {
 				print ("if (IntPtr.Size == 8) {");
 				indent++;
-				GenerateInvoke (x64_stret, supercall, mi, minfo, selector, args, assign_to_temp, category_type, aligned && x64_stret);
+				GenerateInvoke (x64_stret, supercall, mi, minfo, selector, args, category_type, aligned && x64_stret);
 				indent--;
 				print ("} else {");
 				indent++;
-				GenerateInvoke (x86_stret, supercall, mi, minfo, selector, args, assign_to_temp, category_type, aligned && x86_stret);
+				GenerateInvoke (x86_stret, supercall, mi, minfo, selector, args, category_type, aligned && x86_stret);
 				indent--;
 				print ("}");
 			}
 		} else {
-			GenerateInvoke (false, supercall, mi, minfo, selector, args, assign_to_temp, category_type, false);
+			GenerateInvoke (false, supercall, mi, minfo, selector, args, category_type, false);
 		}
 	}
 
@@ -3569,7 +3571,6 @@ public partial class Generator : IMemberGatherer {
 				print ("{0} ret;", TypeManager.FormatType (minfo.type, mi.ReturnType));
 			}
 		} else if (minfo.is_ctor && minfo.is_protocol_member) {
-			print ("// {0} is protocol {1} ", mi.Name, minfo.is_protocol_member);
 			// special case because constructors in protocol members will be converted to factory methods
 			print ($"T? ret;");
 		}

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -2958,7 +2958,7 @@ public partial class Generator : IMemberGatherer {
 			print ($"IntPtr {handleName};");
 			print ($"{handleName} = global::{NamespaceCache.Messaging}.IntPtr_objc_msgSend (Class.GetHandle (typeof (T)), Selector.GetHandle (\"alloc\"));");
 			print ($"{handleName} = {sig} ({handleName}, {selector_field}{args});");
-			print ($"{(assign_to_temp ? "ret = " : "return ")} global::ObjCRuntime.Runtime.GetINativeObject<T> ({handleName}, true);");
+			print ($"ret = global::ObjCRuntime.Runtime.GetINativeObject<T> ({handleName}, true);");
 		} else {
 			bool returns = mi.ReturnType != TypeCache.System_Void && mi.Name != "Constructor";
 			string cast_a = "", cast_b = "";
@@ -2973,19 +2973,25 @@ public partial class Generator : IMemberGatherer {
 
 			if (minfo.is_static)
 				print ("{0}{1}{2} (class_ptr, {5}{6}){7};",
-					   returns ? (assign_to_temp ? "ret = " : "return ") : "",
+					   returns ? "ret = " : "",
 					   cast_a, sig, target_name,
 					   "/*unusued3*/", //supercall ? "Super" : "",
 					   selector_field, args, cast_b);
 			else
 				print ("{0}{1}{2} ({3}{4}, {5}{6}){7};",
-					   returns ? (assign_to_temp ? "ret = " : "return ") : "",
+					   returns ? "ret = " : "",
 					   cast_a, sig, target_name,
 					   handle,
 					   selector_field, args, cast_b);
 
 			if (postproc.Length > 0)
 				print (postproc.ToString ());
+		}
+
+		if (target_name == "This") {
+			// if this is a extension of any kind, ensure that we keep alive the this parameter
+			// so that it is not collected before the msg send call has completed.
+			print ("GC.KeepAlive (This);");
 		}
 	}
 
@@ -3554,6 +3560,18 @@ public partial class Generator : IMemberGatherer {
 				var nullableReturn = isClassType ? "?" : string.Empty;
 				print ("{0}{1} ret;", TypeManager.FormatType (minfo.type, mi.ReturnType), nullableReturn);
 			}
+		} else if (mi.ReturnType != TypeCache.System_Void && mi.Name != "Constructor") {
+			if (minfo.is_bindAs) {
+				var bindAsAttrib = GetBindAsAttribute (minfo.mi);
+				// tricky, e.g. when an nullable `NSNumber[]` is bound as a `float[]`, since FormatType and bindAsAttrib have not clue about the original nullability 
+				print ("{0} ret;", TypeManager.FormatType (bindAsAttrib.Type.DeclaringType, bindAsAttrib.Type));
+			} else {
+				print ("{0} ret;", TypeManager.FormatType (minfo.type, mi.ReturnType));
+			}
+		} else if (minfo.is_ctor && minfo.is_protocol_member) {
+			print ("// {0} is protocol {1} ", mi.Name, minfo.is_protocol_member);
+			// special case be cause constructors in protocol memners will be converted to factory methods
+			print ($"T? ret;");
 		}
 
 		bool needs_temp = use_temp_return || disposes.Length > 0;
@@ -3666,6 +3684,12 @@ public partial class Generator : IMemberGatherer {
 				// we can't be 100% confident that the ObjC API annotations are correct so we always null check inside generated code
 				print ("return ret!;");
 			}
+		} else if (minfo.is_ctor && minfo.is_protocol_member) {
+			// special case since ctrs in protocol members become create methods
+			print ("return ret;");
+		} else if (mi.ReturnType != TypeCache.System_Void && mi.Name != "Constructor") {
+			// general case if we do return and we are not a construc ctor.
+			print ("return ret;");
 		}
 		if (minfo.is_ctor)
 			WriteMarkDirtyIfDerived (sw, mi.DeclaringType);

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -2902,7 +2902,7 @@ public partial class Generator : IMemberGatherer {
 	void GenerateInvoke (bool stret, bool supercall, MethodInfo mi, MemberInformation minfo, string selector, string args, Type category_type, bool aligned)
 	{
 		var isInsanceMethod = category_type is null && !minfo.is_extension_method &&
-		                          !minfo.is_protocol_implementation_method; 
+								  !minfo.is_protocol_implementation_method;
 		string target_name = isInsanceMethod ? "this" : "This";
 		string handle = supercall ? ".SuperHandle" : ".Handle";
 


### PR DESCRIPTION
This is an interesting change. After working on PR https://github.com/dotnet/macios/pull/22417 we noticed that we had a serious problem in how we called extension methods.

To understand the problem we first need to look at the code generation for an extension method:
```csharp
[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
internal static float _GetValue (ICIHueSaturationValueGradientProtocol This)
{
  return global::ObjCRuntime.Messaging.float_objc_msgSend (This.Handle, Selector.GetHandle ("value"));
}
```

The issue with the above code is that the GC can collect the 'This' object while is being used by the objc_msgSend method. For this type of methods to be safe we would need to perform a call to GC.KeepAlive on This.

Fixing the generator is not as easy as adding the 'GC.KeepAlive (This)' after the invocation because while that would work with a method that returns a wrapped object (an object that is a managed representation of an unmanaged object) it would not in all other case. The changes in the generator have to be:

1. For all methods that return a value, create a return variable with the following special cases:
   * Regular methods that return values that are not wrapped.
   * Methods that have been decorated with BindAs.
   * Protocol constructors which are converted in Create methods.
2. Add the GC.KeepAlive call after the obj

With this commit, the generated code now looks like:
```csharp
[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
internal static float _GetValue (ICIHueSaturationValueGradientProtocol This)
{
  float ret;
  ret = global::ObjCRuntime.Messaging.float_objc_msgSend (This.Handle, Selector.GetHandle ("value"));
  GC.KeepAlive (This);
  return ret;
}
```
This change also opens the doors to fix in the future no extension methods that have parameters that are wrapped objects that do not return wrapped objects, but that is work for a different PR.