### PR TITLE
[net10.0] [dotnet] Disable Metrics support when Optimize=true.

### DIFF
--- a/docs/configuration-properties.md
+++ b/docs/configuration-properties.md
@@ -9,7 +9,6 @@ There are a number of properties that are contingent upon the configuration sett
 |---------------------------------------------------------	|-----------------------------------	|---------------------------------------	|
 | DebuggerSupport                                         	| false                             	|                                       	|
 | EnableAssemblyILStripping                               	| true                              	|                                       	|
-| MetricsSupport                                          	| false                             	|                                       	|
 | RuntimeIdentifiers                                      	| maccatalyst-x64;maccatalyst-arm64 	| TargetFramework == netx.x-maccatalyst 	|
 | RuntimeIdentifiers                                      	| osx-x64;osx-arm64                 	| TargetFramework == netx.x-macos       	|
 | UseSystemResourceKeys                                   	| true                              	|                                       	|
@@ -26,3 +25,12 @@ There are a number of properties that are contingent upon the configuration sett
 | RuntimeIdentifiers       	| maccatalyst-x64   	| TargetFramework == netx.x-maccatalyst 	|
 | RuntimeIdentifiers       	| osx-x64           	| TargetFramework == netx.x-macos       	|
 | UseSystemResourceKeys    	| false             	|                                       	|
+
+### Optimize=true
+
+These are options that are set when the `Optimize` property is `true` (which happens by default if `Configuration=Release`).
+
+| **Property**                   | **Value**  |
+|--------------------------------|------------|
+| MetricsSupport                 | false      |
+

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -114,7 +114,7 @@
 		<EnableUnsafeBinaryFormatterSerialization Condition="'$(EnableUnsafeBinaryFormatterSerialization)' == ''">false</EnableUnsafeBinaryFormatterSerialization>
 		<EnableUnsafeUTF7Encoding Condition="'$(EnableUnsafeUTF7Encoding)' == ''">false</EnableUnsafeUTF7Encoding>
 		<EventSourceSupport Condition="'$(EventSourceSupport)' == ''">false</EventSourceSupport>
-		<MetricsSupport Condition="'$(MetricsSupport)' == '' And '$(Configuration)' == 'Release'">false</MetricsSupport>
+		<MetricsSupport Condition="'$(MetricsSupport)' == '' And '$(Optimize)' == 'true'">false</MetricsSupport>
 		<HttpActivityPropagationSupport Condition="'$(HttpActivityPropagationSupport)' == ''">false</HttpActivityPropagationSupport>
 		<InvariantGlobalization Condition="'$(InvariantGlobalization)' == ''">false</InvariantGlobalization>
 		<!-- Enable HybridGlobalization by default-->


### PR DESCRIPTION
Disable Metrics support when `Optimize=true` (instead of when `Release=true`) to avoid depending on a configuration.

This makes our logic identical to Android's logic: https://github.com/dotnet/android/pull/9928.