### PR TITLE
[BGen] Fix argument tests for generic types.

### DIFF
--- a/src/bgen/Extensions/ParameterInfoExtensions.cs
+++ b/src/bgen/Extensions/ParameterInfoExtensions.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Reflection;
+using ObjCRuntime;
+
+public static class ParameterInfoExtensions {
+	/// <summary>
+	/// Returns the type of the parameter taking into account several special cases:
+	/// 1. The parameter is decorated with [BindAs].
+	/// 2. The parameter is generic. 
+	/// </summary>
+	/// <param name="parameterInfo"></param>
+	/// <param name="methodInfo"></param>
+	/// <param name="bindAsAttribute"></param>
+	/// <returns></returns>
+	public static Type GetBindingType (this ParameterInfo parameterInfo, MethodInfo methodInfo, BindAsAttribute? bindAsAttribute = null)
+	{
+		if (parameterInfo.ParameterType.IsGenericParameter) {
+			// a little more complicated, we need to find the source of the generic and use the constraint
+			var classType = methodInfo.DeclaringType!;
+			var genericType = classType.GetGenericArguments ();
+			foreach (var t in genericType) {
+				if (t != parameterInfo.ParameterType)
+					continue;
+
+				var constraints = t.GetGenericParameterConstraints ();
+				if (constraints.Length == 0)
+					return parameterInfo.ParameterType;
+				
+				// we have a constraint, we need to find the first one that is not generic
+				foreach (var constraint in constraints) {
+					if (!constraint.IsGenericType)
+						return constraint;
+				}
+				// all constraints are generic, return the first one
+				return constraints [0];
+			}
+		}
+		// simplest case, we are not generic
+		return bindAsAttribute is null ? parameterInfo.ParameterType : bindAsAttribute.Type;
+	}
+}

--- a/src/bgen/Extensions/ParameterInfoExtensions.cs
+++ b/src/bgen/Extensions/ParameterInfoExtensions.cs
@@ -28,7 +28,7 @@ public static class ParameterInfoExtensions {
 				var constraints = t.GetGenericParameterConstraints ();
 				if (constraints.Length == 0)
 					return parameterInfo.ParameterType;
-				
+
 				// we have a constraint, we need to find the first one that is not generic
 				foreach (var constraint in constraints) {
 					if (!constraint.IsGenericType)

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -3374,7 +3374,7 @@ public partial class Generator : IMemberGatherer {
 			var needs_null_check = ParameterNeedsNullCheck (pi, mi, propInfo);
 			var cap = propInfo?.SetMethod == mi ? (ICustomAttributeProvider) propInfo : (ICustomAttributeProvider) pi;
 			var bind_as = GetBindAsAttribute (cap);
-			var pit = bind_as is null ? pi.ParameterType : bind_as.Type;
+			var pit = pi.GetBindingType (mi, bind_as);
 			if (TypeManager.IsWrappedType (pit) || TypeCache.INativeObject.IsAssignableFrom (pit)) {
 				if (needs_null_check && !null_allowed_override) {
 					print ($"var {safe_name}__handle__ = {safe_name}!.GetNonNullHandle (nameof ({safe_name}));");
@@ -3394,7 +3394,7 @@ public partial class Generator : IMemberGatherer {
 		foreach (var pi in mi.GetParameters ()) {
 			var cap = propInfo?.SetMethod == mi ? (ICustomAttributeProvider) propInfo : (ICustomAttributeProvider) pi;
 			var bind_as = GetBindAsAttribute (cap);
-			var pit = bind_as is null ? pi.ParameterType : bind_as.Type;
+			var pit = pi.GetBindingType (mi, bind_as);
 			if (TypeManager.IsWrappedType (pit) || TypeCache.INativeObject.IsAssignableFrom (pit)) {
 				print ($"GC.KeepAlive ({pi.Name.GetSafeParamName ()});");
 			}

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -466,6 +466,12 @@ namespace GeneratorTests {
 		}
 
 		[Test]
+		public void GenericNSObjectParameter ()
+		{
+			BuildFile (Profile.iOS, "generic-type-nsobject.cs");
+		}
+
+		[Test]
 		public void BindAsTests ()
 		{
 			BuildFile (Profile.iOS, "bindastests.cs");

--- a/tests/generator/generic-type-nsobject.cs
+++ b/tests/generator/generic-type-nsobject.cs
@@ -1,0 +1,13 @@
+using Foundation;
+using ObjCRuntime;
+
+namespace NS {
+	[Abstract]
+	[BaseType (typeof (NSObject))]
+	public interface MyObject<T> where T : NSObject {
+
+		[Export ("abstractMember:")]
+		void AbstractMember (T parameter);
+	}
+}
+


### PR DESCRIPTION
Generic parameter types are special and in reflection do not show as the Type that was given as a constrain. This is problematic because the generator tests for IsWrappedType or IsNativeObject do not work on a generic type.

This is a patch to get the current bindings working with generic parameters from generic classes. Once this is landed we will be able to detect if the types is a wrapped one and we can call GC.KeepAlive when needed.