### PR TITLE
[devops] Improve detection of CI builds to not find any PRs for them.

### DIFF
--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -884,6 +884,12 @@ function Get-GitHubPRsForHash {
 
     Write-Host "Getting related PR ids for commit $Hash"
 
+    $prs = [System.Collections.ArrayList]@()
+    if ($Env:IS_PR -eq "false") {
+        Write-Host "This isn't a PR, IS_PR=false"
+        return $prs
+    }
+
     if ($Org -and $Repo) {
         $url = "https://api.github.com/repos/$($Org)/$($Repo)/commits/$Hash/pulls"
     } else {
@@ -902,7 +908,6 @@ function Get-GitHubPRsForHash {
     Write-Host "Request result: $request"
 
     # loop over the result and remove all the extra noise we are not interested in
-    $prs = [System.Collections.ArrayList]@()
     foreach ($prInfo in $request) {
         $state = $prInfo.state
         if ($state -ne "open") {

--- a/tools/devops/automation/templates/tests/publish-html.yml
+++ b/tools/devops/automation/templates/tests/publish-html.yml
@@ -90,6 +90,7 @@ steps:
     TESTS_JOBSTATUS: $(TESTS_JOBSTATUS) # set by the runTests step
     TESTS_SUMMARY: $(TEST_SUMMARY_PATH)
     ACCESSTOKEN: $(System.AccessToken)
+    IS_PR: ${{ parameters.isPR }}
     ${{ if eq(parameters.repositoryAlias, 'self') }}:
       COMMENT_HASH: $(fix_commit.GIT_HASH)
     ${{ else }}:


### PR DESCRIPTION
Example comment where we got it wrong: https://github.com/dotnet/macios/pull/22498#issuecomment-2761264919

The comment is not for a PR, but for a CI build:
https://github.com/dotnet/macios/commit/c90957b83b4fb9868ba49f82de6fae2056915c2e,
but since the PR contains the actual commit, it got reported there.