### PR TITLE
[tests] Fix running macOS tests on arm64 machines.

### DIFF
--- a/tests/packaged-macos-tests.mk
+++ b/tests/packaged-macos-tests.mk
@@ -4,7 +4,7 @@ include $(TOP)/Make.config
 
 export DOTNET=$(shell which dotnet)
 
-ifeq ($(shell arch),"arm64")
+ifeq ($(shell arch),arm64)
 IS_ARM64=1
 IS_APPLE_SILICON=1
 endif


### PR DESCRIPTION
TIL: quotes are significant in make.