### PR TITLE
[AVFoundation] Add a default ctor for AVRouteDetector. Fixes #10139.

### DIFF
--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -20711,7 +20711,6 @@ namespace AVFoundation {
 	}
 
 	[MacCatalyst (13, 1)]
-	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject))]
 	interface AVRouteDetector {
 		/// <summary>To be added.</summary>

--- a/tests/introspection/ApiCtorInitTest.cs
+++ b/tests/introspection/ApiCtorInitTest.cs
@@ -132,6 +132,8 @@ namespace Introspection {
 #endif
 			case "AVSpeechSynthesisVoice": // Calling description crashes the test
 				return TestRuntime.CheckExactXcodeVersion (12, 2, beta: 3);
+			case "AVRouteDetector": // only seems to work on device.
+				return TestRuntime.IsSimulator;
 			case "SKView":
 				// Causes a crash later. Filed as radar://18440271.
 				// Apple said they won't fix this ('init' isn't a designated initializer)


### PR DESCRIPTION
It doesn't work in the simulator, but it works on device.

Fixes https://github.com/dotnet/macios/issues/10139.