### PR TITLE
[MapKit] Improve and simplify the manually bound constructors for MKMapCameraZoomRange slightly.

### DIFF
--- a/src/MapKit/MKMapCameraZoomRange.cs
+++ b/src/MapKit/MKMapCameraZoomRange.cs
@@ -1,30 +1,39 @@
-#if !MONOMAC
 using System;
+
+using Foundation;
 using ObjCRuntime;
 
 #nullable enable
 
 namespace MapKit {
 
+	/// <summary>This enum is used to select how to initialize a new instance of a <see cref="MKMapCameraZoomRange" />.</summary>
 	public enum MKMapCameraZoomRangeType {
+		/// <summary>The specified distance is the minimum center coordinate distance.</summary>
 		Min,
+		/// <summary>The specified distance is the maximum center coordinate distance.</summary>
 		Max,
 	}
 
 	public partial class MKMapCameraZoomRange {
+		/// <summary>Create a new <see cref="MKMapCameraZoomRange" /> instance.</summary>
+		/// <param name="distance">The minimum center coordinate distance.</param>
 		public MKMapCameraZoomRange (double distance) : this (distance, MKMapCameraZoomRangeType.Min)
 		{
 		}
 
+		/// <summary>Create a new <see cref="MKMapCameraZoomRange" /> instance.</summary>
+		/// <param name="distance">The minimum or maximum center coordinate distance.</param>
+		/// <param name="type">Specify whether <paramref name="distance" /> is the minimum or the maximum coordinate distance.</param>
 		public MKMapCameraZoomRange (double distance, MKMapCameraZoomRangeType type)
+			: base (NSObjectFlag.Empty)
 		{
-			// two different `init*` would share the same C# signature
 			switch (type) {
 			case MKMapCameraZoomRangeType.Min:
-				InitializeHandle (InitWithMinCenterCoordinateDistance (distance));
+				InitializeHandle (_InitWithMinCenterCoordinateDistance (distance));
 				break;
 			case MKMapCameraZoomRangeType.Max:
-				InitializeHandle (InitWithMaxCenterCoordinateDistance (distance));
+				InitializeHandle (_InitWithMaxCenterCoordinateDistance (distance));
 				break;
 			default:
 				throw new ArgumentException (nameof (type));
@@ -32,4 +41,3 @@ namespace MapKit {
 		}
 	}
 }
-#endif

--- a/src/mapkit.cs
+++ b/src/mapkit.cs
@@ -2408,11 +2408,11 @@ namespace MapKit {
 
 		[Internal]
 		[Export ("initWithMinCenterCoordinateDistance:")]
-		IntPtr InitWithMinCenterCoordinateDistance (double minDistance);
+		IntPtr _InitWithMinCenterCoordinateDistance (double minDistance);
 
 		[Internal]
 		[Export ("initWithMaxCenterCoordinateDistance:")]
-		IntPtr InitWithMaxCenterCoordinateDistance (double maxDistance);
+		IntPtr _InitWithMaxCenterCoordinateDistance (double maxDistance);
 
 		[Export ("minCenterCoordinateDistance")]
 		double MinCenterCoordinateDistance { get; }

--- a/tests/cecil-tests/ConstructorTest.KnownFailures.cs
+++ b/tests/cecil-tests/ConstructorTest.KnownFailures.cs
@@ -50,7 +50,6 @@ namespace Cecil.Tests {
 			"HomeKit.HMMatterTopology::.ctor(Foundation.NSObjectFlag)",
 			"HomeKit.HMMatterTopology::.ctor(HomeKit.HMMatterHome[])",
 			"HomeKit.HMMatterTopology::.ctor(ObjCRuntime.NativeHandle)",
-			"MapKit.MKMapCameraZoomRange::.ctor(System.Double,MapKit.MKMapCameraZoomRangeType)",
 			"MapKit.MKPointOfInterestFilter::.ctor(MapKit.MKPointOfInterestCategory[],MapKit.MKPointOfInterestFilterType)",
 			"ModelIO.MDLMesh::.ctor(ModelIO.MDLMesh,System.Int32,System.UInt32,ModelIO.IMDLMeshBufferAllocator)",
 			"ModelIO.MDLMesh::.ctor(System.Numerics.Vector3,CoreGraphics.NVector2i,ModelIO.MDLGeometryType,ModelIO.IMDLMeshBufferAllocator)",

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -4510,8 +4510,6 @@ F:MapKit.MKLocalSearchResultType.PointOfInterest
 F:MapKit.MKLookAroundBadgePosition.BottomTrailing
 F:MapKit.MKLookAroundBadgePosition.TopLeading
 F:MapKit.MKLookAroundBadgePosition.TopTrailing
-F:MapKit.MKMapCameraZoomRangeType.Max
-F:MapKit.MKMapCameraZoomRangeType.Min
 F:MapKit.MKMapElevationStyle.Flat
 F:MapKit.MKMapElevationStyle.Realistic
 F:MapKit.MKMapFeatureOptions.PhysicalFeatures
@@ -19371,8 +19369,6 @@ M:MapKit.MKMapCamera.Copy(Foundation.NSZone)
 M:MapKit.MKMapCamera.EncodeTo(Foundation.NSCoder)
 M:MapKit.MKMapCameraBoundary.Copy(Foundation.NSZone)
 M:MapKit.MKMapCameraBoundary.EncodeTo(Foundation.NSCoder)
-M:MapKit.MKMapCameraZoomRange.#ctor(System.Double,MapKit.MKMapCameraZoomRangeType)
-M:MapKit.MKMapCameraZoomRange.#ctor(System.Double)
 M:MapKit.MKMapCameraZoomRange.Copy(Foundation.NSZone)
 M:MapKit.MKMapCameraZoomRange.EncodeTo(Foundation.NSCoder)
 M:MapKit.MKMapConfiguration.Copy(Foundation.NSZone)
@@ -44470,7 +44466,6 @@ T:MapKit.MKLocalSearchRegionPriority
 T:MapKit.MKLocalSearchResultType
 T:MapKit.MKLookAroundBadgePosition
 T:MapKit.MKLookAroundViewControllerDelegate
-T:MapKit.MKMapCameraZoomRangeType
 T:MapKit.MKMapElevationStyle
 T:MapKit.MKMapFeatureOptions
 T:MapKit.MKMapFeatureType

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -1377,8 +1377,6 @@ namespace Introspection {
 			case "initWithSSIDPrefix:":
 			case "initWithSSIDPrefix:passphrase:isWEP:":
 			// MapKit
-			case "initWithMaxCenterCoordinateDistance:":
-			case "initWithMinCenterCoordinateDistance:":
 			case "initExcludingCategories:":
 			case "initIncludingCategories:":
 				var mi = m as MethodInfo;


### PR DESCRIPTION
Improve and simplify the manually bound constructors for MKMapCameraZoomRange by
using the same pattern we use elsewhere for manually bound constructors.

Also add these constructors to macOS.