### PR TITLE
[UIKit] Fix UIBarButtonItem's callback logic.

### DIFF
--- a/src/UIKit/UIBarButtonItem.cs
+++ b/src/UIKit/UIBarButtonItem.cs
@@ -29,7 +29,7 @@ namespace UIKit {
 				if (clicked is not null)
 					clicked (sender, EventArgs.Empty);
 			}
-	   }
+		}
 
 		/// <param name="image">Image to be used in the button. If it is too large, the image is scaled to fit.</param>
 		/// <param name="style">A style value defined in <see cref="T:UIKit.UIBarButtonItemStyle" />.</param>

--- a/src/UIKit/UIBarButtonItem.cs
+++ b/src/UIKit/UIBarButtonItem.cs
@@ -1,97 +1,86 @@
-//
-// Sanitize callbacks
-//
-
 using Foundation;
 using ObjCRuntime;
 using System;
+using System.Diagnostics.CodeAnalysis;
 
-// Disable until we get around to enable + fix any issues.
-#nullable disable
+#nullable enable
 
 namespace UIKit {
 
 	public partial class UIBarButtonItem {
-		static Selector actionSel = new Selector ("InvokeAction:");
+		const string actionSel = "InvokeAction:";
 
-		[Register]
-		internal class Callback : NSObject {
-			internal UIBarButtonItem container;
+		class Callback : NSObject {
+			WeakReference<UIBarButtonItem> container;
 
-			public Callback ()
+			[DynamicDependency ("InvokeAction")]
+			public Callback (UIBarButtonItem item)
 			{
+				container = new WeakReference<UIBarButtonItem> (item);
 				IsDirectBinding = false;
 			}
 
-			[Export ("InvokeAction:")]
-			[Preserve (Conditional = true)]
+			[Export (actionSel)]
 			public void Call (NSObject sender)
 			{
-				if (container.clicked is not null)
-					container.clicked (sender, EventArgs.Empty);
+				if (!container.TryGetTarget (out var obj) || obj is null)
+					return;
+				var clicked = obj.clicked;
+				if (clicked is not null)
+					clicked (sender, EventArgs.Empty);
 			}
-		}
+	   }
 
 		/// <param name="image">Image to be used in the button. If it is too large, the image is scaled to fit.</param>
-		///         <param name="style">A style value defined in <see cref="T:UIKit.UIBarButtonItemStyle" />.</param>
-		///         <param name="handler">The event handler to be called when the button is pressed.</param>
-		///         <summary>Constructor that allows a custom image, style and evnet handler to be specied when the button is created.</summary>
-		///         <remarks>Alpha values from the source image, ignoring opaque values, are used to create the image that appears on the button.</remarks>
+		/// <param name="style">A style value defined in <see cref="T:UIKit.UIBarButtonItemStyle" />.</param>
+		/// <param name="handler">The event handler to be called when the button is pressed.</param>
+		/// <summary>Constructor that allows a custom image, style and event handler to be specied when the button is created.</summary>
+		/// <remarks>Alpha values from the source image, ignoring opaque values, are used to create the image that appears on the button.</remarks>
 		public UIBarButtonItem (UIImage image, UIBarButtonItemStyle style, EventHandler handler)
-		: this (image, style, new Callback (), actionSel)
+		: this (image, style, null, null)
 		{
-			callback = (Callback) Target;
-			callback.container = this;
-			clicked += handler;
-			MarkDirty ();
+			Clicked += handler;
 		}
 
 
 		/// <param name="title">String value used to display the title of the button.</param>
-		///         <param name="style">A style value defined in <see cref="T:UIKit.UIBarButtonItemStyle" />.</param>
-		///         <param name="handler">The event handler to be called when the button is pressed.</param>
-		///         <summary>Constructor that allows a title to be specified for display on the button depending on the style used. Also allows an event handler to be specified that will be called when the button is pressed.</summary>
-		///         <remarks>Some <see cref="T:UIKit.UIBarButtonItemStyle" /> values display the title on the button while others display an image.</remarks>
+		/// <param name="style">A style value defined in <see cref="T:UIKit.UIBarButtonItemStyle" />.</param>
+		/// <param name="handler">The event handler to be called when the button is pressed.</param>
+		/// <summary>Constructor that allows a title to be specified for display on the button depending on the style used. Also allows an event handler to be specified that will be called when the button is pressed.</summary>
+		/// <remarks>Some <see cref="T:UIKit.UIBarButtonItemStyle" /> values display the title on the button while others display an image.</remarks>
 		public UIBarButtonItem (string title, UIBarButtonItemStyle style, EventHandler handler)
-		: this (title, style, new Callback (), actionSel)
+		: this (title, style, null, null)
 		{
-			callback = (Callback) Target;
-			callback.container = this;
-			clicked += handler;
-			MarkDirty ();
+			Clicked += handler;
 		}
 
 
 		/// <param name="systemItem">The <see cref="T:UIKit.UIBarButtonSystemItem" /> used to create the button.</param>
-		///         <param name="handler">The event handler to be called when the button is pressed.</param>
-		///         <summary>Constructor that allows a particular <see cref="T:UIKit.UIBarButtonSystemItem" /> to be specified when the button is created along with an event handler.</summary>
-		///         <remarks>The event handler will be called when the button is pressed.</remarks>
+		/// <param name="handler">The event handler to be called when the button is pressed.</param>
+		/// <summary>Constructor that allows a particular <see cref="T:UIKit.UIBarButtonSystemItem" /> to be specified when the button is created along with an event handler.</summary>
+		/// <remarks>The event handler will be called when the button is pressed.</remarks>
 		public UIBarButtonItem (UIBarButtonSystemItem systemItem, EventHandler handler)
-		: this (systemItem, new Callback (), actionSel)
+		: this (systemItem, null, null)
 		{
-			callback = (Callback) Target;
-			callback.container = this;
-			clicked += handler;
-			MarkDirty ();
+			Clicked += handler;
 		}
 
 		/// <param name="systemItem">The <see cref="T:UIKit.UIBarButtonSystemItem" /> used to create the button.</param>
-		///         <summary>Constructor that allows a particular <see cref="T:UIKit.UIBarButtonSystemItem" /> to be specified when the button is created.</summary>
-		///         <remarks>The <see cref="T:UIKit.UIBarButtonSystemItem" /> allows a number of buttons pre-defined by the system to be used when creating a UIBarButtonItem.</remarks>
+		/// <summary>Constructor that allows a particular <see cref="T:UIKit.UIBarButtonSystemItem" /> to be specified when the button is created.</summary>
+		/// <remarks>The <see cref="T:UIKit.UIBarButtonSystemItem" /> allows a number of buttons pre-defined by the system to be used when creating a UIBarButtonItem.</remarks>
 		public UIBarButtonItem (UIBarButtonSystemItem systemItem) : this (systemItem: systemItem, target: null, action: null)
 		{
 		}
 
-		internal EventHandler clicked;
-		internal Callback callback;
+		Callback? callback;
+		EventHandler? clicked;
 
 		public event EventHandler Clicked {
 			add {
 				if (clicked is null) {
-					callback = new Callback ();
-					callback.container = this;
+					callback = new Callback (this);
 					this.Target = callback;
-					this.Action = actionSel;
+					this.Action = new Selector (actionSel);
 					MarkDirty ();
 				}
 

--- a/src/UIKit/UIBarButtonItem.cs
+++ b/src/UIKit/UIBarButtonItem.cs
@@ -13,7 +13,7 @@ namespace UIKit {
 		class Callback : NSObject {
 			WeakReference<UIBarButtonItem> container;
 
-			[DynamicDependency ("InvokeAction")]
+			[DynamicDependency ("Call")]
 			public Callback (UIBarButtonItem item)
 			{
 				container = new WeakReference<UIBarButtonItem> (item);


### PR DESCRIPTION
There was a race condition in the constructors, where we'd create a new
Callback instance when calling the base constructor, and then fetching that
Callback instance inside the constructor itself, storing it in a field: the GC
could collect the Callback instance once we'd call the native init method, and
before we'd fetched it later on.

Fix it by not creating the Callback instance in the call to the base
constructor, but add the event handler in the actual constructor later.

Also add a few more code improvements.

Hopefully fixes this crash:

    *** Terminating app due to uncaught exception 'ObjCRuntime.RuntimeException', reason: 'Failed to marshal the Objective-C object 0x60000025f660 (type: UIKit_UIBarButtonItem_Callback). Could not find an existing managed instance for this object, nor was it possible to create a new managed instance (because the type 'UIKit.UIBarButtonItem+Callback' does not have a constructor that takes one NativeHandle argument). (ObjCRuntime.RuntimeException)
       at ObjCRuntime.Runtime.ThrowException(IntPtr) + 0x53
       at UIKit.UIApplication.UIApplicationMain(Int32, String[], IntPtr, IntPtr) + 0xb0
       at UIKit.UIApplication.Main(String[], Type, Type) + 0xcb
       at MainClass.Main(String[]) + 0xf