### PR TITLE
[src] Ask the compiler to print out the full path to files in compiler messages.

### DIFF
--- a/scripts/rsp-to-csproj/rsp-to-csproj.cs
+++ b/scripts/rsp-to-csproj/rsp-to-csproj.cs
@@ -192,6 +192,9 @@ foreach (var a in arguments) {
 	case "analyzerconfig":
 		items.Add (new ("EditorConfigFiles", GetFullPath (value)));
 		break;
+	case "fullpaths":
+		properties.Add (new ("GenerateFullPaths", value));
+		break;
 	default:
 		ReportError ($"Didn't understand argument '{a}'");
 		break;

--- a/src/Makefile
+++ b/src/Makefile
@@ -56,7 +56,7 @@ DOTNET_REFERENCES = \
 	/r:$(DOTNET_BCL_DIR)/System.Xml.ReaderWriter.dll \
 
 DOTNET_OR_GREATER_DEFINES:=$(foreach version,$(shell seq 6 $(firstword $(subst ., ,$(subst net,,$(DOTNET_TFM))))),/define:NET$(version)_0_OR_GREATER)
-DOTNET_FLAGS=/warnaserror+ /nostdlib+ /deterministic /features:strict /nologo /target:library /debug /unsafe /define:NET /define:NET_TODO $(DOTNET_OR_GREATER_DEFINES) $(DOTNET_REFERENCES)
+DOTNET_FLAGS=/warnaserror+ /nostdlib+ /deterministic /features:strict /nologo /target:library /debug /unsafe /define:NET /define:NET_TODO $(DOTNET_OR_GREATER_DEFINES) $(DOTNET_REFERENCES) /fullpaths
 
 ifeq ($(XCODE_IS_STABLE),true)
 DOTNET_FLAGS+=/define:XCODE_IS_STABLE


### PR DESCRIPTION
This is the default when building with MSBuild, and it also makes it easier to
c&p paths and have them work everywhere.