### PR TITLE
[tools] Fix class_ptr rewriter to patch exception handlers too when instructions change.

### DIFF
--- a/tools/common/Rewriter.cs
+++ b/tools/common/Rewriter.cs
@@ -258,6 +258,28 @@ namespace ClassRedirector {
 					}
 				}
 			}
+			foreach (var eh in body.ExceptionHandlers) {
+				if (eh.TryStart == old) {
+					eh.TryStart = @new;
+					changed = true;
+				}
+				if (eh.TryEnd == old) {
+					eh.TryEnd = @new;
+					changed = true;
+				}
+				if (eh.FilterStart == old) {
+					eh.FilterStart = @new;
+					changed = true;
+				}
+				if (eh.HandlerStart == old) {
+					eh.HandlerStart = @new;
+					changed = true;
+				}
+				if (eh.HandlerEnd == old) {
+					eh.HandlerEnd = @new;
+					changed = true;
+				}
+			}
 			return changed;
 		}
 


### PR DESCRIPTION
Fixes these test failures when running a release build with all optimizations and the static registrar:

    MonoTouchFixtures.AppKit.NSGridViewTest
    	[FAIL] CreateWithNSViewArrayOfArrayCheckDifferentArrayLength : System.InvalidProgramException : InvalidProgram_Default
    		   at AppKit.NSGridView.Create(NSView[][])
    		   at MonoTouchFixtures.AppKit.NSGridViewTest.CreateWithNSViewArrayOfArrayCheckDifferentArrayLength()
    		   at System.RuntimeMethodHandle.InvokeMethod(Object, Void**, Signature, Boolean)
    		   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
    		   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object, BindingFlags)
    	[FAIL] CreateWithNSViewArrayOfArrayCheckNSTextView : System.InvalidProgramException : InvalidProgram_Default
    		   at AppKit.NSGridView.Create(NSView[][])
    		   at MonoTouchFixtures.AppKit.NSGridViewTest.CreateWithNSViewArrayOfArrayCheckNSTextView()
    		   at System.RuntimeMethodHandle.InvokeMethod(Object, Void**, Signature, Boolean)
    		   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
    		   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object, BindingFlags)
    	[FAIL] CreateWithNSViewArrayOfArrayCheckWithNull :   Broken Array #3
      Expected: <System.ArgumentNullException>
      But was:  <System.InvalidProgramException: InvalidProgram_Default
       at AppKit.NSGridView.Create(NSView[][])
       at MonoTouchFixtures.AppKit.NSGridViewTest.<>c__DisplayClass6_0.<CreateWithNSViewArrayOfArrayCheckWithNull>b__0()
       at NUnit.Framework.Assert.Throws(IResolveConstraint, TestDelegate, String, Object[] )>

    		   at MonoTouchFixtures.AppKit.NSGridViewTest.CreateWithNSViewArrayOfArrayCheckWithNull()
    	[FAIL] CreateWithNSViewArrayOfArrayCheckWithNullArray :   Broken Array #2
      Expected: <System.ArgumentNullException>
      But was:  <System.InvalidProgramException: InvalidProgram_Default
       at AppKit.NSGridView.Create(NSView[][])
       at MonoTouchFixtures.AppKit.NSGridViewTest.<>c__DisplayClass5_0.<CreateWithNSViewArrayOfArrayCheckWithNullArray>b__0()
       at NUnit.Framework.Assert.Throws(IResolveConstraint, TestDelegate, String, Object[] )>

    		   at MonoTouchFixtures.AppKit.NSGridViewTest.CreateWithNSViewArrayOfArrayCheckWithNullArray()
    	[FAIL] CreateWithNSViewArrayOfArrayCheckWithNullNSView :   Broken Array #1
      Expected: <System.ArgumentNullException>
      But was:  <System.InvalidProgramException: InvalidProgram_Default
       at AppKit.NSGridView.Create(NSView[][])
       at MonoTouchFixtures.AppKit.NSGridViewTest.<>c__DisplayClass4_0.<CreateWithNSViewArrayOfArrayCheckWithNullNSView>b__0()
       at NUnit.Framework.Assert.Throws(IResolveConstraint, TestDelegate, String, Object[] )>

    		   at MonoTouchFixtures.AppKit.NSGridViewTest.CreateWithNSViewArrayOfArrayCheckWithNullNSView()
    	[FAIL] CreateWithTwoDimensionalNSViewArrayCheckDifferentDimensionSize : System.InvalidProgramException : InvalidProgram_Default
    		   at AppKit.NSGridView.Create(NSView[,])
    		   at MonoTouchFixtures.AppKit.NSGridViewTest.CreateWithTwoDimensionalNSViewArrayCheckDifferentDimensionSize()
    		   at System.RuntimeMethodHandle.InvokeMethod(Object, Void**, Signature, Boolean)
    		   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
    		   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object, BindingFlags)
    	[FAIL] CreateWithTwoDimensionalNSViewArrayCheckWithNull :   Broken Array #4
      Expected: <System.ArgumentNullException>
      But was:  <System.InvalidProgramException: InvalidProgram_Default
       at AppKit.NSGridView.Create(NSView[,])
       at MonoTouchFixtures.AppKit.NSGridViewTest.<>c__DisplayClass7_0.<CreateWithTwoDimensionalNSViewArrayCheckWithNull>b__0()
       at NUnit.Framework.Assert.Throws(IResolveConstraint, TestDelegate, String, Object[] )>

    		   at MonoTouchFixtures.AppKit.NSGridViewTest.CreateWithTwoDimensionalNSViewArrayCheckWithNull()
    	[FAIL] CreateWithTwoDimensionalNSViewArrayNSTextView : System.InvalidProgramException : InvalidProgram_Default
    		   at AppKit.NSGridView.Create(NSView[,])
    		   at MonoTouchFixtures.AppKit.NSGridViewTest.CreateWithTwoDimensionalNSViewArrayNSTextView()
    		   at System.RuntimeMethodHandle.InvokeMethod(Object, Void**, Signature, Boolean)
    		   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
    		   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object, BindingFlags)
    	[FAIL] CreateWithTwoDimensionalNSViewArrayWithNullCell :   Broken Array #5
      Expected: <System.ArgumentNullException>
      But was:  <System.InvalidProgramException: InvalidProgram_Default
       at AppKit.NSGridView.Create(NSView[,])
       at MonoTouchFixtures.AppKit.NSGridViewTest.<>c__DisplayClass8_0.<CreateWithTwoDimensionalNSViewArrayWithNullCell>b__0()
       at NUnit.Framework.Assert.Throws(IResolveConstraint, TestDelegate, String, Object[] )>

    		   at MonoTouchFixtures.AppKit.NSGridViewTest.CreateWithTwoDimensionalNSViewArrayWithNullCell()