### PR TITLE
[MetalPerformanceShaders] Improve the manually bound constructors for MPSCnnBinaryConvolutionNode and MPSCnnBinaryFullyConnectedNode slightly.

### DIFF
--- a/src/MetalPerformanceShaders/MPSEnums.cs
+++ b/src/MetalPerformanceShaders/MPSEnums.cs
@@ -241,6 +241,7 @@ namespace MetalPerformanceShaders {
 	/// <summary>Flagging enumeration for options available to binary convolution kernels.</summary>
 	[MacCatalyst (13, 1)]
 	[Native]
+	[Flags]
 	public enum MPSCnnBinaryConvolutionFlags : ulong {
 		/// <summary>To be added.</summary>
 		None = 0,

--- a/src/MetalPerformanceShaders/MPSKernel.cs
+++ b/src/MetalPerformanceShaders/MPSKernel.cs
@@ -108,7 +108,7 @@ namespace MetalPerformanceShaders {
 			MPSSetHeapCacheDuration (commandBuffer.GetHandle (), seconds);
 			GC.KeepAlive (commandBuffer);
 		}
-#endif
+#endif // !COREBUILD
 	}
 
 #if !COREBUILD
@@ -459,22 +459,20 @@ namespace MetalPerformanceShaders {
 	}
 
 	public partial class MPSCnnBinaryConvolutionNode {
-		/// <param name="sourceNode">To be added.</param>
-		///         <param name="weights">To be added.</param>
-		///         <param name="outputBiasTerms">To be added.</param>
-		///         <param name="outputScaleTerms">To be added.</param>
-		///         <param name="inputBiasTerms">To be added.</param>
-		///         <param name="inputScaleTerms">To be added.</param>
-		///         <param name="type">To be added.</param>
-		///         <param name="flags">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Create a new <see cref="MPSCnnBinaryConvolutionNode" /> instance.</summary>
+		/// <param name="sourceNode">An <see cref="MPSNNImageNode" /> node for the source image.</param>
+		/// <param name="weights">An <see cref="IMPSCnnConvolutionDataSource" /> instance that provides weights and biases.</param>
+		/// <param name="outputBiasTerms">An array of bias terms to be applied to the convolution output.</param>
+		/// <param name="outputScaleTerms">An array of scale terms to be applied to the convolution output.</param>
+		/// <param name="inputBiasTerms">An array of bias terms to be applied to the input before convulution and input scaling.</param>
+		/// <param name="inputScaleTerms">An array of scale terms to be applied to the input before convulution and input scaling.</param>
+		/// <param name="type">Which type of binary convulution to use.</param>
+		/// <param name="flags">Any flags for the new instance.</param>
 		[SupportedOSPlatform ("tvos")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("maccatalyst")]
-		public static MPSCnnBinaryConvolutionNode Create (MPSNNImageNode sourceNode, IMPSCnnConvolutionDataSource weights, float [] outputBiasTerms, float [] outputScaleTerms, float [] inputBiasTerms, float [] inputScaleTerms, MPSCnnBinaryConvolutionType type, MPSCnnBinaryConvolutionFlags flags)
+		public static MPSCnnBinaryConvolutionNode Create (MPSNNImageNode sourceNode, IMPSCnnConvolutionDataSource weights, float []? outputBiasTerms, float []? outputScaleTerms, float []? inputBiasTerms, float []? inputScaleTerms, MPSCnnBinaryConvolutionType type, MPSCnnBinaryConvolutionFlags flags)
 		{
 			unsafe {
 				fixed (void* outputBiasTermsHandle = outputBiasTerms)
@@ -485,49 +483,46 @@ namespace MetalPerformanceShaders {
 			}
 		}
 
-		/// <param name="sourceNode">To be added.</param>
-		///         <param name="weights">To be added.</param>
-		///         <param name="outputBiasTerms">To be added.</param>
-		///         <param name="outputScaleTerms">To be added.</param>
-		///         <param name="inputBiasTerms">To be added.</param>
-		///         <param name="inputScaleTerms">To be added.</param>
-		///         <param name="type">To be added.</param>
-		///         <param name="flags">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Create a new <see cref="MPSCnnBinaryConvolutionNode" /> instance.</summary>
+		/// <param name="sourceNode">An <see cref="MPSNNImageNode" /> node for the source image.</param>
+		/// <param name="weights">An <see cref="IMPSCnnConvolutionDataSource" /> instance that provides weights and biases.</param>
+		/// <param name="outputBiasTerms">An array of bias terms to be applied to the convolution output.</param>
+		/// <param name="outputScaleTerms">An array of scale terms to be applied to the convolution output.</param>
+		/// <param name="inputBiasTerms">An array of bias terms to be applied to the input before convulution and input scaling.</param>
+		/// <param name="inputScaleTerms">An array of scale terms to be applied to the input before convulution and input scaling.</param>
+		/// <param name="type">Which type of binary convulution to use.</param>
+		/// <param name="flags">Any flags for the new instance.</param>
 		[SupportedOSPlatform ("tvos")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("maccatalyst")]
-		public MPSCnnBinaryConvolutionNode (MPSNNImageNode sourceNode, IMPSCnnConvolutionDataSource weights, float [] outputBiasTerms, float [] outputScaleTerms, float [] inputBiasTerms, float [] inputScaleTerms, MPSCnnBinaryConvolutionType type, MPSCnnBinaryConvolutionFlags flags) : base (NSObjectFlag.Empty)
+		public MPSCnnBinaryConvolutionNode (MPSNNImageNode sourceNode, IMPSCnnConvolutionDataSource weights, float []? outputBiasTerms, float []? outputScaleTerms, float []? inputBiasTerms, float []? inputScaleTerms, MPSCnnBinaryConvolutionType type, MPSCnnBinaryConvolutionFlags flags) : base (NSObjectFlag.Empty)
 		{
 			unsafe {
 				fixed (void* outputBiasTermsHandle = outputBiasTerms)
 				fixed (void* outputScaleTermsHandle = outputScaleTerms)
 				fixed (void* inputBiasTermsHandle = inputBiasTerms)
 				fixed (void* inputScaleTermsHandle = inputScaleTerms)
-					InitializeHandle (InitWithSource (sourceNode, weights, (IntPtr) outputBiasTermsHandle, (IntPtr) outputScaleTermsHandle, (IntPtr) inputBiasTermsHandle, (IntPtr) inputScaleTermsHandle, type, flags));
+					InitializeHandle (_InitWithSource (sourceNode, weights, (IntPtr) outputBiasTermsHandle, (IntPtr) outputScaleTermsHandle, (IntPtr) inputBiasTermsHandle, (IntPtr) inputScaleTermsHandle, type, flags));
 			}
 		}
 	}
 
 	public partial class MPSCnnBinaryFullyConnectedNode {
-		/// <param name="sourceNode">To be added.</param>
-		///         <param name="weights">To be added.</param>
-		///         <param name="outputBiasTerms">To be added.</param>
-		///         <param name="outputScaleTerms">To be added.</param>
-		///         <param name="inputBiasTerms">To be added.</param>
-		///         <param name="inputScaleTerms">To be added.</param>
-		///         <param name="type">To be added.</param>
-		///         <param name="flags">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Create a new <see cref="MPSCnnBinaryConvolutionNode" /> instance.</summary>
+		/// <param name="sourceNode">An <see cref="MPSNNImageNode" /> node for the source image.</param>
+		/// <param name="weights">An <see cref="IMPSCnnConvolutionDataSource" /> instance that provides weights and biases.</param>
+		/// <param name="outputBiasTerms">An array of bias terms to be applied to the convolution output.</param>
+		/// <param name="outputScaleTerms">An array of scale terms to be applied to the convolution output.</param>
+		/// <param name="inputBiasTerms">An array of bias terms to be applied to the input before convulution and input scaling.</param>
+		/// <param name="inputScaleTerms">An array of scale terms to be applied to the input before convulution and input scaling.</param>
+		/// <param name="type">Which type of binary convulution to use.</param>
+		/// <param name="flags">Any flags for the new instance.</param>
 		[SupportedOSPlatform ("tvos")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("maccatalyst")]
-		public new static MPSCnnBinaryFullyConnectedNode Create (MPSNNImageNode sourceNode, IMPSCnnConvolutionDataSource weights, float [] outputBiasTerms, float [] outputScaleTerms, float [] inputBiasTerms, float [] inputScaleTerms, MPSCnnBinaryConvolutionType type, MPSCnnBinaryConvolutionFlags flags)
+		public new static MPSCnnBinaryFullyConnectedNode Create (MPSNNImageNode sourceNode, IMPSCnnConvolutionDataSource weights, float []? outputBiasTerms, float []? outputScaleTerms, float []? inputBiasTerms, float []? inputScaleTerms, MPSCnnBinaryConvolutionType type, MPSCnnBinaryConvolutionFlags flags)
 		{
 			unsafe {
 				fixed (void* outputBiasTermsHandle = outputBiasTerms)
@@ -538,30 +533,29 @@ namespace MetalPerformanceShaders {
 			}
 		}
 
-		/// <param name="sourceNode">To be added.</param>
-		///         <param name="weights">To be added.</param>
-		///         <param name="outputBiasTerms">To be added.</param>
-		///         <param name="outputScaleTerms">To be added.</param>
-		///         <param name="inputBiasTerms">To be added.</param>
-		///         <param name="inputScaleTerms">To be added.</param>
-		///         <param name="type">To be added.</param>
-		///         <param name="flags">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Create a new <see cref="MPSCnnBinaryConvolutionNode" /> instance.</summary>
+		/// <param name="sourceNode">An <see cref="MPSNNImageNode" /> node for the source image.</param>
+		/// <param name="weights">An <see cref="IMPSCnnConvolutionDataSource" /> instance that provides weights and biases.</param>
+		/// <param name="outputBiasTerms">An array of bias terms to be applied to the convolution output.</param>
+		/// <param name="outputScaleTerms">An array of scale terms to be applied to the convolution output.</param>
+		/// <param name="inputBiasTerms">An array of bias terms to be applied to the input before convulution and input scaling.</param>
+		/// <param name="inputScaleTerms">An array of scale terms to be applied to the input before convulution and input scaling.</param>
+		/// <param name="type">Which type of binary convulution to use.</param>
+		/// <param name="flags">Any flags for the new instance.</param>
 		[SupportedOSPlatform ("tvos")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("maccatalyst")]
-		public MPSCnnBinaryFullyConnectedNode (MPSNNImageNode sourceNode, IMPSCnnConvolutionDataSource weights, float [] outputBiasTerms, float [] outputScaleTerms, float [] inputBiasTerms, float [] inputScaleTerms, MPSCnnBinaryConvolutionType type, MPSCnnBinaryConvolutionFlags flags) : base (NSObjectFlag.Empty)
+		public MPSCnnBinaryFullyConnectedNode (MPSNNImageNode sourceNode, IMPSCnnConvolutionDataSource weights, float []? outputBiasTerms, float []? outputScaleTerms, float []? inputBiasTerms, float []? inputScaleTerms, MPSCnnBinaryConvolutionType type, MPSCnnBinaryConvolutionFlags flags) : base (NSObjectFlag.Empty)
 		{
 			unsafe {
 				fixed (void* outputBiasTermsHandle = outputBiasTerms)
 				fixed (void* outputScaleTermsHandle = outputScaleTerms)
 				fixed (void* inputBiasTermsHandle = inputBiasTerms)
 				fixed (void* inputScaleTermsHandle = inputScaleTerms)
-					InitializeHandle (InitWithSource (sourceNode, weights, (IntPtr) outputBiasTermsHandle, (IntPtr) outputScaleTermsHandle, (IntPtr) inputBiasTermsHandle, (IntPtr) inputScaleTermsHandle, type, flags));
+					InitializeHandle (_InitWithSource (sourceNode, weights, (IntPtr) outputBiasTermsHandle, (IntPtr) outputScaleTermsHandle, (IntPtr) inputBiasTermsHandle, (IntPtr) inputScaleTermsHandle, type, flags));
 			}
 		}
 	}
-#endif
+#endif // COREBUILD
 }

--- a/src/metalperformanceshaders.cs
+++ b/src/metalperformanceshaders.cs
@@ -5816,7 +5816,7 @@ namespace MetalPerformanceShaders {
 		[Internal]
 		[MacCatalyst (13, 1)]
 		[Export ("initWithSource:weights:outputBiasTerms:outputScaleTerms:inputBiasTerms:inputScaleTerms:type:flags:")]
-		IntPtr InitWithSource (MPSNNImageNode sourceNode, IMPSCnnConvolutionDataSource weights, [NullAllowed] IntPtr outputBiasTerms, [NullAllowed] IntPtr outputScaleTerms, [NullAllowed] IntPtr inputBiasTerms, [NullAllowed] IntPtr inputScaleTerms, MPSCnnBinaryConvolutionType type, MPSCnnBinaryConvolutionFlags flags);
+		IntPtr _InitWithSource (MPSNNImageNode sourceNode, IMPSCnnConvolutionDataSource weights, [NullAllowed] IntPtr outputBiasTerms, [NullAllowed] IntPtr outputScaleTerms, [NullAllowed] IntPtr inputBiasTerms, [NullAllowed] IntPtr inputScaleTerms, MPSCnnBinaryConvolutionType type, MPSCnnBinaryConvolutionFlags flags);
 	}
 
 	/// <summary>A <see cref="T:MetalPerformanceShaders.MPSCnnBinaryConvolutionNode" /> that represents a fully-connected convolution layer that uses binary weights.</summary>
@@ -5848,7 +5848,7 @@ namespace MetalPerformanceShaders {
 		[Internal]
 		[MacCatalyst (13, 1)]
 		[Export ("initWithSource:weights:outputBiasTerms:outputScaleTerms:inputBiasTerms:inputScaleTerms:type:flags:")]
-		IntPtr InitWithSource (MPSNNImageNode sourceNode, IMPSCnnConvolutionDataSource weights, [NullAllowed] IntPtr outputBiasTerms, [NullAllowed] IntPtr outputScaleTerms, [NullAllowed] IntPtr inputBiasTerms, [NullAllowed] IntPtr inputScaleTerms, MPSCnnBinaryConvolutionType type, MPSCnnBinaryConvolutionFlags flags);
+		IntPtr _InitWithSource (MPSNNImageNode sourceNode, IMPSCnnConvolutionDataSource weights, [NullAllowed] IntPtr outputBiasTerms, [NullAllowed] IntPtr outputScaleTerms, [NullAllowed] IntPtr inputBiasTerms, [NullAllowed] IntPtr inputScaleTerms, MPSCnnBinaryConvolutionType type, MPSCnnBinaryConvolutionFlags flags);
 	}
 
 	/// <summary>A <see cref="T:MetalPerformanceShaders.MPSCnnConvolutionNode" /> that represents a transpose kernel.</summary>

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -1360,8 +1360,6 @@ namespace Introspection {
 			case "initWithProfileNumber:profileLabel:defaultProfile:":
 			case "initWithProfileNumber:profileName:":
 			case "initWithProfileNumber:profileLabel:":
-			// MPSCnnBinaryConvolutionNode and MPSCnnBinaryFullyConnectedNode
-			case "initWithSource:weights:outputBiasTerms:outputScaleTerms:inputBiasTerms:inputScaleTerms:type:flags:":
 			// UISegmentedControl
 			case "initWithItems:":
 			// CLBeaconRegion


### PR DESCRIPTION
* Improve and simplify the manually bound constructors for MPSCnnBinaryConvolutionNode
  and MPSCnnBinaryFullyConnectedNode by using the same pattern we use elsewhere for
  manually bound constructors.
* Make MPSCnnBinaryConvolutionFlags an actual [Flags] enum.
* Make a few parameters nullable that are supposed to be nullable.