### PR TITLE
[MapKit] Improve and simplify the manually bound constructors for MKPointOfInterestFilter slightly.

### DIFF
--- a/src/MapKit/MKPointOfInterestFilter.cs
+++ b/src/MapKit/MKPointOfInterestFilter.cs
@@ -1,30 +1,40 @@
-#if !MONOMAC
 using System;
+
+using Foundation;
 using ObjCRuntime;
 
 #nullable enable
 
 namespace MapKit {
 
+	/// <summary>This enum is used to select how to initialize a new instance of a <see cref="MKPointOfInterestFilter" />.</summary>
 	public enum MKPointOfInterestFilterType {
+		/// <summary>The specified categories are included.</summary>
 		Including,
+		/// <summary>The specified categories are excluded.</summary>
 		Excluding,
 	}
 
 	public partial class MKPointOfInterestFilter {
+		/// <summary>Create a new <see cref="MKPointOfInterestFilter" /> instance.</summary>
+		/// <param name="categories">An array of categories for the filter to include.</param>
 		public MKPointOfInterestFilter (MKPointOfInterestCategory [] categories) : this (categories, MKPointOfInterestFilterType.Including)
 		{
 		}
 
+		/// <summary>Create a new <see cref="MKPointOfInterestFilter" /> instance.</summary>
+		/// <param name="categories">An array of categories for the filter to include or exclude.</param>
+		/// <param name="type">Specify whether <paramref name="categories" /> are included in or excluded from the filter.</param>
 		public MKPointOfInterestFilter (MKPointOfInterestCategory [] categories, MKPointOfInterestFilterType type)
+			: base (NSObjectFlag.Empty)
 		{
 			// two different `init*` would share the same C# signature
 			switch (type) {
 			case MKPointOfInterestFilterType.Including:
-				InitializeHandle (InitIncludingCategories (categories));
+				InitializeHandle (_InitIncludingCategories (categories), "initExcludingCategories:");
 				break;
 			case MKPointOfInterestFilterType.Excluding:
-				InitializeHandle (InitExcludingCategories (categories));
+				InitializeHandle (_InitExcludingCategories (categories), "initIncludingCategories:");
 				break;
 			default:
 				throw new ArgumentException (nameof (type));
@@ -32,4 +42,3 @@ namespace MapKit {
 		}
 	}
 }
-#endif

--- a/src/mapkit.cs
+++ b/src/mapkit.cs
@@ -2355,11 +2355,11 @@ namespace MapKit {
 
 		[Internal]
 		[Export ("initIncludingCategories:")]
-		IntPtr InitIncludingCategories ([BindAs (typeof (MKPointOfInterestCategory []))] NSString [] categories);
+		IntPtr _InitIncludingCategories ([BindAs (typeof (MKPointOfInterestCategory []))] NSString [] categories);
 
 		[Internal]
 		[Export ("initExcludingCategories:")]
-		IntPtr InitExcludingCategories ([BindAs (typeof (MKPointOfInterestCategory []))] NSString [] categories);
+		IntPtr _InitExcludingCategories ([BindAs (typeof (MKPointOfInterestCategory []))] NSString [] categories);
 
 		[Export ("includesCategory:")]
 		bool IncludesCategory ([BindAs (typeof (MKPointOfInterestCategory))] NSString category);

--- a/tests/cecil-tests/ConstructorTest.KnownFailures.cs
+++ b/tests/cecil-tests/ConstructorTest.KnownFailures.cs
@@ -48,7 +48,6 @@ namespace Cecil.Tests {
 			"HomeKit.HMMatterTopology::.ctor(Foundation.NSObjectFlag)",
 			"HomeKit.HMMatterTopology::.ctor(HomeKit.HMMatterHome[])",
 			"HomeKit.HMMatterTopology::.ctor(ObjCRuntime.NativeHandle)",
-			"MapKit.MKPointOfInterestFilter::.ctor(MapKit.MKPointOfInterestCategory[],MapKit.MKPointOfInterestFilterType)",
 			"ModelIO.MDLMesh::.ctor(ModelIO.MDLMesh,System.Int32,System.UInt32,ModelIO.IMDLMeshBufferAllocator)",
 			"ModelIO.MDLMesh::.ctor(System.Numerics.Vector3,CoreGraphics.NVector2i,ModelIO.MDLGeometryType,ModelIO.IMDLMeshBufferAllocator)",
 			"ModelIO.MDLMesh::.ctor(System.Numerics.Vector3,CoreGraphics.NVector2i,System.Boolean,ModelIO.MDLGeometryType,ModelIO.IMDLMeshBufferAllocator,System.Nullable`1<System.Int32>,System.Nullable`1<System.Boolean>,System.Nullable`1<System.Boolean>)",

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -4567,8 +4567,6 @@ F:MapKit.MKPointOfInterestCategory.University
 F:MapKit.MKPointOfInterestCategory.Volleyball
 F:MapKit.MKPointOfInterestCategory.Winery
 F:MapKit.MKPointOfInterestCategory.Zoo
-F:MapKit.MKPointOfInterestFilterType.Excluding
-F:MapKit.MKPointOfInterestFilterType.Including
 F:MapKit.MKStandardMapEmphasisStyle.Default
 F:MapKit.MKStandardMapEmphasisStyle.Muted
 F:MediaExtension.MEDecodeFrameStatus.FrameDropped
@@ -17398,8 +17396,6 @@ M:MapKit.MKPitchControl.Dispose(System.Boolean)
 M:MapKit.MKPitchControl.MKPitchControlAppearance.#ctor(System.IntPtr)
 M:MapKit.MKPlacemark.#ctor(CoreLocation.CLLocationCoordinate2D,MapKit.MKPlacemarkAddress)
 M:MapKit.MKPlacemark.Copy(Foundation.NSZone)
-M:MapKit.MKPointOfInterestFilter.#ctor(MapKit.MKPointOfInterestCategory[],MapKit.MKPointOfInterestFilterType)
-M:MapKit.MKPointOfInterestFilter.#ctor(MapKit.MKPointOfInterestCategory[])
 M:MapKit.MKPointOfInterestFilter.Copy(Foundation.NSZone)
 M:MapKit.MKPolygonView.#ctor(CoreGraphics.CGRect)
 M:MapKit.MKPolygonView.MKPolygonViewAppearance.#ctor(System.IntPtr)
@@ -40631,7 +40627,6 @@ T:MapKit.MKMapViewOverlay
 T:MapKit.MKOverlay
 T:MapKit.MKOverlayLevel
 T:MapKit.MKPointOfInterestCategory
-T:MapKit.MKPointOfInterestFilterType
 T:MapKit.MKRendererForOverlayDelegate
 T:MapKit.MKScaleViewAlignment
 T:MapKit.MKSearchCompletionFilterType

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -1365,9 +1365,6 @@ namespace Introspection {
 			case "initWithSSID:passphrase:isWEP:":
 			case "initWithSSIDPrefix:":
 			case "initWithSSIDPrefix:passphrase:isWEP:":
-			// MapKit
-			case "initExcludingCategories:":
-			case "initIncludingCategories:":
 				var mi = m as MethodInfo;
 				return mi is not null && !mi.IsPublic && (mi.ReturnType.Name == "IntPtr" || mi.ReturnType.Name == "NativeHandle");
 			// NSAppleEventDescriptor


### PR DESCRIPTION
Improve and simplify the manually bound constructors for MKPointOfInterestFilter by
using the same pattern we use elsewhere for manually bound constructors.