### PR TITLE
[Foundation] Improve and simplify the manually bound constructors for NSUrlProtectionSpace slightly.

### DIFF
--- a/src/Foundation/NSUrlProtectionSpace.cs
+++ b/src/Foundation/NSUrlProtectionSpace.cs
@@ -38,7 +38,7 @@ namespace Foundation {
 				InitializeHandle (_Init (host, port, protocol, realm, authenticationMethod), "initWithHost:port:protocol:realm:authenticationMethod:");
 		}
 
-// Disable until we get around to enable + fix any issues.
+		// Disable until we get around to enable + fix any issues.
 #nullable disable
 		/// <summary>To be added.</summary>
 		///         <value>To be added.</value>

--- a/src/Foundation/NSUrlProtectionSpace.cs
+++ b/src/Foundation/NSUrlProtectionSpace.cs
@@ -5,43 +5,41 @@ using System;
 using ObjCRuntime;
 using Security;
 
-// Disable until we get around to enable + fix any issues.
-#nullable disable
+#nullable enable
 
 namespace Foundation {
 
 	public partial class NSUrlProtectionSpace {
-
-		/// <param name="host">To be added.</param>
-		///         <param name="port">To be added.</param>
-		///         <param name="protocol">To be added.</param>
-		///         <param name="realm">To be added.</param>
-		///         <param name="authenticationMethod">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
-		public NSUrlProtectionSpace (string host, int port, string protocol, string realm, string authenticationMethod)
-			: base (NSObjectFlag.Empty)
+		/// <summary>Create a new <see cref="NSUrlProtectionSpace" /> instance.</summary>
+		/// <param name="host">The host for the new <see cref="NSUrlProtectionSpace" /> instance.</param>
+		/// <param name="port">The port for the new <see cref="NSUrlProtectionSpace" /> instance.</param>
+		/// <param name="protocol">The protocol for the new <see cref="NSUrlProtectionSpace" /> instance.</param>
+		/// <param name="realm">The realm for the new <see cref="NSUrlProtectionSpace" /> instance.</param>
+		/// <param name="authenticationMethod">The authentication method for the new <see cref="NSUrlProtectionSpace" /> instance.</param>
+		/// <remarks>This overload does not support proxies.</remarks>
+		public NSUrlProtectionSpace (string host, int port, string? protocol, string? realm, string? authenticationMethod)
+			: this (host, port, protocol, realm, authenticationMethod, false)
 		{
-			Handle = Init (host, port, protocol, realm, authenticationMethod);
 		}
 
-		/// <param name="host">To be added.</param>
-		///         <param name="port">To be added.</param>
-		///         <param name="protocol">To be added.</param>
-		///         <param name="realm">To be added.</param>
-		///         <param name="authenticationMethod">To be added.</param>
-		///         <param name="useProxy">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
-		public NSUrlProtectionSpace (string host, int port, string protocol, string realm, string authenticationMethod, bool useProxy)
+		/// <summary>Create a new <see cref="NSUrlProtectionSpace" /> instance.</summary>
+		/// <param name="host">The host for the new <see cref="NSUrlProtectionSpace" /> instance.</param>
+		/// <param name="port">The port for the new <see cref="NSUrlProtectionSpace" /> instance.</param>
+		/// <param name="protocol">The protocol for the new <see cref="NSUrlProtectionSpace" /> instance.</param>
+		/// <param name="realm">The realm for the new <see cref="NSUrlProtectionSpace" /> instance.</param>
+		/// <param name="authenticationMethod">The authentication method for the new <see cref="NSUrlProtectionSpace" /> instance.</param>
+		/// <param name="useProxy">Whether a proxy is used or not.</param>
+		public NSUrlProtectionSpace (string host, int port, string? protocol, string? realm, string? authenticationMethod, bool useProxy)
 			: base (NSObjectFlag.Empty)
 		{
 			if (useProxy)
-				Handle = InitWithProxy (host, port, protocol, realm, authenticationMethod);
+				InitializeHandle (_InitWithProxy (host, port, protocol, realm, authenticationMethod), "initWithProxyHost:port:type:realm:authenticationMethod:");
 			else
-				Handle = Init (host, port, protocol, realm, authenticationMethod);
+				InitializeHandle (_Init (host, port, protocol, realm, authenticationMethod), "initWithHost:port:protocol:realm:authenticationMethod:");
 		}
 
+// Disable until we get around to enable + fix any issues.
+#nullable disable
 		/// <summary>To be added.</summary>
 		///         <value>To be added.</value>
 		///         <remarks>To be added.</remarks>
@@ -51,5 +49,6 @@ namespace Foundation {
 				return (handle == IntPtr.Zero) ? null : new SecTrust (handle, false);
 			}
 		}
+#nullable restore
 	}
 }

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -10328,11 +10328,11 @@ namespace Foundation {
 
 		[Internal]
 		[Export ("initWithHost:port:protocol:realm:authenticationMethod:")]
-		IntPtr Init (string host, nint port, [NullAllowed] string protocol, [NullAllowed] string realm, [NullAllowed] string authenticationMethod);
+		IntPtr _Init (string host, nint port, [NullAllowed] string protocol, [NullAllowed] string realm, [NullAllowed] string authenticationMethod);
 
 		[Internal]
 		[Export ("initWithProxyHost:port:type:realm:authenticationMethod:")]
-		IntPtr InitWithProxy (string host, nint port, [NullAllowed] string type, [NullAllowed] string realm, [NullAllowed] string authenticationMethod);
+		IntPtr _InitWithProxy (string host, nint port, [NullAllowed] string type, [NullAllowed] string realm, [NullAllowed] string authenticationMethod);
 
 		[Export ("realm")]
 		string Realm { get; }

--- a/tests/cecil-tests/SetHandleTest.KnownFailures.cs
+++ b/tests/cecil-tests/SetHandleTest.KnownFailures.cs
@@ -23,8 +23,6 @@ namespace Cecil.Tests {
 			"Foundation.NSString::.ctor(System.String,System.Int32,System.Int32)",
 			"Foundation.NSString::.ctor(System.String)",
 			"Foundation.NSThread::.ctor(Foundation.NSObject,ObjCRuntime.Selector,Foundation.NSObject)",
-			"Foundation.NSUrlProtectionSpace::.ctor(System.String,System.Int32,System.String,System.String,System.String,System.Boolean)",
-			"Foundation.NSUrlProtectionSpace::.ctor(System.String,System.Int32,System.String,System.String,System.String)",
 			"Foundation.NSUserDefaults::.ctor(System.String,Foundation.NSUserDefaultsType)",
 			"Foundation.NSUuid::.ctor(System.Byte[])",
 			"GameplayKit.GKPath::.ctor(System.Numerics.Vector2[],System.Single,System.Boolean)",

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -1340,9 +1340,6 @@ namespace Introspection {
 			// MPSGraphExecutable
 			case "initWithMPSGraphPackageAtURL:compilationDescriptor:":
 			case "initWithCoreMLPackageAtURL:compilationDescriptor:":
-			// NSUrlProtectionSpace
-			case "initWithHost:port:protocol:realm:authenticationMethod:":
-			case "initWithProxyHost:port:type:realm:authenticationMethod:":
 			// NSUserDefaults
 			case "initWithSuiteName:":
 			case "initWithUser:":


### PR DESCRIPTION
Improve and simplify the manually bound constructors for NSUrlProtectionSpace by
using the same pattern we use elsewhere for manually bound constructors.