### PR TITLE
[Rgen] Update the method for the trampoline return type for the general case

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
@@ -49,7 +49,8 @@ static partial class BindingSyntaxFactory {
 			{ SpecialType: SpecialType.System_Boolean } 
 				=> CastToByte (auxVariableName, typeInfo.Delegate.ReturnType),
 			
-			_ => null
+			// default case, return the value as is
+			_ => IdentifierName (auxVariableName),
 
 		};
 #pragma warning restore format

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -221,7 +221,7 @@ namespace NS {
 	}
 }
 ";
-			
+
 			yield return [
 				voidReturnType,
 				null!

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -208,6 +208,22 @@ namespace NS {
 
 			yield return [
 				intReturnType,
+				"auxVariable"
+			];
+
+			const string voidReturnType = @"
+using System;
+
+namespace NS {
+	public delegate void Callback()
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			
+			yield return [
+				voidReturnType,
 				null!
 			];
 		}


### PR DESCRIPTION


There are two simple cases:

1. void: we return null which will indicate no need to return a value.
2. value or native type: return the aux variable directly.

We updated the default type and added unit tests for both cases.