### PR TITLE
[RGen] Keep track if the element of an array is a INativeObject.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -128,7 +128,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// Returns, if the type is an array, if its elements are a wrapped object from the objc world.
 	/// </summary>
 	public bool ArrayElementTypeIsWrapped { get; init; }
-	
+
 	/// <summary>
 	/// Returns, if the type is an array, if its elements implement the INativeObject interface.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -128,6 +128,11 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// Returns, if the type is an array, if its elements are a wrapped object from the objc world.
 	/// </summary>
 	public bool ArrayElementTypeIsWrapped { get; init; }
+	
+	/// <summary>
+	/// Returns, if the type is an array, if its elements implement the INativeObject interface.
+	/// </summary>
+	public bool ArrayElementIsINativeObject { get; init; }
 
 	readonly bool isNSObject = false;
 
@@ -259,6 +264,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 			IsArray = true;
 			ArrayElementType = arraySymbol.ElementType.SpecialType;
 			ArrayElementTypeIsWrapped = arraySymbol.ElementType.IsWrapped ();
+			ArrayElementIsINativeObject = arraySymbol.ElementType.IsINativeObject ();
 		}
 
 		// try to get the named type symbol to have more educated decisions

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Core.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Core.cs
@@ -504,4 +504,20 @@ static partial class TypeSymbolExtensions {
 		// either we are a NSObject or we are a subclass of it
 		return IsWrapped (symbol, isNSObject);
 	}
+
+	/// <summary>
+	/// Returns if the symbol is a INativeObject or inherits from a INativeObject.
+	/// </summary>
+	/// <param name="symbol">The symbol to check if it is an INativeObject.</param>
+	/// <returns>True if the symbol implement INativeObject or inherits from one, false otherwise.</returns>
+	public static bool IsINativeObject (this ITypeSymbol symbol)
+	{
+		symbol.GetInheritance (
+			isNSObject: out bool _,
+			isNativeObject: out bool isNativeObject,
+			isDictionaryContainer: out bool _,
+			parents: out ImmutableArray<string> _,
+			interfaces: out ImmutableArray<string> _);
+		return isNativeObject;
+	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Core.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Core.cs
@@ -506,7 +506,7 @@ static partial class TypeSymbolExtensions {
 	}
 
 	/// <summary>
-	/// Returns if the symbol is a INativeObject or inherits from a INativeObject.
+	/// Returns if the symbol is an INativeObject or inherits from an INativeObject.
 	/// </summary>
 	/// <param name="symbol">The symbol to check if it is an INativeObject.</param>
 	/// <returns>True if the symbol implement INativeObject or inherits from one, false otherwise.</returns>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/TypeSymbolExtensionsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/TypeSymbolExtensionsTests.cs
@@ -1859,5 +1859,162 @@ public partial class MyClass {
 		Assert.NotNull (symbol);
 		Assert.Equal (expectedResult, symbol.Type.IsWrapped ());
 	}
+	
+	class TestDataIsINativeObject : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			const string stringProperty = @"
+using System;
+using ObjCBindings;
+
+namespace NS;
+
+[BindingType<Class>]
+public partial class MyClass {
+	public string Property { get; set; }
+}
+";
+			yield return [stringProperty, false];
+
+			const string nsUuidProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS;
+
+[BindingType<Class>]
+public partial class MyClass {
+	public NSUuid Property { get; set; }
+}
+";
+			yield return [nsUuidProperty, true];
+
+			const string nmatrix4Property = @"
+using System;
+using CoreGraphics;
+using ObjCBindings;
+
+namespace NS;
+
+[BindingType<Class>]
+public partial class MyClass {
+	public NMatrix4 Property { get; set; }
+}
+";
+
+			yield return [nmatrix4Property, false];
+
+			const string nativeHandleProperty = @"
+using System;
+using ObjCRuntime;
+using ObjCBindings;
+
+namespace NS;
+
+[BindingType<Class>]
+public partial class MyClass {
+	public NativeHandle Property { get; set; }
+}
+";
+			yield return [nativeHandleProperty, false];
+
+			const string nsZoneProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS;
+
+[BindingType<Class>]
+public partial class MyClass {
+	public NSZone Property { get; set; }
+}
+";
+			yield return [nsZoneProperty, true];
+
+			const string nsobjectProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS;
+
+[BindingType<Class>]
+public partial class MyClass {
+	public NSObject Property { get; set; }
+}
+";
+			yield return [nsobjectProperty, true];
+
+			const string nssetProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS;
+
+[BindingType<Class>]
+public partial class MyClass {
+	public NSSet<NSObject> Property { get; set; }
+}
+";
+			yield return [nssetProperty, true];
+
+
+			const string mtlDeviceProperty = @"
+using System;
+using Metal;
+using ObjCBindings;
+
+namespace NS;
+
+[BindingType<Class>]
+public partial class MyClass {
+	public IMTLDevice Property { get; set; }
+}
+";
+			yield return [mtlDeviceProperty, true];
+
+			const string EnumProperty = @"
+using System;
+using System.Runtime.InteropServices;
+using ObjCBindings;
+
+namespace NS;
+
+public enum MyEnum : ulong {
+	First,
+	Second,
+}
+
+[BindingType<Class>]
+public partial class MyClass {
+	public MyEnum Property { get; set; }
+}
+";
+			yield return [EnumProperty, false];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataIsINativeObject>]
+	void IsINativeObjectTests (ApplePlatform platform, string inputText, bool expectedResult)
+	{
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
+		Assert.Single (syntaxTrees);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ()
+			.OfType<PropertyDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		Assert.NotNull (semanticModel);
+		var symbol = semanticModel.GetDeclaredSymbol (declaration);
+		Assert.NotNull (symbol);
+		Assert.Equal (expectedResult, symbol.Type.IsINativeObject ());
+	}
 
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/TypeSymbolExtensionsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/TypeSymbolExtensionsTests.cs
@@ -1859,7 +1859,7 @@ public partial class MyClass {
 		Assert.NotNull (symbol);
 		Assert.Equal (expectedResult, symbol.Type.IsWrapped ());
 	}
-	
+
 	class TestDataIsINativeObject : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -1998,7 +1998,7 @@ public partial class MyClass {
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
-	
+
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataIsINativeObject>]
 	void IsINativeObjectTests (ApplePlatform platform, string inputText, bool expectedResult)


### PR DESCRIPTION
This is needed for trampolines that are dealing with INativeObjects that are not inheriting from NSObject.