### PR TITLE
[RGen] Add factory methods for NSArray.FromHandle

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Property.cs
@@ -105,7 +105,7 @@ static partial class BindingSyntaxFactory {
 				
 				// NSObject[] => CFArray.ArrayFromHandle<Foundation.NSMetadataItem> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, Selector.GetHandle ("results")))!;
 				{ ReturnType.IsArray: true, ReturnType.ArrayElementTypeIsWrapped: true } => 
-					GetNSArrayFromHandle (property.ReturnType.FullyQualifiedName, [Argument (objMsgSend)], suppressNullableWarning: !property.ReturnType.IsNullable),
+					GetCFArrayFromHandle (property.ReturnType.FullyQualifiedName, [Argument (objMsgSend)], suppressNullableWarning: !property.ReturnType.IsNullable),
 				
 				// Runtime.GetNSObject<Foundation.NSObject> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, Selector.GetHandle ("delegate")));
 				{ ReturnType.IsArray: false, ReturnType.IsNSObject: true } => 

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -52,11 +52,26 @@ static partial class BindingSyntaxFactory {
 	/// <param name="args">The arguments to bass to the ArrayFromHandle method.</param>
 	/// <param name="suppressNullableWarning">If we should suppress the nullable warning.</param>
 	/// <returns>The expression that calls ArrayFromHandle method.</returns>
-	public static ExpressionSyntax GetNSArrayFromHandle (string nsObjectType, ImmutableArray<ArgumentSyntax> args,
+	public static ExpressionSyntax GetCFArrayFromHandle (string nsObjectType, ImmutableArray<ArgumentSyntax> args,
 		bool suppressNullableWarning = false)
 	{
 		var argsList = ArgumentList (SeparatedList<ArgumentSyntax> (args.ToSyntaxNodeOrTokenArray ()));
 		return StaticInvocationGenericExpression ("CFArray", "ArrayFromHandle",
+			nsObjectType, argsList, suppressNullableWarning);
+	}
+	
+	/// <summary>
+	/// Generates a call to the method NSArray.ArrayFromHandle&lt;T&gt; to create a collection of NSObjects.
+	/// </summary>
+	/// <param name="nsObjectType">The type of the object to use as T</param>
+	/// <param name="args">The arguments to bass to the ArrayFromHandle method.</param>
+	/// <param name="suppressNullableWarning">If we should suppress the nullable warning.</param>
+	/// <returns>The expression that calls ArrayFromHandle method.</returns>
+	public static ExpressionSyntax GetNSArrayFromHandle (string nsObjectType, ImmutableArray<ArgumentSyntax> args,
+		bool suppressNullableWarning = false)
+	{
+		var argsList = ArgumentList (SeparatedList<ArgumentSyntax> (args.ToSyntaxNodeOrTokenArray ()));
+		return StaticInvocationGenericExpression ("NSArray", "ArrayFromHandle",
 			nsObjectType, argsList, suppressNullableWarning);
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -765,5 +765,69 @@ public class BindingSyntaxFactoryRuntimeTests {
 		var declaration = RetainAndAutoreleaseNativeObject (arguments);
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
 	}
+	
+	class TestDataGetCFArrayFromHandle : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			yield return [
+				"NSObject",
+				ImmutableArray.Create (
+					Argument (IdentifierName ("arg1"))),
+				"CFArray.ArrayFromHandle<NSObject> (arg1)",
+			];
+
+			yield return [
+				"NSString",
+				ImmutableArray.Create (
+					Argument (IdentifierName ("arg1")),
+					Argument (IdentifierName ("arg2")),
+					Argument (IdentifierName ("arg3"))
+				),
+				"CFArray.ArrayFromHandle<NSString> (arg1, arg2, arg3)",
+			];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	
+	[Theory]
+	[ClassData (typeof (TestDataGetCFArrayFromHandle))]
+	void GetCFArrayFromHandleTests (string objectType, ImmutableArray<ArgumentSyntax> arguments, string expectedDeclaration)
+	{
+		var declaration = GetCFArrayFromHandle (objectType, arguments);
+		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
+	}
+	
+	class TestDataGetNSArrayFromHandle : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			yield return [
+				"NSObject",
+				ImmutableArray.Create (
+					Argument (IdentifierName ("arg1"))),
+				"NSArray.ArrayFromHandle<NSObject> (arg1)",
+			];
+
+			yield return [
+				"NSString",
+				ImmutableArray.Create (
+					Argument (IdentifierName ("arg1")),
+					Argument (IdentifierName ("arg2")),
+					Argument (IdentifierName ("arg3"))
+				),
+				"NSArray.ArrayFromHandle<NSString> (arg1, arg2, arg3)",
+			];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	
+	[Theory]
+	[ClassData (typeof (TestDataGetNSArrayFromHandle))]
+	void GetNSArrayFromHandleTests (string objectType, ImmutableArray<ArgumentSyntax> arguments, string expectedDeclaration)
+	{
+		var declaration = GetNSArrayFromHandle (objectType, arguments);
+		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
+	}
 
 }


### PR DESCRIPTION
We need to provide both versions, CFArray.FromHandle<T> and NSArray.FromHandle<T>.

In this PR:

1. Renamed the old version to match what it generates.
2. Add new method.
3. Provide tests for both methods.