### PR TITLE
[RGen] Indicate if a symbol represents a pointer.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -169,7 +169,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// If the parameter is a delegate. The method information of the invoke.
 	/// </summary>
 	public DelegateInfo? Delegate { get; init; } = null;
-	
+
 	/// <summary>
 	/// If the type is a pointer type.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -169,6 +169,11 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// If the parameter is a delegate. The method information of the invoke.
 	/// </summary>
 	public DelegateInfo? Delegate { get; init; } = null;
+	
+	/// <summary>
+	/// If the type is a pointer type.
+	/// </summary>
+	public bool IsPointer { get; init; }
 
 	/// <summary>
 	/// True if the symbol represents a generic type.
@@ -242,6 +247,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		IsStruct = symbol.TypeKind == TypeKind.Struct;
 		IsInterface = symbol.TypeKind == TypeKind.Interface;
 		IsDelegate = symbol.TypeKind == TypeKind.Delegate;
+		IsPointer = symbol is IPointerTypeSymbol;
 		IsNativeIntegerType = symbol.IsNativeIntegerType;
 		IsNativeEnum = symbol.HasAttribute (AttributesNames.NativeAttribute);
 		IsProtocol = symbol.HasAttribute (AttributesNames.ProtocolAttribute);

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Generator.cs
@@ -192,7 +192,7 @@ static partial class TypeSymbolExtensions {
 		// pointers do not need stret
 		if (returnType is IPointerTypeSymbol)
 			return false;
-		
+
 		if (X86NeedStret (returnType))
 			return true;
 

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Generator.cs
@@ -189,6 +189,10 @@ static partial class TypeSymbolExtensions {
 	/// <returns>If the type represented by the symtol needs a stret call variant.</returns>
 	public static bool NeedsStret (this ITypeSymbol returnType, Compilation compilation)
 	{
+		// pointers do not need stret
+		if (returnType is IPointerTypeSymbol)
+			return false;
+		
 		if (X86NeedStret (returnType))
 			return true;
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/TypeInfoTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/TypeInfoTests.cs
@@ -417,7 +417,7 @@ namespace NS {
 	public class MyClass {
 		public unsafe void ProcessPointer (int* pointer)
 		{
-			if (pointer == null)
+			if (pointer is null)
 			{
 				return;
 			}
@@ -440,6 +440,6 @@ namespace NS {
 		// ensure that the method has a single parameter
 		Assert.Single (changes.Value.Parameters);
 		// ensure that the first parameter is a pointer
-		Assert.True (changes.Value.Parameters[0].Type.IsPointer);
+		Assert.True (changes.Value.Parameters [0].Type.IsPointer);
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/TypeInfoTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/TypeInfoTests.cs
@@ -403,4 +403,43 @@ namespace NS {
 		Assert.NotNull (changes);
 		Assert.Equal (expected, changes);
 	}
+
+	[Theory]
+	[AllSupportedPlatforms]
+	void TypeInfoIsPointer (ApplePlatform platform)
+	{
+		var inputText = @"
+using System;
+using ObjCRuntime;
+using System.Collections.Generic;
+
+namespace NS {
+	public class MyClass {
+		public unsafe void ProcessPointer (int* pointer)
+		{
+			if (pointer == null)
+			{
+				return;
+			}
+
+			// Modify the value at the pointer
+			*pointer += 10;
+		}
+	}
+}
+";
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
+		Assert.Single (syntaxTrees);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ().OfType<MethodDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		Assert.True (Method.TryCreate (declaration, semanticModel, out var changes));
+		Assert.NotNull (changes);
+		// ensure that the method has a single parameter
+		Assert.Single (changes.Value.Parameters);
+		// ensure that the first parameter is a pointer
+		Assert.True (changes.Value.Parameters[0].Type.IsPointer);
+	}
 }


### PR DESCRIPTION
Add an extra property that will let us known during code generation if a symbol represents a pointer. For that:

1. We add a boolean to ensure that the symbol is a pointer symbol.
2. Update the NeedsStret method to account for the fact that some symbols are pointers.
3. Add a new test case.