### PR TITLE
[Rgen] Add a factory for the IdentifierName.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
@@ -193,14 +193,14 @@ static partial class BindingSyntaxFactory {
 	/// <param name="isGlobal">If the global alias qualifier will be used. This will only be used if the namespace
 	/// was provided.</param>
 	/// <returns>The identifier expression for a given class.</returns>
-	internal static ExpressionSyntax GetIdentifierName (string[]? @namespace, string @class, bool isGlobal = false)
+	internal static ExpressionSyntax GetIdentifierName (string []? @namespace, string @class, bool isGlobal = false)
 	{
 		// retrieve the name syntax for the namespace
 		if (@namespace is null) {
 			// if we have no namespace, we do not care about it being global
 			return IdentifierName (@class);
 		}
-		
+
 		var fullNamespace = string.Join (".", @namespace);
 		if (isGlobal) {
 			return MemberAccessExpression (
@@ -208,7 +208,7 @@ static partial class BindingSyntaxFactory {
 				AliasQualifiedName (
 					IdentifierName (
 						Token (SyntaxKind.GlobalKeyword)),
-					IdentifierName(fullNamespace)),
+					IdentifierName (fullNamespace)),
 				IdentifierName (@class));
 		}
 
@@ -216,7 +216,7 @@ static partial class BindingSyntaxFactory {
 			IdentifierName (fullNamespace),
 			IdentifierName (@class));
 	}
-	
+
 	/// <summary>
 	/// Helper method that will return the Identifier name for a class. 
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
@@ -183,4 +183,45 @@ static partial class BindingSyntaxFactory {
 			IdentifierName (variableName).WithTrailingTrivia (Space),
 			value.WithLeadingTrivia (Space));
 	}
+
+	/// <summary>
+	/// Returns the expression required for an identifier name. The method will add the namespace and global qualifier
+	/// if needed based on the parameters.
+	/// </summary>
+	/// <param name="namespace">The namespace of the class. This can be null.</param>
+	/// <param name="class">The class name.</param>
+	/// <param name="isGlobal">If the global alias qualifier will be used. This will only be used if the namespace
+	/// was provided.</param>
+	/// <returns>The identifier expression for a given class.</returns>
+	internal static ExpressionSyntax GetIdentifierName (string[]? @namespace, string @class, bool isGlobal = false)
+	{
+		// retrieve the name syntax for the namespace
+		if (@namespace is null) {
+			// if we have no namespace, we do not care about it being global
+			return IdentifierName (@class);
+		}
+		
+		var fullNamespace = string.Join (".", @namespace);
+		if (isGlobal) {
+			return MemberAccessExpression (
+				SyntaxKind.SimpleMemberAccessExpression,
+				AliasQualifiedName (
+					IdentifierName (
+						Token (SyntaxKind.GlobalKeyword)),
+					IdentifierName(fullNamespace)),
+				IdentifierName (@class));
+		}
+
+		return QualifiedName (
+			IdentifierName (fullNamespace),
+			IdentifierName (@class));
+	}
+	
+	/// <summary>
+	/// Helper method that will return the Identifier name for a class. 
+	/// </summary>
+	/// <param name="class">The class whose identifier we want to retrieve.</param>
+	/// <returns>The identifier name expression for a given class.</returns>
+	internal static ExpressionSyntax GetIdentifierName (string @class)
+		=> IdentifierName (@class);
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -829,7 +829,7 @@ public class BindingSyntaxFactoryRuntimeTests {
 		var declaration = GetNSArrayFromHandle (objectType, arguments);
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
 	}
-	
+
 	class TestDataGetIdentifierNameTests : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -840,30 +840,30 @@ public class BindingSyntaxFactoryRuntimeTests {
 				false,
 				"NSObject",
 			];
-			
+
 			yield return [
 				null!,
 				"NSObject",
 				true,
 				"NSObject",
 			];
-			
+
 			// single namespace
 			yield return [
-				new [] {"Foundation"},
+				new [] { "Foundation" },
 				"NSObject",
 				false,
 				"Foundation.NSObject",
 			];
-			
+
 			// global single namespace
 			yield return [
-				new [] {"Foundation"},
+				new [] { "Foundation" },
 				"NSObject",
 				true,
 				"global::Foundation.NSObject",
 			];
-			
+
 			// multiple namespaces
 			yield return [
 				new [] {
@@ -894,7 +894,7 @@ public class BindingSyntaxFactoryRuntimeTests {
 
 	[Theory]
 	[ClassData (typeof (TestDataGetIdentifierNameTests))]
-	void GetIdentifierNameTests (string[]? @namespace, string @class, bool isGlobal, string expectedDeclaration)
+	void GetIdentifierNameTests (string []? @namespace, string @class, bool isGlobal, string expectedDeclaration)
 	{
 		var declaration = GetIdentifierName (@namespace, @class, isGlobal);
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -829,5 +829,75 @@ public class BindingSyntaxFactoryRuntimeTests {
 		var declaration = GetNSArrayFromHandle (objectType, arguments);
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
 	}
+	
+	class TestDataGetIdentifierNameTests : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			// no namespace
+			yield return [
+				null!,
+				"NSObject",
+				false,
+				"NSObject",
+			];
+			
+			yield return [
+				null!,
+				"NSObject",
+				true,
+				"NSObject",
+			];
+			
+			// single namespace
+			yield return [
+				new [] {"Foundation"},
+				"NSObject",
+				false,
+				"Foundation.NSObject",
+			];
+			
+			// global single namespace
+			yield return [
+				new [] {"Foundation"},
+				"NSObject",
+				true,
+				"global::Foundation.NSObject",
+			];
+			
+			// multiple namespaces
+			yield return [
+				new [] {
+					"System",
+					"Runtime",
+					"CompilerServices",
+				},
+				"Unsafe",
+				false,
+				"System.Runtime.CompilerServices.Unsafe"
+			];
+
+			// global multiple namespaces
+			yield return [
+				new [] {
+					"System",
+					"Runtime",
+					"CompilerServices",
+				},
+				"Unsafe",
+				true,
+				"global::System.Runtime.CompilerServices.Unsafe"
+			];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[ClassData (typeof (TestDataGetIdentifierNameTests))]
+	void GetIdentifierNameTests (string[]? @namespace, string @class, bool isGlobal, string expectedDeclaration)
+	{
+		var declaration = GetIdentifierName (@namespace, @class, isGlobal);
+		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
+	}
 
 }


### PR DESCRIPTION
This will later allow the code to use "global::" by a single switch. This change just adds the method, we will update the other methods accordingly in later PRs.