### PR TITLE
[RGen] Use the global alias for NSValue and NSNumber.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Macios.Generator.Emitters;
 /// Syntax factory for the Dlfcn calls.
 /// </summary>
 static partial class BindingSyntaxFactory {
-	readonly static ExpressionSyntax Dlfcn = GetIdentifierName ("Dlfcn");
+	readonly static TypeSyntax Dlfcn = GetIdentifierName ("Dlfcn");
 
 	/// <summary>
 	/// Get the syntax needed to access a library handle.

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -21,6 +21,14 @@ namespace Microsoft.Macios.Generator.Emitters;
 static partial class BindingSyntaxFactory {
 	readonly static string objc_msgSend = "objc_msgSend";
 	readonly static string objc_msgSendSuper = "objc_msgSendSuper";
+	public static readonly TypeSyntax NSValue = GetIdentifierName (
+		@namespace: ["Foundation"], 
+		@class: "NSValue", 
+		isGlobal: true);
+	public static readonly TypeSyntax NSNumber = GetIdentifierName (
+		@namespace: ["Foundation"], 
+		@class: "NSNumber", 
+		isGlobal: true);
 
 	/// <summary>
 	/// Returns the expression needed to cast a parameter to its native type.
@@ -352,7 +360,7 @@ static partial class BindingSyntaxFactory {
 		var factoryInvocation = InvocationExpression (
 			MemberAccessExpression (
 				SyntaxKind.SimpleMemberAccessExpression,
-				GetIdentifierName ("NSNumber"),
+				NSNumber,
 				IdentifierName (factoryMethod).WithTrailingTrivia (Space))
 		);
 
@@ -441,7 +449,7 @@ static partial class BindingSyntaxFactory {
 		var factoryInvocation = InvocationExpression (
 			MemberAccessExpression (
 				SyntaxKind.SimpleMemberAccessExpression,
-				GetIdentifierName ("NSValue"),
+				NSValue,
 				IdentifierName (factoryMethod).WithTrailingTrivia (Space))
 		).WithArgumentList (ArgumentList (SingletonSeparatedList (
 			Argument (IdentifierName (parameter.Name)))));
@@ -501,11 +509,11 @@ static partial class BindingSyntaxFactory {
 		// use a switch to decide which of the constructors we are going to use to build the array.
 		var lambdaFunctionVariable = "obj";
 		var nsNumberExpr = ObjectCreationExpression (
-				IdentifierName ("NSNumber").WithLeadingTrivia (Space).WithTrailingTrivia (Space))
+				NSNumber.WithLeadingTrivia (Space).WithTrailingTrivia (Space))
 			.WithArgumentList (ArgumentList (SingletonSeparatedList (
 				Argument (IdentifierName (lambdaFunctionVariable)))));
 		var nsValueExpr = ObjectCreationExpression (
-				IdentifierName ("NSValue").WithLeadingTrivia (Space).WithTrailingTrivia (Space))
+				NSValue.WithLeadingTrivia (Space).WithTrailingTrivia (Space))
 			.WithArgumentList (ArgumentList (SingletonSeparatedList (
 				Argument (IdentifierName (lambdaFunctionVariable)))));
 		var smartEnumExpr = InvocationExpression (MemberAccessExpression (

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -22,12 +22,12 @@ static partial class BindingSyntaxFactory {
 	readonly static string objc_msgSend = "objc_msgSend";
 	readonly static string objc_msgSendSuper = "objc_msgSendSuper";
 	public static readonly TypeSyntax NSValue = GetIdentifierName (
-		@namespace: ["Foundation"], 
-		@class: "NSValue", 
+		@namespace: ["Foundation"],
+		@class: "NSValue",
 		isGlobal: true);
 	public static readonly TypeSyntax NSNumber = GetIdentifierName (
-		@namespace: ["Foundation"], 
-		@class: "NSNumber", 
+		@namespace: ["Foundation"],
+		@class: "NSNumber",
 		isGlobal: true);
 
 	/// <summary>

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -12,7 +12,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 namespace Microsoft.Macios.Generator.Emitters;
 
 static partial class BindingSyntaxFactory {
-	public static readonly ExpressionSyntax Runtime = GetIdentifierName ("Runtime");
+	public static readonly TypeSyntax Runtime = GetIdentifierName ("Runtime");
 	public const string ClassPtr = "class_ptr";
 
 	/// <summary>

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
@@ -193,7 +193,7 @@ static partial class BindingSyntaxFactory {
 	/// <param name="isGlobal">If the global alias qualifier will be used. This will only be used if the namespace
 	/// was provided.</param>
 	/// <returns>The identifier expression for a given class.</returns>
-	internal static ExpressionSyntax GetIdentifierName (string []? @namespace, string @class, bool isGlobal = false)
+	internal static TypeSyntax GetIdentifierName (string []? @namespace, string @class, bool isGlobal = false)
 	{
 		// retrieve the name syntax for the namespace
 		if (@namespace is null) {
@@ -203,8 +203,7 @@ static partial class BindingSyntaxFactory {
 
 		var fullNamespace = string.Join (".", @namespace);
 		if (isGlobal) {
-			return MemberAccessExpression (
-				SyntaxKind.SimpleMemberAccessExpression,
+			return QualifiedName (
 				AliasQualifiedName (
 					IdentifierName (
 						Token (SyntaxKind.GlobalKeyword)),
@@ -222,6 +221,6 @@ static partial class BindingSyntaxFactory {
 	/// </summary>
 	/// <param name="class">The class whose identifier we want to retrieve.</param>
 	/// <returns>The identifier name expression for a given class.</returns>
-	internal static ExpressionSyntax GetIdentifierName (string @class)
+	internal static TypeSyntax GetIdentifierName (string @class)
 		=> IdentifierName (@class);
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
@@ -335,52 +335,52 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 		{
 			yield return [
 				new Parameter (0, ReturnTypeForInt (), "myParam"),
-				"var nsb_myParam = NSNumber.FromInt32 (myParam);"
+				"var nsb_myParam = global::Foundation.NSNumber.FromInt32 (myParam);"
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForInt (isUnsigned: true), "myParam"),
-				"var nsb_myParam = NSNumber.FromUInt32 (myParam);"
+				"var nsb_myParam = global::Foundation.NSNumber.FromUInt32 (myParam);"
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForBool (), "myParam"),
-				"var nsb_myParam = NSNumber.FromBoolean (myParam);"
+				"var nsb_myParam = global::Foundation.NSNumber.FromBoolean (myParam);"
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForEnum ("MyEnum"), "myParam"),
-				"var nsb_myParam = NSNumber.FromInt32 ((int) myParam);",
+				"var nsb_myParam = global::Foundation.NSNumber.FromInt32 ((int) myParam);",
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_Byte), "myParam"),
-				"var nsb_myParam = NSNumber.FromByte ((byte) myParam);",
+				"var nsb_myParam = global::Foundation.NSNumber.FromByte ((byte) myParam);",
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_SByte), "myParam"),
-				"var nsb_myParam = NSNumber.FromSByte ((sbyte) myParam);",
+				"var nsb_myParam = global::Foundation.NSNumber.FromSByte ((sbyte) myParam);",
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_Int16), "myParam"),
-				"var nsb_myParam = NSNumber.FromInt16 ((short) myParam);",
+				"var nsb_myParam = global::Foundation.NSNumber.FromInt16 ((short) myParam);",
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_UInt16), "myParam"),
-				"var nsb_myParam = NSNumber.FromUInt16 ((ushort) myParam);",
+				"var nsb_myParam = global::Foundation.NSNumber.FromUInt16 ((ushort) myParam);",
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_Int64), "myParam"),
-				"var nsb_myParam = NSNumber.FromInt64 ((long) myParam);",
+				"var nsb_myParam = global::Foundation.NSNumber.FromInt64 ((long) myParam);",
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_UInt64), "myParam"),
-				"var nsb_myParam = NSNumber.FromUInt64 ((ulong) myParam);",
+				"var nsb_myParam = global::Foundation.NSNumber.FromUInt64 ((ulong) myParam);",
 			];
 		}
 
@@ -405,85 +405,85 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 		{
 			yield return [
 				new Parameter (0, ReturnTypeForStruct ("CoreGraphics.CGAffineTransform"), "myParam"),
-				"var nsb_myParam = NSValue.FromCGAffineTransform (myParam);"
+				"var nsb_myParam = global::Foundation.NSValue.FromCGAffineTransform (myParam);"
 			];
 			yield return [
 				new Parameter (0, ReturnTypeForStruct ("Foundation.NSRange"), "myParam"),
-				"var nsb_myParam = NSValue.FromRange (myParam);"
+				"var nsb_myParam = global::Foundation.NSValue.FromRange (myParam);"
 			];
 			yield return [
 				new Parameter (0, ReturnTypeForStruct ("CoreGraphics.CGVector"), "myParam"),
-				"var nsb_myParam = NSValue.FromCGVector (myParam);"
+				"var nsb_myParam = global::Foundation.NSValue.FromCGVector (myParam);"
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForStruct ("SceneKit.SCNMatrix4"), "myParam"),
-				"var nsb_myParam = NSValue.FromSCNMatrix4 (myParam);",
+				"var nsb_myParam = global::Foundation.NSValue.FromSCNMatrix4 (myParam);",
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForStruct ("CoreLocation.CLLocationCoordinate2D"), "myParam"),
-				"var nsb_myParam = NSValue.FromMKCoordinate (myParam);",
+				"var nsb_myParam = global::Foundation.NSValue.FromMKCoordinate (myParam);",
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForStruct ("SceneKit.SCNVector3"), "myParam"),
-				"var nsb_myParam = NSValue.FromVector (myParam);",
+				"var nsb_myParam = global::Foundation.NSValue.FromVector (myParam);",
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForStruct ("SceneKit.SCNVector4"), "myParam"),
-				"var nsb_myParam = NSValue.FromVector (myParam);",
+				"var nsb_myParam = global::Foundation.NSValue.FromVector (myParam);",
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForStruct ("CoreGraphics.CGPoint"), "myParam"),
-				"var nsb_myParam = NSValue.FromCGPoint (myParam);",
+				"var nsb_myParam = global::Foundation.NSValue.FromCGPoint (myParam);",
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForStruct ("CoreGraphics.CGRect"), "myParam"),
-				"var nsb_myParam = NSValue.FromCGRect (myParam);",
+				"var nsb_myParam = global::Foundation.NSValue.FromCGRect (myParam);",
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForStruct ("CoreGraphics.CGSize"), "myParam"),
-				"var nsb_myParam = NSValue.FromCGSize (myParam);",
+				"var nsb_myParam = global::Foundation.NSValue.FromCGSize (myParam);",
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForStruct ("UIKit.UIEdgeInsets"), "myParam"),
-				"var nsb_myParam = NSValue.FromUIEdgeInsets (myParam);",
+				"var nsb_myParam = global::Foundation.NSValue.FromUIEdgeInsets (myParam);",
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForStruct ("UIKit.UIOffset"), "myParam"),
-				"var nsb_myParam = NSValue.FromUIOffset (myParam);",
+				"var nsb_myParam = global::Foundation.NSValue.FromUIOffset (myParam);",
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForStruct ("MapKit.MKCoordinateSpan"), "myParam"),
-				"var nsb_myParam = NSValue.FromMKCoordinateSpan (myParam);",
+				"var nsb_myParam = global::Foundation.NSValue.FromMKCoordinateSpan (myParam);",
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForStruct ("CoreMedia.CMTimeRange"), "myParam"),
-				"var nsb_myParam = NSValue.FromCMTimeRange (myParam);",
+				"var nsb_myParam = global::Foundation.NSValue.FromCMTimeRange (myParam);",
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForStruct ("CoreMedia.CMTime"), "myParam"),
-				"var nsb_myParam = NSValue.FromCMTime (myParam);",
+				"var nsb_myParam = global::Foundation.NSValue.FromCMTime (myParam);",
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForStruct ("CoreMedia.CMTimeMapping"), "myParam"),
-				"var nsb_myParam = NSValue.FromCMTimeMapping (myParam);",
+				"var nsb_myParam = global::Foundation.NSValue.FromCMTimeMapping (myParam);",
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForStruct ("CoreAnimation.CATransform3D"), "myParam"),
-				"var nsb_myParam = NSValue.FromCATransform3D (myParam);",
+				"var nsb_myParam = global::Foundation.NSValue.FromCATransform3D (myParam);",
 			];
 		}
 
@@ -544,7 +544,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 					name: "myParam") {
 					BindAs = new (ReturnTypeForNSObject ("Foundation.NSNumber")),
 				},
-				"var nsb_myParam = NSArray.FromNSObjects (obj => new NSNumber (obj), myParam);"
+				"var nsb_myParam = NSArray.FromNSObjects (obj => new global::Foundation.NSNumber (obj), myParam);"
 			];
 
 			// nsvalue
@@ -555,7 +555,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 					name: "myParam") {
 					BindAs = new (ReturnTypeForNSObject ("Foundation.NSValue")),
 				},
-				"var nsb_myParam = NSArray.FromNSObjects (obj => new NSValue (obj), myParam);"
+				"var nsb_myParam = NSArray.FromNSObjects (obj => new global::Foundation.NSValue (obj), myParam);"
 			];
 
 			// smart enum
@@ -597,7 +597,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 					name: "myParam") {
 					BindAs = new (ReturnTypeForNSObject ("Foundation.NSNumber")),
 				},
-				"var nsb_myParam = NSNumber.FromUInt64 ((ulong) myParam);",
+				"var nsb_myParam = global::Foundation.NSNumber.FromUInt64 ((ulong) myParam);",
 			];
 
 			yield return [
@@ -607,7 +607,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 					name: "myParam") {
 					BindAs = new (ReturnTypeForNSObject ("Foundation.NSNumber")),
 				},
-				"var nsb_myParam = NSArray.FromNSObjects (obj => new NSNumber (obj), myParam);"
+				"var nsb_myParam = NSArray.FromNSObjects (obj => new global::Foundation.NSNumber (obj), myParam);"
 			];
 
 			// nsvalue	
@@ -618,7 +618,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 					name: "myParam") {
 					BindAs = new (ReturnTypeForNSObject ("Foundation.NSValue")),
 				},
-				"var nsb_myParam = NSValue.FromCATransform3D (myParam);",
+				"var nsb_myParam = global::Foundation.NSValue.FromCATransform3D (myParam);",
 			];
 
 			yield return [
@@ -628,7 +628,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 					name: "myParam") {
 					BindAs = new (ReturnTypeForNSObject ("Foundation.NSValue")),
 				},
-				"var nsb_myParam = NSArray.FromNSObjects (obj => new NSValue (obj), myParam);"
+				"var nsb_myParam = NSArray.FromNSObjects (obj => new global::Foundation.NSValue (obj), myParam);"
 			];
 
 			// smart enum
@@ -730,7 +730,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 
 			yield return [
 				GetBindFromAuxVariable (parameter)!,
-				"using var nsb_myParam = NSNumber.FromUInt64 ((ulong) myParam);",
+				"using var nsb_myParam = global::Foundation.NSNumber.FromUInt64 ((ulong) myParam);",
 			];
 
 			parameter = new (
@@ -742,7 +742,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 
 			yield return [
 				GetBindFromAuxVariable (parameter)!,
-				"using var nsb_myParam = NSArray.FromNSObjects (obj => new NSNumber (obj), myParam);",
+				"using var nsb_myParam = NSArray.FromNSObjects (obj => new global::Foundation.NSNumber (obj), myParam);",
 			];
 
 			parameter = new (
@@ -754,7 +754,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 
 			yield return [
 				GetBindFromAuxVariable (parameter)!,
-				"using var nsb_myParam = NSValue.FromCATransform3D (myParam);",
+				"using var nsb_myParam = global::Foundation.NSValue.FromCATransform3D (myParam);",
 			];
 
 			parameter = new (
@@ -766,7 +766,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 
 			yield return [
 				GetBindFromAuxVariable (parameter)!,
-				"using var nsb_myParam = NSArray.FromNSObjects (obj => new NSValue (obj), myParam);",
+				"using var nsb_myParam = NSArray.FromNSObjects (obj => new global::Foundation.NSValue (obj), myParam);",
 			];
 
 			parameter = new (


### PR DESCRIPTION
This way we reduce the possible collisions with the user namespaces.