### PR TITLE
[RGen] Add number of indexes to be able to use them to retrieve members.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Binding.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Binding.cs
@@ -108,6 +108,7 @@ readonly partial struct Binding {
 		}
 	}
 
+	readonly Dictionary<string, int> enumIndex = new ();
 	readonly ImmutableArray<EnumMember> enumMembers = [];
 
 	/// <summary>
@@ -115,9 +116,24 @@ readonly partial struct Binding {
 	/// </summary>
 	public ImmutableArray<EnumMember> EnumMembers {
 		get => enumMembers;
-		init => enumMembers = value;
+		init {
+			enumMembers = value;
+			// populate the enum index for fast lookup using the symbol name
+			for (var index = 0; index < enumMembers.Length; index++) {
+				var member = enumMembers[index];
+				if (member.Selector is null)
+					continue;
+				enumIndex[member.Selector] = index;
+			}
+		}
 	}
 
+	/// <summary>
+	/// Returns all the selectors for the enum members.
+	/// </summary>
+	public ImmutableArray<string> EnumMemberSelectors => [..enumIndex.Keys];
+
+	readonly Dictionary<string, int> propertyIndex = new ();
 	readonly ImmutableArray<Property> properties = [];
 
 	/// <summary>
@@ -125,9 +141,25 @@ readonly partial struct Binding {
 	/// </summary>
 	public ImmutableArray<Property> Properties {
 		get => properties;
-		init => properties = value;
+		init {
+			properties = value;
+			// populate the property index for fast lookup using the symbol name
+			for (var index = 0; index < properties.Length; index++) {
+				var property = properties[index];
+				// there are two type of properties, those that are fields and those that are properties
+				if (property.Selector is null)
+					continue;
+				propertyIndex [property.Selector!] = index;
+			}
+		}
 	}
 
+	/// <summary>
+	/// Return sall the selectors for the properties.
+	/// </summary>
+	public ImmutableArray<string> PropertySelectors => [..propertyIndex.Keys];
+
+	readonly Dictionary<string, int> constructorIndex = new ();
 	readonly ImmutableArray<Constructor> constructors = [];
 
 	/// <summary>
@@ -135,9 +167,24 @@ readonly partial struct Binding {
 	/// </summary>
 	public ImmutableArray<Constructor> Constructors {
 		get => constructors;
-		init => constructors = value;
+		init {
+			constructors = value;
+			// populate the constructor index for fast lookup using the symbol name
+			for (var index = 0; index < constructors.Length; index++) {
+				var constructor = constructors[index];
+				if (constructor.Selector is null)
+					continue;
+				constructorIndex [constructor.Selector] = index;
+			}
+		}
 	}
 
+	/// <summary>
+	/// Returns all the selectors for the constructors.
+	/// </summary>
+	public ImmutableArray<string> ConstructorSelectors => [..constructorIndex.Keys];
+
+	readonly Dictionary<string, int> eventsIndex = new ();
 	readonly ImmutableArray<Event> events = [];
 
 	/// <summary>
@@ -145,9 +192,22 @@ readonly partial struct Binding {
 	/// </summary>
 	public ImmutableArray<Event> Events {
 		get => events;
-		init => events = value;
+		init {
+			events = value;
+			// populate the event index for fast lookup using the symbol name
+			for (var index = 0; index < events.Length; index++) {
+				var eventItem = events[index];
+				eventsIndex [eventItem.Name] = index;
+			}
+		}
 	}
 
+	/// <summary>
+	/// Returns all the selectors for the events.
+	/// </summary>
+	public ImmutableArray<string> EventSelectors => [..eventsIndex.Keys];
+
+	readonly Dictionary<string, int> methodIndex = new ();
 	readonly ImmutableArray<Method> methods = [];
 
 	/// <summary>
@@ -155,8 +215,22 @@ readonly partial struct Binding {
 	/// </summary>
 	public ImmutableArray<Method> Methods {
 		get => methods;
-		init => methods = value;
+		init {
+			methods = value;
+			// populate the method index for fast lookup using the symbol name
+			for (var index = 0; index < methods.Length; index++) {
+				var method = methods[index];
+				if (method.Selector is null)
+					continue;
+				methodIndex [method.Selector] = index;
+			}
+		}
 	}
+
+	/// <summary>
+	/// Returns all the selectors for the methods.
+	/// </summary>
+	public ImmutableArray<string> MethodSelectors => [..methodIndex.Keys];
 
 	delegate bool SkipDelegate<in T> (T declarationSyntax, SemanticModel semanticModel);
 
@@ -181,4 +255,61 @@ readonly partial struct Binding {
 
 		members = bucket.ToImmutable ();
 	}
+
+	static bool TryGetFromIndex<T> (string selector, ImmutableArray<T> collection, Dictionary<string, int> index, [NotNullWhen (true)]out T? value)
+		where T : struct
+	{
+		if (index.TryGetValue (selector, out var indexValue)) {
+			value = collection [indexValue];
+			return true;
+		}
+
+		value = null;
+		return false;
+	}
+
+	/// <summary>
+	/// Get the enum member that matches the field name.
+	/// </summary>
+	/// <param name="fieldName">The native field name.</param>
+	/// <param name="enumMember">The enum member that matches the field name.</param>
+	/// <returns>True if the enum member was found. False otherwise.</returns>
+	public bool TryGetEnumValue (string fieldName, out EnumMember? enumMember)
+		=> TryGetFromIndex (fieldName, enumMembers, enumIndex, out enumMember);
+
+	/// <summary>
+	/// Get the property that matches the selector.
+	/// </summary>
+	/// <param name="selector">The selector used for the property. It can also be a field name.</param>
+	/// <param name="property">The property that matches the given selector/field name.</param>
+	/// <returns>True if the property was found. False otherwise.</returns>
+	public bool TryGetProperty (string selector, out Property? property)
+		=> TryGetFromIndex (selector, properties, propertyIndex, out property);
+
+	/// <summary>
+	/// Get the constructor that matches the selector.
+	/// </summary>
+	/// <param name="selector">The selector used for the constructor.</param>
+	/// <param name="constructor">The constructor that matches the given selector.</param>
+	/// <returns>True if the constructor was found. False otherwise.</returns>
+	public bool TryGetConstructor (string selector, out Constructor? constructor)
+		=> TryGetFromIndex (selector, constructors, constructorIndex, out constructor);
+
+	/// <summary>
+	/// Get the event that matches the selector.
+	/// </summary>
+	/// <param name="selector">The selector used for the event.</param>
+	/// <param name="event">The event that matches the given selector.</param>
+	/// <returns>True if the event was found. False otherwise.</returns>
+	public bool TryGetEvent (string selector, out Event? @event)
+		=> TryGetFromIndex (selector, events, eventsIndex, out @event);
+
+	/// <summary>
+	/// Get The method that matches the selector.
+	/// </summary>
+	/// <param name="selector">The selector used for the method.</param>
+	/// <param name="method">The method that matches the given selector.</param>
+	/// <returns>True if the method was found. False otherwise.</returns>
+	public bool TryGetMethod (string selector, out Method? method)
+		=> TryGetFromIndex (selector, methods, methodIndex, out method);
 }

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Binding.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Binding.cs
@@ -120,10 +120,10 @@ readonly partial struct Binding {
 			enumMembers = value;
 			// populate the enum index for fast lookup using the symbol name
 			for (var index = 0; index < enumMembers.Length; index++) {
-				var member = enumMembers[index];
+				var member = enumMembers [index];
 				if (member.Selector is null)
 					continue;
-				enumIndex[member.Selector] = index;
+				enumIndex [member.Selector] = index;
 			}
 		}
 	}
@@ -131,7 +131,7 @@ readonly partial struct Binding {
 	/// <summary>
 	/// Returns all the selectors for the enum members.
 	/// </summary>
-	public ImmutableArray<string> EnumMemberSelectors => [..enumIndex.Keys];
+	public ImmutableArray<string> EnumMemberSelectors => [.. enumIndex.Keys];
 
 	readonly Dictionary<string, int> propertyIndex = new ();
 	readonly ImmutableArray<Property> properties = [];
@@ -145,7 +145,7 @@ readonly partial struct Binding {
 			properties = value;
 			// populate the property index for fast lookup using the symbol name
 			for (var index = 0; index < properties.Length; index++) {
-				var property = properties[index];
+				var property = properties [index];
 				// there are two type of properties, those that are fields and those that are properties
 				if (property.Selector is null)
 					continue;
@@ -157,7 +157,7 @@ readonly partial struct Binding {
 	/// <summary>
 	/// Return sall the selectors for the properties.
 	/// </summary>
-	public ImmutableArray<string> PropertySelectors => [..propertyIndex.Keys];
+	public ImmutableArray<string> PropertySelectors => [.. propertyIndex.Keys];
 
 	readonly Dictionary<string, int> constructorIndex = new ();
 	readonly ImmutableArray<Constructor> constructors = [];
@@ -171,7 +171,7 @@ readonly partial struct Binding {
 			constructors = value;
 			// populate the constructor index for fast lookup using the symbol name
 			for (var index = 0; index < constructors.Length; index++) {
-				var constructor = constructors[index];
+				var constructor = constructors [index];
 				if (constructor.Selector is null)
 					continue;
 				constructorIndex [constructor.Selector] = index;
@@ -182,7 +182,7 @@ readonly partial struct Binding {
 	/// <summary>
 	/// Returns all the selectors for the constructors.
 	/// </summary>
-	public ImmutableArray<string> ConstructorSelectors => [..constructorIndex.Keys];
+	public ImmutableArray<string> ConstructorSelectors => [.. constructorIndex.Keys];
 
 	readonly Dictionary<string, int> eventsIndex = new ();
 	readonly ImmutableArray<Event> events = [];
@@ -196,7 +196,7 @@ readonly partial struct Binding {
 			events = value;
 			// populate the event index for fast lookup using the symbol name
 			for (var index = 0; index < events.Length; index++) {
-				var eventItem = events[index];
+				var eventItem = events [index];
 				eventsIndex [eventItem.Name] = index;
 			}
 		}
@@ -205,7 +205,7 @@ readonly partial struct Binding {
 	/// <summary>
 	/// Returns all the selectors for the events.
 	/// </summary>
-	public ImmutableArray<string> EventSelectors => [..eventsIndex.Keys];
+	public ImmutableArray<string> EventSelectors => [.. eventsIndex.Keys];
 
 	readonly Dictionary<string, int> methodIndex = new ();
 	readonly ImmutableArray<Method> methods = [];
@@ -219,7 +219,7 @@ readonly partial struct Binding {
 			methods = value;
 			// populate the method index for fast lookup using the symbol name
 			for (var index = 0; index < methods.Length; index++) {
-				var method = methods[index];
+				var method = methods [index];
 				if (method.Selector is null)
 					continue;
 				methodIndex [method.Selector] = index;
@@ -230,7 +230,7 @@ readonly partial struct Binding {
 	/// <summary>
 	/// Returns all the selectors for the methods.
 	/// </summary>
-	public ImmutableArray<string> MethodSelectors => [..methodIndex.Keys];
+	public ImmutableArray<string> MethodSelectors => [.. methodIndex.Keys];
 
 	delegate bool SkipDelegate<in T> (T declarationSyntax, SemanticModel semanticModel);
 
@@ -256,7 +256,7 @@ readonly partial struct Binding {
 		members = bucket.ToImmutable ();
 	}
 
-	static bool TryGetFromIndex<T> (string selector, ImmutableArray<T> collection, Dictionary<string, int> index, [NotNullWhen (true)]out T? value)
+	static bool TryGetFromIndex<T> (string selector, ImmutableArray<T> collection, Dictionary<string, int> index, [NotNullWhen (true)] out T? value)
 		where T : struct
 	{
 		if (index.TryGetValue (selector, out var indexValue)) {

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Constructor.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Constructor.Generator.cs
@@ -16,7 +16,12 @@ readonly partial struct Constructor {
 	/// <summary>
 	/// The data of the export attribute used to mark the value as a property binding. 
 	/// </summary>
-	public ExportData<ObjCBindings.Constructor> ExportMethodData { get; }
+	public ExportData<ObjCBindings.Constructor> ExportMethodData { get; init; }
+
+	/// <summary>
+	/// Return the native selector that references the enum value.
+	/// </summary>
+	public string? Selector => ExportMethodData.Selector;
 
 	public static bool TryCreate (ConstructorDeclarationSyntax declaration, RootContext context,
 		[NotNullWhen (true)] out Constructor? change)

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMember.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMember.Generator.cs
@@ -16,6 +16,12 @@ readonly partial struct EnumMember {
 	public FieldInfo<EnumValue>? FieldInfo { get; }
 
 	/// <summary>
+	/// Return the native selector that references the enum value.
+	/// </summary>
+	public string? Selector => FieldInfo?.FieldData.SymbolName;
+
+
+	/// <summary>
 	/// Create a new change that happened on a member.
 	/// </summary>
 	/// <param name="name">The name of the changed member.</param>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
@@ -21,6 +21,12 @@ readonly partial struct Method {
 	/// </summary>
 	public ExportData<ObjCBindings.Method> ExportMethodData { get; }
 
+
+	/// <summary>
+	/// Return the native selector that references the enum value.
+	/// </summary>
+	public string? Selector => ExportMethodData.Selector;
+
 	/// <summary>
 	/// Returns the bind from data if present in the binding.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
@@ -145,6 +145,21 @@ readonly partial struct Property {
 		init => requiresDirtyCheck = value;
 	}
 
+	/// <summary>
+	/// Return the native selector that references the enum value.
+	/// </summary>
+	public string? Selector {
+		get {
+			if (IsField) {
+				return ExportFieldData.Value.FieldData.SymbolName;
+			}
+			if (IsProperty) {
+				return ExportPropertyData.Value.Selector;
+			}
+			return null;
+		}
+	}
+
 	static FieldInfo<ObjCBindings.Property>? GetFieldInfo (RootContext context, IPropertySymbol propertySymbol)
 	{
 		// grab the last port of the namespace

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Constructor.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Constructor.Transformer.cs
@@ -22,6 +22,11 @@ readonly partial struct Constructor {
 		init => overrideExportData = value;
 	}
 
+	/// <summary>
+	/// Return the native selector that references the enum value.
+	/// </summary>
+	public string? Selector => ExportMethodData?.Selector;
+
 	public Constructor (string type,
 		SymbolAvailability symbolAvailability,
 		Dictionary<string, List<AttributeData>> attributes,

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/EnumMember.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/EnumMember.Transformer.cs
@@ -14,6 +14,12 @@ readonly partial struct EnumMember {
 	/// </summary>
 	public FieldInfo? FieldInfo { get; init; }
 
+
+	/// <summary>
+	/// Return the native selector that references the enum value.
+	/// </summary>
+	public string? Selector => FieldInfo?.FieldData?.SymbolName;
+
 	public EnumMember (string name,
 		string libraryName,
 		string? libraryPath,

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Method.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Method.Transformer.cs
@@ -26,6 +26,11 @@ readonly partial struct Method {
 	}
 
 	/// <summary>
+	/// Return the native selector that references the enum value.
+	/// </summary>
+	public string? Selector => ExportMethodData?.Selector;
+
+	/// <summary>
 	/// Returns the bind from data if present in the binding.
 	/// </summary>
 	public BindAsData? BindAs => BindAsAttribute;

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Property.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Property.Transformer.cs
@@ -78,6 +78,22 @@ readonly partial struct Property {
 	/// <inheritdoc />
 	public bool Equals (Property other) => CoreEquals (other);
 
+	/// <summary>
+	/// Return the native selector that references the enum value.
+	/// </summary>
+	public string? Selector {
+		get {
+			if (IsField) {
+				return ExportFieldData?.SymbolName;
+			}
+
+			if (IsProperty) {
+				return ExportPropertyData?.Selector;
+			}
+			return null;
+		}
+	}
+
 	internal Property (string name,
 		TypeInfo returnType,
 		SymbolAvailability symbolAvailability,

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingTests.cs
@@ -1,13 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma warning disable APL0003
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.DataModel;
 using Xamarin.Tests;
 using Xamarin.Utils;
 using Xunit;
+using Constructor = Microsoft.Macios.Generator.DataModel.Constructor;
+using Method = Microsoft.Macios.Generator.DataModel.Method;
+using Property = Microsoft.Macios.Generator.DataModel.Property;
+using static Microsoft.Macios.Generator.Tests.TestDataFactory;
 
 namespace Microsoft.Macios.Generator.Tests.DataModel;
 
@@ -250,5 +257,213 @@ public class TestClass {
 		Assert.NotNull (node);
 		var semanticModel = compilation.GetSemanticModel (sourceTrees [0]);
 		Assert.Equal (expected, Binding.Skip (node, semanticModel));
+	}
+
+	[Fact]
+	public void EnumIndexTest ()
+	{
+		var bindingInfo = new BindingInfo (new BindingTypeData<ObjCBindings.SmartEnum> ());
+		string presentSelector = "AVCaptureDeviceTypeBuiltInMicrophone";
+		string missingSelector = "AVCaptureDeviceTypeBuiltInWideAngleCamera";
+
+		var binding = new Binding(
+			bindingInfo: bindingInfo,
+			name: "TestBinding",
+			@namespace: ["TestNamespace"],
+			fullyQualifiedSymbol: "TestNamespace.TestBinding",
+			symbolAvailability: new ()) {
+			EnumMembers = [
+				new (
+					name: "BuiltInMicrophone",
+					libraryName: "AVCaptureDeviceTypeBuiltInMicrophone",
+					libraryPath: null,
+					fieldData: new (presentSelector),
+					symbolAvailability: new(),
+					attributes: []),
+			],
+		};
+		EnumMember? member;
+		Assert.False (binding.TryGetEnumValue (missingSelector, out member));
+		Assert.Null (member);
+		Assert.True (binding.TryGetEnumValue (presentSelector, out member));
+		Assert.NotNull (member);
+	}
+
+	[Fact]
+	public void PropertyIndexTest ()
+	{
+		var bindingInfo = new BindingInfo (new BindingTypeData<ObjCBindings.Class> ());
+		string presentSelector = "name";
+		string missingSelector = "surname";
+
+		var binding = new Binding(
+			bindingInfo: bindingInfo,
+			name: "TestBinding",
+			@namespace: ["TestNamespace"],
+			fullyQualifiedSymbol: "TestNamespace.TestBinding",
+			symbolAvailability: new ()) {
+			Properties = [
+				new (
+					name: "Name",
+					returnType: ReturnTypeForString (),
+					symbolAvailability: new (),
+					attributes: [
+						new ("ObjCBindings.ExportAttribute<ObjCBindings.Property>", ["name"])
+					],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+						SyntaxFactory.Token (SyntaxKind.PartialKeyword),
+					],
+					accessors: [
+						new (
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Setter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
+							modifiers: []
+						),
+					]
+				) {
+					ExportPropertyData = new ("name")
+				}
+			]
+		};
+
+		Property? member;
+		Assert.False (binding.TryGetProperty (missingSelector, out member));
+		Assert.Null (member);
+		Assert.True (binding.TryGetProperty (presentSelector, out member));
+		Assert.NotNull (member);
+	}
+
+	[Fact]
+	public void ConstructorIndexTest ()
+	{
+		var bindingInfo = new BindingInfo (new BindingTypeData<ObjCBindings.Class> ());
+		string presentSelector = "initWithName:";
+		string missingSelector = "initWithName:Surname:";
+
+		var binding = new Binding(
+			bindingInfo: bindingInfo,
+			name: "TestBinding",
+			@namespace: ["TestNamespace"],
+			fullyQualifiedSymbol: "TestNamespace.TestBinding",
+			symbolAvailability: new ()) {
+			Constructors = [
+				new (
+					type: "MyClass",
+					symbolAvailability: new (),
+					attributes: [],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword)
+					],
+					parameters: []
+				) {
+					ExportMethodData = new (presentSelector)
+				}
+			]
+		};
+
+		Constructor? member;
+		Assert.False (binding.TryGetConstructor (missingSelector, out member));
+		Assert.Null (member);
+		Assert.True (binding.TryGetConstructor (presentSelector, out member));
+		Assert.NotNull (member);
+	}
+
+	[Fact]
+	public void EventIndexTest ()
+	{
+		var bindingInfo = new BindingInfo (new BindingTypeData<ObjCBindings.Class> ());
+		string presentSelector = "Changed";
+		string missingSelector = "Added";
+
+		var binding = new Binding(
+			bindingInfo: bindingInfo,
+			name: "TestBinding",
+			@namespace: ["TestNamespace"],
+			fullyQualifiedSymbol: "TestNamespace.TestBinding",
+			symbolAvailability: new ()) {
+			Events = [
+				new (
+					name: "Changed",
+					type: "System.EventHandler",
+					symbolAvailability: new (),
+					attributes: [],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					accessors: [
+						new (
+							accessorKind: AccessorKind.Add,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
+							modifiers: []
+						),
+						new (
+							accessorKind: AccessorKind.Remove,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
+							modifiers: []
+						)
+					])
+			],
+		};
+
+		Event? member;
+		Assert.False (binding.TryGetEvent (missingSelector, out member));
+		Assert.Null (member);
+		Assert.True (binding.TryGetEvent (presentSelector, out member));
+		Assert.NotNull (member);
+	}
+
+	[Fact]
+	public void MethodIndexTest ()
+	{
+		var bindingInfo = new BindingInfo (new BindingTypeData<ObjCBindings.Class> ());
+		string presentSelector = "withName:";
+		string missingSelector = "withName:Surname:";
+
+		var binding = new Binding(
+			bindingInfo: bindingInfo,
+			name: "TestBinding",
+			@namespace: ["TestNamespace"],
+			fullyQualifiedSymbol: "TestNamespace.TestBinding",
+			symbolAvailability: new ()) {
+			Methods = [
+				new (
+					type: "NS.MyClass",
+					name: "SetName",
+					returnType: ReturnTypeForVoid (),
+					symbolAvailability: new (),
+					exportMethodData: new ("withName:"),
+					attributes: [
+						new ("ObjCBindings.ExportAttribute<ObjCBindings.Method>", ["withName:"])
+					],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+						SyntaxFactory.Token (SyntaxKind.PartialKeyword),
+					],
+					parameters: [
+						new (position: 0, type: ReturnTypeForString (), name: "name")
+					]
+				),
+			]
+		};
+
+		Method? member;
+		Assert.False (binding.TryGetMethod (missingSelector, out member));
+		Assert.Null (member);
+		Assert.True (binding.TryGetMethod (presentSelector, out member));
+		Assert.NotNull (member);
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingTests.cs
@@ -266,7 +266,7 @@ public class TestClass {
 		string presentSelector = "AVCaptureDeviceTypeBuiltInMicrophone";
 		string missingSelector = "AVCaptureDeviceTypeBuiltInWideAngleCamera";
 
-		var binding = new Binding(
+		var binding = new Binding (
 			bindingInfo: bindingInfo,
 			name: "TestBinding",
 			@namespace: ["TestNamespace"],
@@ -278,7 +278,7 @@ public class TestClass {
 					libraryName: "AVCaptureDeviceTypeBuiltInMicrophone",
 					libraryPath: null,
 					fieldData: new (presentSelector),
-					symbolAvailability: new(),
+					symbolAvailability: new (),
 					attributes: []),
 			],
 		};
@@ -296,7 +296,7 @@ public class TestClass {
 		string presentSelector = "name";
 		string missingSelector = "surname";
 
-		var binding = new Binding(
+		var binding = new Binding (
 			bindingInfo: bindingInfo,
 			name: "TestBinding",
 			@namespace: ["TestNamespace"],
@@ -350,7 +350,7 @@ public class TestClass {
 		string presentSelector = "initWithName:";
 		string missingSelector = "initWithName:Surname:";
 
-		var binding = new Binding(
+		var binding = new Binding (
 			bindingInfo: bindingInfo,
 			name: "TestBinding",
 			@namespace: ["TestNamespace"],
@@ -385,7 +385,7 @@ public class TestClass {
 		string presentSelector = "Changed";
 		string missingSelector = "Added";
 
-		var binding = new Binding(
+		var binding = new Binding (
 			bindingInfo: bindingInfo,
 			name: "TestBinding",
 			@namespace: ["TestNamespace"],
@@ -433,7 +433,7 @@ public class TestClass {
 		string presentSelector = "withName:";
 		string missingSelector = "withName:Surname:";
 
-		var binding = new Binding(
+		var binding = new Binding (
 			bindingInfo: bindingInfo,
 			name: "TestBinding",
 			@namespace: ["TestNamespace"],


### PR DESCRIPTION
In the transformer we want to be able to quickly access the members of a bindings via its selectors since that is how we are going to identify the members that are present in more than one platform.

To do so, we add an index per member type and we use its selector to locate its possition in the immutable array.