### PR TITLE
[runtime] Add ability to report how long app launch takes. Fixes #22510.

### DIFF
--- a/runtime/monotouch-debug.h
+++ b/runtime/monotouch-debug.h
@@ -18,6 +18,7 @@
 extern "C" {
 #endif
 
+void monotouch_start_launch_timer ();
 void monotouch_configure_debugging ();
 void monotouch_start_debugging ();
 void monotouch_start_profiling ();

--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -237,6 +237,10 @@ extern void mono_gc_init_finalizer_thread (void);
 int
 xamarin_main (int argc, char *argv[], enum XamarinLaunchMode launch_mode)
 {
+#ifdef DEBUG
+	monotouch_start_launch_timer ();
+#endif
+
 	// + 1 for the initial "monotouch" +1 for the final NULL = +2.
 	// This is not an exact number (it will most likely be lower, since there
 	// are other arguments besides --app-arg), but it's a guaranteed and bound


### PR DESCRIPTION
Report how long the app launch takes (only in debug mode).

It's measured from the very beginning of the main method, until we receive the
[UIApplicationDidFinishLaunchingNotification][1] notification.

We now print the following to the system's log using `NSLog`:

    Microsoft.iOS: Started launch timer
    [...]
    Microsoft.iOS: Did finish launching in 0.295 s

This is off by default, and can be enabled by setting the environment variable
`XAMARIN_TRACK_LAUNCH_DURATION` to:

* `enable`: enable.
* `disable`: disable.

If using mlaunch, the environment variable can be set by passing
`--setenv:XAMARIN_TRACK_LAUNCH_DURATION=...` to mlaunch.

Fixes https://github.com/dotnet/macios/issues/22510.

[1]: https://developer.apple.com/documentation/uikit/uiapplication/didfinishlaunchingnotification