### PR TITLE
[bgen] Add support for writing xml docs for async methods.

### DIFF
--- a/src/bgen/Attributes.cs
+++ b/src/bgen/Attributes.cs
@@ -721,6 +721,8 @@ public class AsyncAttribute : Attribute {
 	public string MethodName { get; set; }
 	public string ResultTypeName { get; set; }
 	public string PostNonResultSnippet { get; set; }
+	public string XmlDocs { get; set; }
+	public string XmlDocsWithOutParameter { get; set; }
 }
 
 //

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -4316,6 +4316,14 @@ public partial class Generator : IMemberGatherer {
 			}
 		}
 
+		var asyncAttribute = AttributeManager.GetCustomAttribute<AsyncAttribute> (mi);
+		var xmlDocs = asyncKind == AsyncMethodKind.Plain ? asyncAttribute.XmlDocs : asyncAttribute.XmlDocsWithOutParameter;
+		if (!string.IsNullOrEmpty (xmlDocs)) {
+			var docLines = xmlDocs.Split ('\n');
+			foreach (var line in docLines)
+				print ($"/// {line}");
+		}
+
 		PrintMethodAttributes (minfo);
 
 		PrintAsyncHeader (minfo, asyncKind);
@@ -4334,7 +4342,7 @@ public partial class Generator : IMemberGatherer {
 		print ("var tcs = new TaskCompletionSource<{0}> ();", ttype);
 		bool ignoreResult = !is_void &&
 			asyncKind == AsyncMethodKind.Plain &&
-			AttributeManager.GetCustomAttribute<AsyncAttribute> (mi).PostNonResultSnippet is null;
+			asyncAttribute.PostNonResultSnippet is null;
 		print ("{6}{5}{4}{0}{7}({1}{2}({3}) => {{",
 			mi.Name,
 			GetInvokeParamList (minfo.AsyncInitialParams, false),

--- a/tests/generator/ExpectedXmlDocs.MacCatalyst.xml
+++ b/tests/generator/ExpectedXmlDocs.MacCatalyst.xml
@@ -405,6 +405,21 @@
             Summary for T2.#ctor(String)
             </summary>
         </member>
+        <member name="M:XmlDocumentation.T1.DoSomething(System.Action)">
+            <summary>Summary for T1.DoSomething</summary>
+        </member>
+        <member name="M:XmlDocumentation.T1.DoSomethingAsync">
+            <summary>Summary for async version of T1.DoSomething</summary>
+        </member>
+        <member name="M:XmlDocumentation.T1.DoSomethingElse(System.Action)">
+            <summary>Summary for T1.DoSomethingElse</summary>
+        </member>
+        <member name="M:XmlDocumentation.T1.DoSomethingElseAsync">
+            <summary>Summary for async version of T1.DoSomethingElse</summary>
+        </member>
+        <member name="M:XmlDocumentation.T1.DoSomethingElseAsync(System.Boolean@)">
+            <summary>Summary for async version of T1.DoSomethingElse - with out parameter (should show up in xml docs)</summary>
+        </member>
         <member name="M:XmlDocumentation.T1.Method">
             <summary>
             Summary for T1.Method

--- a/tests/generator/ExpectedXmlDocs.iOS.xml
+++ b/tests/generator/ExpectedXmlDocs.iOS.xml
@@ -405,6 +405,21 @@
             Summary for T2.#ctor(String)
             </summary>
         </member>
+        <member name="M:XmlDocumentation.T1.DoSomething(System.Action)">
+            <summary>Summary for T1.DoSomething</summary>
+        </member>
+        <member name="M:XmlDocumentation.T1.DoSomethingAsync">
+            <summary>Summary for async version of T1.DoSomething</summary>
+        </member>
+        <member name="M:XmlDocumentation.T1.DoSomethingElse(System.Action)">
+            <summary>Summary for T1.DoSomethingElse</summary>
+        </member>
+        <member name="M:XmlDocumentation.T1.DoSomethingElseAsync">
+            <summary>Summary for async version of T1.DoSomethingElse</summary>
+        </member>
+        <member name="M:XmlDocumentation.T1.DoSomethingElseAsync(System.Boolean@)">
+            <summary>Summary for async version of T1.DoSomethingElse - with out parameter (should show up in xml docs)</summary>
+        </member>
         <member name="M:XmlDocumentation.T1.Method">
             <summary>
             Summary for T1.Method

--- a/tests/generator/ExpectedXmlDocs.macOS.xml
+++ b/tests/generator/ExpectedXmlDocs.macOS.xml
@@ -405,6 +405,21 @@
             Summary for T2.#ctor(String)
             </summary>
         </member>
+        <member name="M:XmlDocumentation.T1.DoSomething(System.Action)">
+            <summary>Summary for T1.DoSomething</summary>
+        </member>
+        <member name="M:XmlDocumentation.T1.DoSomethingAsync">
+            <summary>Summary for async version of T1.DoSomething</summary>
+        </member>
+        <member name="M:XmlDocumentation.T1.DoSomethingElse(System.Action)">
+            <summary>Summary for T1.DoSomethingElse</summary>
+        </member>
+        <member name="M:XmlDocumentation.T1.DoSomethingElseAsync">
+            <summary>Summary for async version of T1.DoSomethingElse</summary>
+        </member>
+        <member name="M:XmlDocumentation.T1.DoSomethingElseAsync(System.Boolean@)">
+            <summary>Summary for async version of T1.DoSomethingElse - with out parameter (should show up in xml docs)</summary>
+        </member>
         <member name="M:XmlDocumentation.T1.Method">
             <summary>
             Summary for T1.Method

--- a/tests/generator/ExpectedXmlDocs.tvOS.xml
+++ b/tests/generator/ExpectedXmlDocs.tvOS.xml
@@ -405,6 +405,21 @@
             Summary for T2.#ctor(String)
             </summary>
         </member>
+        <member name="M:XmlDocumentation.T1.DoSomething(System.Action)">
+            <summary>Summary for T1.DoSomething</summary>
+        </member>
+        <member name="M:XmlDocumentation.T1.DoSomethingAsync">
+            <summary>Summary for async version of T1.DoSomething</summary>
+        </member>
+        <member name="M:XmlDocumentation.T1.DoSomethingElse(System.Action)">
+            <summary>Summary for T1.DoSomethingElse</summary>
+        </member>
+        <member name="M:XmlDocumentation.T1.DoSomethingElseAsync">
+            <summary>Summary for async version of T1.DoSomethingElse</summary>
+        </member>
+        <member name="M:XmlDocumentation.T1.DoSomethingElseAsync(System.Boolean@)">
+            <summary>Summary for async version of T1.DoSomethingElse - with out parameter (should show up in xml docs)</summary>
+        </member>
         <member name="M:XmlDocumentation.T1.Method">
             <summary>
             Summary for T1.Method

--- a/tests/generator/tests/xmldocs.cs
+++ b/tests/generator/tests/xmldocs.cs
@@ -35,6 +35,26 @@ namespace XmlDocumentation {
 		[Field ("TEventArgs", "__Internal")]
 		[Notification (typeof (TEventArgs))]
 		NSString TEventArgs { get; }
+
+		/// <summary>Summary for T1.DoSomething</summary>
+		[Async (XmlDocs = """
+						<summary>Summary for async version of T1.DoSomething</summary>
+						""",
+				XmlDocsWithOutParameter = """
+						<summary>Summary for async version of T1.DoSomething - with out parameter (shouldn't show up in xml docs)</summary>
+						""")]
+		[Export ("doSomething:")]
+		void DoSomething (Action completionHandler);
+
+		/// <summary>Summary for T1.DoSomethingElse</summary>
+		[Async (XmlDocs = """
+						<summary>Summary for async version of T1.DoSomethingElse</summary>
+						""",
+				XmlDocsWithOutParameter = """
+						<summary>Summary for async version of T1.DoSomethingElse - with out parameter (should show up in xml docs)</summary>
+						""")]
+		[Export ("doSomething:")]
+		bool DoSomethingElse (Action completionHandler);
 	}
 
 	/// <summary>TEventArgs</summary>


### PR DESCRIPTION
This is accomplished by adding two new properties to the Async attribute:
`XmlDocs` and `XmlDocsWithOutParameter`. We need two properties, because an
[Async] member can end up with two async overloads if the original member has
a return value (which will end up being the out parameter in one of the async
overloads).