### PR TITLE
[bgen] Add support for writing xml docs for events.

### DIFF
--- a/src/bgen/Attributes.cs
+++ b/src/bgen/Attributes.cs
@@ -432,6 +432,7 @@ public class EventArgsAttribute : Attribute {
 	public string ArgName { get; set; }
 	public bool SkipGeneration { get; set; }
 	public bool FullName { get; set; }
+	public string XmlDocs { get; set; }
 }
 
 //

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -6709,6 +6709,14 @@ public partial class Generator : IMemberGatherer {
 						} else
 							prev_miname = miname;
 
+						var eventArgs = AttributeManager.GetCustomAttribute<EventArgsAttribute> (mi);
+						var xmlDocs = eventArgs?.XmlDocs;
+						if (!string.IsNullOrEmpty (xmlDocs)) {
+							var docLines = xmlDocs.Split ('\n');
+							foreach (var line in docLines)
+								print ($"/// {line}");
+						}
+
 						if (mi.ReturnType == TypeCache.System_Void) {
 							PrintObsoleteAttributes (mi);
 

--- a/tests/generator/ExpectedXmlDocs.MacCatalyst.xml
+++ b/tests/generator/ExpectedXmlDocs.MacCatalyst.xml
@@ -564,6 +564,16 @@
         <member name="F:XmlDocumentation.TClass.__mt_WeakDelegate_var">
             <summary>TClass.WeakDelegate</summary>
         </member>
+        <member name="E:XmlDocumentation.TClass.DidChangeMutteringVolume">
+            <summary>TClassDelegate.DidChangeMutteringVolume - EventArgs.</summary>
+        </member>
+        <member name="T:XmlDocumentation.TMutteranceEventArgs">
+            <summary>Provides data for an event based on an Objective-C protocol method.</summary>
+        </member>
+        <member name="M:XmlDocumentation.TMutteranceEventArgs.#ctor(System.Double)">
+            <summary>Create a new instance of the <see cref="T:XmlDocumentation.TMutteranceEventArgs" /> with the specified event data.</summary>
+            <param name="mutteringVolume">The value for the <see cref="P:XmlDocumentation.TMutteranceEventArgs.MutteringVolume" /> property.</param>
+        </member>
         <member name="T:XmlDocumentation.TUtteranceEventArgs">
             <summary>Provides data for an event based on an Objective-C protocol method.</summary>
         </member>
@@ -580,6 +590,12 @@
         <member name="M:XmlDocumentation.ITClassDelegate._DidChangeUtteringSpeed(XmlDocumentation.ITClassDelegate,XmlDocumentation.TClass,System.Double)">
             <summary>TClassDelegate.DidChangeUtteringSpeed</summary>
         </member>
+        <member name="M:XmlDocumentation.ITClassDelegate.DidChangeMutteringVolume(XmlDocumentation.TClass,System.Double)">
+            <summary>TClassDelegate.DidChangeMutteringVolume</summary>
+        </member>
+        <member name="M:XmlDocumentation.ITClassDelegate._DidChangeMutteringVolume(XmlDocumentation.ITClassDelegate,XmlDocumentation.TClass,System.Double)">
+            <summary>TClassDelegate.DidChangeMutteringVolume</summary>
+        </member>
         <member name="T:XmlDocumentation.TClassDelegate_Extensions">
             <summary>Extension methods to the <see cref="T:XmlDocumentation.ITClassDelegate" /> interface to support all the methods from the TClassDelegate protocol.</summary>
             <remarks>
@@ -588,6 +604,9 @@
         </member>
         <member name="M:XmlDocumentation.TClassDelegate_Extensions.DidChangeUtteringSpeed(XmlDocumentation.ITClassDelegate,XmlDocumentation.TClass,System.Double)">
             <summary>TClassDelegate.DidChangeUtteringSpeed</summary>
+        </member>
+        <member name="M:XmlDocumentation.TClassDelegate_Extensions.DidChangeMutteringVolume(XmlDocumentation.ITClassDelegate,XmlDocumentation.TClass,System.Double)">
+            <summary>TClassDelegate.DidChangeMutteringVolume</summary>
         </member>
         <member name="T:XmlDocumentation.TClassDelegate">
             <summary>TClassDelegate</summary>
@@ -651,6 +670,9 @@
                     Developers should not invoke this method directly, instead they should call <see cref="M:ObjCRuntime.Runtime.GetNSObject(System.IntPtr)" /> as it will prevent two instances of a managed object pointing to the same native object.
                 </para>
             </remarks>
+        </member>
+        <member name="M:XmlDocumentation.TClassDelegate.DidChangeMutteringVolume(XmlDocumentation.TClass,System.Double)">
+            <summary>TClassDelegate.DidChangeMutteringVolume</summary>
         </member>
         <member name="M:XmlDocumentation.TClassDelegate.DidChangeUtteringSpeed(XmlDocumentation.TClass,System.Double)">
             <summary>TClassDelegate.DidChangeUtteringSpeed</summary>

--- a/tests/generator/ExpectedXmlDocs.iOS.xml
+++ b/tests/generator/ExpectedXmlDocs.iOS.xml
@@ -564,6 +564,16 @@
         <member name="F:XmlDocumentation.TClass.__mt_WeakDelegate_var">
             <summary>TClass.WeakDelegate</summary>
         </member>
+        <member name="E:XmlDocumentation.TClass.DidChangeMutteringVolume">
+            <summary>TClassDelegate.DidChangeMutteringVolume - EventArgs.</summary>
+        </member>
+        <member name="T:XmlDocumentation.TMutteranceEventArgs">
+            <summary>Provides data for an event based on an Objective-C protocol method.</summary>
+        </member>
+        <member name="M:XmlDocumentation.TMutteranceEventArgs.#ctor(System.Double)">
+            <summary>Create a new instance of the <see cref="T:XmlDocumentation.TMutteranceEventArgs" /> with the specified event data.</summary>
+            <param name="mutteringVolume">The value for the <see cref="P:XmlDocumentation.TMutteranceEventArgs.MutteringVolume" /> property.</param>
+        </member>
         <member name="T:XmlDocumentation.TUtteranceEventArgs">
             <summary>Provides data for an event based on an Objective-C protocol method.</summary>
         </member>
@@ -580,6 +590,12 @@
         <member name="M:XmlDocumentation.ITClassDelegate._DidChangeUtteringSpeed(XmlDocumentation.ITClassDelegate,XmlDocumentation.TClass,System.Double)">
             <summary>TClassDelegate.DidChangeUtteringSpeed</summary>
         </member>
+        <member name="M:XmlDocumentation.ITClassDelegate.DidChangeMutteringVolume(XmlDocumentation.TClass,System.Double)">
+            <summary>TClassDelegate.DidChangeMutteringVolume</summary>
+        </member>
+        <member name="M:XmlDocumentation.ITClassDelegate._DidChangeMutteringVolume(XmlDocumentation.ITClassDelegate,XmlDocumentation.TClass,System.Double)">
+            <summary>TClassDelegate.DidChangeMutteringVolume</summary>
+        </member>
         <member name="T:XmlDocumentation.TClassDelegate_Extensions">
             <summary>Extension methods to the <see cref="T:XmlDocumentation.ITClassDelegate" /> interface to support all the methods from the TClassDelegate protocol.</summary>
             <remarks>
@@ -588,6 +604,9 @@
         </member>
         <member name="M:XmlDocumentation.TClassDelegate_Extensions.DidChangeUtteringSpeed(XmlDocumentation.ITClassDelegate,XmlDocumentation.TClass,System.Double)">
             <summary>TClassDelegate.DidChangeUtteringSpeed</summary>
+        </member>
+        <member name="M:XmlDocumentation.TClassDelegate_Extensions.DidChangeMutteringVolume(XmlDocumentation.ITClassDelegate,XmlDocumentation.TClass,System.Double)">
+            <summary>TClassDelegate.DidChangeMutteringVolume</summary>
         </member>
         <member name="T:XmlDocumentation.TClassDelegate">
             <summary>TClassDelegate</summary>
@@ -651,6 +670,9 @@
                     Developers should not invoke this method directly, instead they should call <see cref="M:ObjCRuntime.Runtime.GetNSObject(System.IntPtr)" /> as it will prevent two instances of a managed object pointing to the same native object.
                 </para>
             </remarks>
+        </member>
+        <member name="M:XmlDocumentation.TClassDelegate.DidChangeMutteringVolume(XmlDocumentation.TClass,System.Double)">
+            <summary>TClassDelegate.DidChangeMutteringVolume</summary>
         </member>
         <member name="M:XmlDocumentation.TClassDelegate.DidChangeUtteringSpeed(XmlDocumentation.TClass,System.Double)">
             <summary>TClassDelegate.DidChangeUtteringSpeed</summary>

--- a/tests/generator/ExpectedXmlDocs.macOS.xml
+++ b/tests/generator/ExpectedXmlDocs.macOS.xml
@@ -564,6 +564,16 @@
         <member name="F:XmlDocumentation.TClass.__mt_WeakDelegate_var">
             <summary>TClass.WeakDelegate</summary>
         </member>
+        <member name="E:XmlDocumentation.TClass.DidChangeMutteringVolume">
+            <summary>TClassDelegate.DidChangeMutteringVolume - EventArgs.</summary>
+        </member>
+        <member name="T:XmlDocumentation.TMutteranceEventArgs">
+            <summary>Provides data for an event based on an Objective-C protocol method.</summary>
+        </member>
+        <member name="M:XmlDocumentation.TMutteranceEventArgs.#ctor(System.Double)">
+            <summary>Create a new instance of the <see cref="T:XmlDocumentation.TMutteranceEventArgs" /> with the specified event data.</summary>
+            <param name="mutteringVolume">The value for the <see cref="P:XmlDocumentation.TMutteranceEventArgs.MutteringVolume" /> property.</param>
+        </member>
         <member name="T:XmlDocumentation.TUtteranceEventArgs">
             <summary>Provides data for an event based on an Objective-C protocol method.</summary>
         </member>
@@ -580,6 +590,12 @@
         <member name="M:XmlDocumentation.ITClassDelegate._DidChangeUtteringSpeed(XmlDocumentation.ITClassDelegate,XmlDocumentation.TClass,System.Double)">
             <summary>TClassDelegate.DidChangeUtteringSpeed</summary>
         </member>
+        <member name="M:XmlDocumentation.ITClassDelegate.DidChangeMutteringVolume(XmlDocumentation.TClass,System.Double)">
+            <summary>TClassDelegate.DidChangeMutteringVolume</summary>
+        </member>
+        <member name="M:XmlDocumentation.ITClassDelegate._DidChangeMutteringVolume(XmlDocumentation.ITClassDelegate,XmlDocumentation.TClass,System.Double)">
+            <summary>TClassDelegate.DidChangeMutteringVolume</summary>
+        </member>
         <member name="T:XmlDocumentation.TClassDelegate_Extensions">
             <summary>Extension methods to the <see cref="T:XmlDocumentation.ITClassDelegate" /> interface to support all the methods from the TClassDelegate protocol.</summary>
             <remarks>
@@ -588,6 +604,9 @@
         </member>
         <member name="M:XmlDocumentation.TClassDelegate_Extensions.DidChangeUtteringSpeed(XmlDocumentation.ITClassDelegate,XmlDocumentation.TClass,System.Double)">
             <summary>TClassDelegate.DidChangeUtteringSpeed</summary>
+        </member>
+        <member name="M:XmlDocumentation.TClassDelegate_Extensions.DidChangeMutteringVolume(XmlDocumentation.ITClassDelegate,XmlDocumentation.TClass,System.Double)">
+            <summary>TClassDelegate.DidChangeMutteringVolume</summary>
         </member>
         <member name="T:XmlDocumentation.TClassDelegate">
             <summary>TClassDelegate</summary>
@@ -651,6 +670,9 @@
                     Developers should not invoke this method directly, instead they should call <see cref="M:ObjCRuntime.Runtime.GetNSObject(System.IntPtr)" /> as it will prevent two instances of a managed object pointing to the same native object.
                 </para>
             </remarks>
+        </member>
+        <member name="M:XmlDocumentation.TClassDelegate.DidChangeMutteringVolume(XmlDocumentation.TClass,System.Double)">
+            <summary>TClassDelegate.DidChangeMutteringVolume</summary>
         </member>
         <member name="M:XmlDocumentation.TClassDelegate.DidChangeUtteringSpeed(XmlDocumentation.TClass,System.Double)">
             <summary>TClassDelegate.DidChangeUtteringSpeed</summary>

--- a/tests/generator/ExpectedXmlDocs.tvOS.xml
+++ b/tests/generator/ExpectedXmlDocs.tvOS.xml
@@ -564,6 +564,16 @@
         <member name="F:XmlDocumentation.TClass.__mt_WeakDelegate_var">
             <summary>TClass.WeakDelegate</summary>
         </member>
+        <member name="E:XmlDocumentation.TClass.DidChangeMutteringVolume">
+            <summary>TClassDelegate.DidChangeMutteringVolume - EventArgs.</summary>
+        </member>
+        <member name="T:XmlDocumentation.TMutteranceEventArgs">
+            <summary>Provides data for an event based on an Objective-C protocol method.</summary>
+        </member>
+        <member name="M:XmlDocumentation.TMutteranceEventArgs.#ctor(System.Double)">
+            <summary>Create a new instance of the <see cref="T:XmlDocumentation.TMutteranceEventArgs" /> with the specified event data.</summary>
+            <param name="mutteringVolume">The value for the <see cref="P:XmlDocumentation.TMutteranceEventArgs.MutteringVolume" /> property.</param>
+        </member>
         <member name="T:XmlDocumentation.TUtteranceEventArgs">
             <summary>Provides data for an event based on an Objective-C protocol method.</summary>
         </member>
@@ -580,6 +590,12 @@
         <member name="M:XmlDocumentation.ITClassDelegate._DidChangeUtteringSpeed(XmlDocumentation.ITClassDelegate,XmlDocumentation.TClass,System.Double)">
             <summary>TClassDelegate.DidChangeUtteringSpeed</summary>
         </member>
+        <member name="M:XmlDocumentation.ITClassDelegate.DidChangeMutteringVolume(XmlDocumentation.TClass,System.Double)">
+            <summary>TClassDelegate.DidChangeMutteringVolume</summary>
+        </member>
+        <member name="M:XmlDocumentation.ITClassDelegate._DidChangeMutteringVolume(XmlDocumentation.ITClassDelegate,XmlDocumentation.TClass,System.Double)">
+            <summary>TClassDelegate.DidChangeMutteringVolume</summary>
+        </member>
         <member name="T:XmlDocumentation.TClassDelegate_Extensions">
             <summary>Extension methods to the <see cref="T:XmlDocumentation.ITClassDelegate" /> interface to support all the methods from the TClassDelegate protocol.</summary>
             <remarks>
@@ -588,6 +604,9 @@
         </member>
         <member name="M:XmlDocumentation.TClassDelegate_Extensions.DidChangeUtteringSpeed(XmlDocumentation.ITClassDelegate,XmlDocumentation.TClass,System.Double)">
             <summary>TClassDelegate.DidChangeUtteringSpeed</summary>
+        </member>
+        <member name="M:XmlDocumentation.TClassDelegate_Extensions.DidChangeMutteringVolume(XmlDocumentation.ITClassDelegate,XmlDocumentation.TClass,System.Double)">
+            <summary>TClassDelegate.DidChangeMutteringVolume</summary>
         </member>
         <member name="T:XmlDocumentation.TClassDelegate">
             <summary>TClassDelegate</summary>
@@ -651,6 +670,9 @@
                     Developers should not invoke this method directly, instead they should call <see cref="M:ObjCRuntime.Runtime.GetNSObject(System.IntPtr)" /> as it will prevent two instances of a managed object pointing to the same native object.
                 </para>
             </remarks>
+        </member>
+        <member name="M:XmlDocumentation.TClassDelegate.DidChangeMutteringVolume(XmlDocumentation.TClass,System.Double)">
+            <summary>TClassDelegate.DidChangeMutteringVolume</summary>
         </member>
         <member name="M:XmlDocumentation.TClassDelegate.DidChangeUtteringSpeed(XmlDocumentation.TClass,System.Double)">
             <summary>TClassDelegate.DidChangeUtteringSpeed</summary>

--- a/tests/generator/tests/xmldocs.cs
+++ b/tests/generator/tests/xmldocs.cs
@@ -250,6 +250,13 @@ namespace XmlDocumentation {
 		[Export ("speechSynthesizer:didChangeUtteringSpeedTo:")]
 		[EventArgs ("TUtterance")]
 		void DidChangeUtteringSpeed (TClass obj, double utteringSpeed);
+
+		/// <summary>TClassDelegate.DidChangeMutteringVolume</summary>
+		[Export ("speechSynthesizer:didChangeMutteringVolumeTo:")]
+		[EventArgs ("TMutterance", XmlDocs = """
+			<summary>TClassDelegate.DidChangeMutteringVolume - EventArgs.</summary>
+			""")]
+		void DidChangeMutteringVolume (TClass obj, double mutteringVolume);
 	}
 
 	interface ITClassDelegate { }


### PR DESCRIPTION
This is accomplished by adding a new `XmlDocs` property to the EventArgs
attribute.