### PR TITLE
[CoreLocation] Improve and simplify the manually bound constructors for CLBeaconRegion slightly.

### DIFF
--- a/src/CoreLocation/CLBeaconRegion.cs
+++ b/src/CoreLocation/CLBeaconRegion.cs
@@ -1,33 +1,158 @@
 #nullable enable
 
-#if iOS
+#if __IOS__ || __MACCATALYST__ || __MACOS__
 
 using System;
 
+using Foundation;
 using ObjCRuntime;
 
+#nullable enable
+
 namespace CoreLocation {
+	/// <summary>This enum is used to select how to initialize a new instance of a <see cref="CLBeaconRegion" />.</summary>
+	public enum CLBeaconRegionUuidType {
+		/// <summary>The specified <see cref="NSUuid" /> is a proximity uuid.</summary>
+		[SupportedOSPlatform ("ios")]
+		[SupportedOSPlatform ("maccatalyst")]
+		[SupportedOSPlatform ("macos")]
+		[UnsupportedOSPlatform ("tvos")]
+		[ObsoletedOSPlatform ("ios13.0", "Use 'CLBeaconRegionUuidType.Uuid' instead, the constructor for this value deprecated.")]
+		[ObsoletedOSPlatform ("maccatalyst", "Use 'CLBeaconRegionUuidType.Uuid' instead, the constructor for this value deprecated.")]
+		[ObsoletedOSPlatform ("macos", "Use 'CLBeaconRegionUuidType.Uuid' instead, the constructor for this value deprecated.")]
+		ProximityUuid,
+		/// <summary>The specified <see cref="NSUuid" /> is not a proximity uuid.</summary>
+		Uuid,
+	}
 
 	public partial class CLBeaconRegion {
+		/// <summary>Constructor that produces a region identified by <paramref name="identifier" /> that reports iBeacons associated with the <paramref name="proximityUuid" />.</summary>
+		/// <param name="proximityUuid">The unique ID of the iBeacons of interest.</param>
+		/// <param name="identifier">The name of the region to be created.</param>
+		[ObsoletedOSPlatform ("ios13.0", "Use the constructor that takes an 'CLBeaconRegionUuidType' value instead, and pass 'CLBeaconRegionUuidType.Uuid'.")]
+		[ObsoletedOSPlatform ("maccatalyst", "Use the constructor that takes an 'CLBeaconRegionUuidType' value instead, and pass 'CLBeaconRegionUuidType.Uuid'.")]
+		[ObsoletedOSPlatform ("macos", "Use the constructor that takes an 'CLBeaconRegionUuidType' value instead, and pass 'CLBeaconRegionUuidType.Uuid'.")]
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("ios")]
+		[SupportedOSPlatform ("maccatalyst")]
+		[UnsupportedOSPlatform ("tvos")]
+		public CLBeaconRegion (NSUuid proximityUuid, string identifier)
+			: base (NSObjectFlag.Empty)
+		{
+			InitializeHandle (_InitWithProximityUuid (proximityUuid, identifier), "initWithProximityUUID:identifier:");
+		}
 
-#if NET
+		/// <summary>Constructor that produces a region identified by <paramref name="identifier" /> that reports iBeacons associated with the <paramref name="uuid" />.</summary>
+		/// <param name="uuid">The unique ID of the iBeacons of interest.</param>
+		/// <param name="identifier">The name of the region to be created.</param>
+		/// <param name="uuidType">Specifies whether the beacon is a proximity uuid or not.</param>
+		public CLBeaconRegion (NSUuid uuid, string identifier, CLBeaconRegionUuidType uuidType)
+			: base (NSObjectFlag.Empty)
+		{
+			switch (uuidType) {
+			case CLBeaconRegionUuidType.ProximityUuid:
+				InitializeHandle (_InitWithProximityUuid (uuid, identifier), "initWithProximityUUID:identifier:");
+				break;
+			case CLBeaconRegionUuidType.Uuid:
+				InitializeHandle (_InitWithUuid (uuid, identifier), "initWithUUID:identifier:");
+				break;
+			default:
+				throw new ArgumentException (nameof (uuidType));
+			}
+		}
+
+		/// <summary>Constructor that produces a region identified by <paramref name="identifier" /> that reports iBeacons associated with the <paramref name="proximityUuid" /> and that assigns the <see cref="P:CoreLocation.CLBeaconRegion.Major" /> property.</summary>
+		/// <param name="proximityUuid">The unique ID of the iBeacons of interest.</param>
+		/// <param name="major">Can be used by the app developer for any purpose.</param>
+		/// <param name="identifier">The name of the region to be created.</param>
+		[ObsoletedOSPlatform ("ios13.0", "Use the constructor that takes an 'CLBeaconRegionUuidType' value instead, and pass 'CLBeaconRegionUuidType.Uuid'.")]
+		[ObsoletedOSPlatform ("maccatalyst", "Use the constructor that takes an 'CLBeaconRegionUuidType' value instead, and pass 'CLBeaconRegionUuidType.Uuid'.")]
+		[ObsoletedOSPlatform ("macos", "Use the constructor that takes an 'CLBeaconRegionUuidType' value instead, and pass 'CLBeaconRegionUuidType.Uuid'.")]
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("ios")]
+		[SupportedOSPlatform ("maccatalyst")]
+		[UnsupportedOSPlatform ("tvos")]
+		public CLBeaconRegion (NSUuid proximityUuid, ushort major, string identifier)
+			: base (NSObjectFlag.Empty)
+		{
+			InitializeHandle (_InitWithProximityUuid (proximityUuid, major, identifier), "initWithProximityUUID:major:identifier:");
+		}
+
+		/// <summary>Constructor that produces a region identified by <paramref name="identifier" /> that reports iBeacons associated with the <paramref name="uuid" /> and that assigns the <see cref="P:CoreLocation.CLBeaconRegion.Major" /> property.</summary>
+		/// <param name="uuid">The unique ID of the iBeacons of interest.</param>
+		/// <param name="major">Can be used by the app developer for any purpose.</param>
+		/// <param name="identifier">The name of the region to be created.</param>
+		/// <param name="uuidType">Specifies whether the beacon is a proximity uuid or not.</param>
+		public CLBeaconRegion (NSUuid uuid, ushort major, string identifier, CLBeaconRegionUuidType uuidType)
+			: base (NSObjectFlag.Empty)
+		{
+			switch (uuidType) {
+			case CLBeaconRegionUuidType.ProximityUuid:
+				InitializeHandle (_InitWithProximityUuid (uuid, major, identifier), "initWithProximityUUID:major:identifier:");
+				break;
+			case CLBeaconRegionUuidType.Uuid:
+				InitializeHandle (_InitWithUuid (uuid, major, identifier), "initWithUUID:major:identifier:");
+				break;
+			default:
+				throw new ArgumentException (nameof (uuidType));
+			}
+		}
+
+		/// <summary>Constructor that produces a region identified by <paramref name="identifier" /> that reports iBeacons associated with the <paramref name="proximityUuid" /> and that assigns the <see cref="P:CoreLocation.CLBeaconRegion.Major" /> and <see cref="P:CoreLocation.CLBeaconRegion.Minor" /> properties.</summary>
+		/// <param name="proximityUuid">The unique ID of the iBeacons of interest.</param>
+		/// <param name="major">Can be used by the app developer for any purpose.</param>
+		/// <param name="minor">Can be used by the app developer for any purpose.</param>
+		/// <param name="identifier">The name of the region to be created.</param>
+		[ObsoletedOSPlatform ("ios13.0", "Use the constructor that takes an 'CLBeaconRegionUuidType' value instead, and pass 'CLBeaconRegionUuidType.Uuid'.")]
+		[ObsoletedOSPlatform ("maccatalyst", "Use the constructor that takes an 'CLBeaconRegionUuidType' value instead, and pass 'CLBeaconRegionUuidType.Uuid'.")]
+		[ObsoletedOSPlatform ("macos", "Use the constructor that takes an 'CLBeaconRegionUuidType' value instead, and pass 'CLBeaconRegionUuidType.Uuid'.")]
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("ios")]
+		[SupportedOSPlatform ("maccatalyst")]
+		[UnsupportedOSPlatform ("tvos")]
+		public CLBeaconRegion (NSUuid proximityUuid, ushort major, ushort minor, string identifier)
+			: base (NSObjectFlag.Empty)
+		{
+			InitializeHandle (_InitWithProximityUuid (proximityUuid, major, minor, identifier), "initWithProximityUUID:major:minor:identifier:");
+		}
+
+		/// <summary>Constructor that produces a region identified by <paramref name="identifier" /> that reports iBeacons associated with the <paramref name="uuid" /> and that assigns the <see cref="P:CoreLocation.CLBeaconRegion.Major" /> and <see cref="P:CoreLocation.CLBeaconRegion.Minor" /> properties.</summary>
+		/// <param name="uuid">The unique ID of the iBeacons of interest.</param>
+		/// <param name="major">Can be used by the app developer for any purpose.</param>
+		/// <param name="minor">Can be used by the app developer for any purpose.</param>
+		/// <param name="identifier">The name of the region to be created.</param>
+		/// <param name="uuidType">Specifies whether the beacon is a proximity uuid or not.</param>
+		public CLBeaconRegion (NSUuid uuid, ushort major, ushort minor, string identifier, CLBeaconRegionUuidType uuidType)
+			: base (NSObjectFlag.Empty)
+		{
+			switch (uuidType) {
+			case CLBeaconRegionUuidType.ProximityUuid:
+				InitializeHandle (_InitWithProximityUuid (uuid, major, minor, identifier), "initWithProximityUUID:major:minor:identifier:");
+				break;
+			case CLBeaconRegionUuidType.Uuid:
+				InitializeHandle (_InitWithUuid (uuid, major, minor, identifier), "initWithUUID:major:minor:identifier:");
+				break;
+			default:
+				throw new ArgumentException (nameof (uuidType));
+			}
+		}
+
+		/// <summary>Create a new <see cref="CLBeaconRegion" /> instance.</summary>
+		/// <param name="uuid">The unique ID of the iBeacons of interest.</param>
+		/// <param name="major">Can be used by the app developer for any purpose.</param>
+		/// <param name="minor">Can be used by the app developer for any purpose.</param>
+		/// <param name="identifier">The name of the region to be created.</param>
 		[SupportedOSPlatform ("ios13.0")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[UnsupportedOSPlatform ("tvos")]
-#else
-		[Introduced (PlatformName.iOS, 13,0, PlatformArchitecture.All)]
-#endif
-		static public CLBeaconRegion Create (NSUuid uuid, ushort? major, ushort? minor, string identifier)
+		public static CLBeaconRegion Create (NSUuid uuid, ushort? major, ushort? minor, string identifier)
 		{
-			var handle = IntPtr.Zero;
 			if (!major.HasValue)
-				handle = _Constructor (uuid, identifier);
-			else if (!minor.HasValue)
-				handle = _Constructor (uuid, major.Value, identifier);
-			else
-				handle = _Constructor (uuid, major.Value, minor.Value, identifier);
-			return new CLBeaconRegion (handle);
+				return new CLBeaconRegion (uuid, identifier, CLBeaconRegionUuidType.Uuid);
+			if (!minor.HasValue)
+				return new CLBeaconRegion (uuid, major.Value, identifier, CLBeaconRegionUuidType.Uuid);
+			return new CLBeaconRegion (uuid, major.Value, minor.Value, identifier, CLBeaconRegionUuidType.Uuid);
 		}
 	}
 }

--- a/src/corelocation.cs
+++ b/src/corelocation.cs
@@ -1301,57 +1301,53 @@ namespace CoreLocation {
 		/// <param name="proximityUuid">The unique ID of the iBeacons of interest.</param>
 		/// <param name="identifier">The name of the region to be created.</param>
 		/// <summary>Constructor that produces a region identified by <paramref name="identifier" /> that reports iBeacons associated with the <paramref name="proximityUuid" />.</summary>
-		/// <remarks>To be added.</remarks>
-		[NoMac]
+		[Internal]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use the 'Create' method or the constructor using 'CLBeaconIdentityConstraint' instead.")]
 		[MacCatalyst (13, 1)]
 		[Deprecated (PlatformName.MacCatalyst, 13, 1, message: "Use the 'Create' method or the constructor using 'CLBeaconIdentityConstraint' instead.")]
 		[Export ("initWithProximityUUID:identifier:")]
-		NativeHandle Constructor (NSUuid proximityUuid, string identifier);
+		NativeHandle _InitWithProximityUuid (NSUuid proximityUuid, string identifier);
 
-		[NoMac]
 		[iOS (13, 0)]
 		[MacCatalyst (13, 1)]
 		[Internal] // signature conflict with deprecated API
 		[Export ("initWithUUID:identifier:")]
-		IntPtr _Constructor (NSUuid uuid, string identifier);
+		IntPtr _InitWithUuid (NSUuid uuid, string identifier);
 
 		/// <param name="proximityUuid">The unique ID of the iBeacons of interest.</param>
 		/// <param name="major">Can be used by the app developer for any purpose.</param>
 		/// <param name="identifier">The name of the region to be created.</param>
 		/// <summary>Constructor that produces a region identified by <paramref name="identifier" /> that reports iBeacons associated with the <paramref name="proximityUuid" /> and that assigns the <see cref="P:CoreLocation.CLBeaconRegion.Major" /> property.</summary>
-		/// <remarks>To be added.</remarks>
-		[NoMac]
+		[Internal]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use the 'Create' method or the constructor using 'CLBeaconIdentityConstraint' instead.")]
 		[MacCatalyst (13, 1)]
 		[Deprecated (PlatformName.MacCatalyst, 13, 1, message: "Use the 'Create' method or the constructor using 'CLBeaconIdentityConstraint' instead.")]
 		[Export ("initWithProximityUUID:major:identifier:")]
-		NativeHandle Constructor (NSUuid proximityUuid, ushort major, string identifier);
+		NativeHandle _InitWithProximityUuid (NSUuid proximityUuid, ushort major, string identifier);
 
 		[iOS (13, 0)]
 		[MacCatalyst (13, 1)]
 		[Internal] // signature conflict with deprecated API
 		[Export ("initWithUUID:major:identifier:")]
-		IntPtr _Constructor (NSUuid uuid, ushort major, string identifier);
+		IntPtr _InitWithUuid (NSUuid uuid, ushort major, string identifier);
 
 		/// <param name="proximityUuid">The unique ID of the iBeacons of interest.</param>
 		/// <param name="major">Can be used by the app developer for any purpose.</param>
 		/// <param name="minor">Can be used by the app developer for any purpose.</param>
 		/// <param name="identifier">The name of the region to be created.</param>
-		/// <summary>Constructor that produces a region identified by <paramref name="identifier" /> that reports iBeacons associated with the <paramref name="proximityUuid" /> and that assigns the <see cref="P:CoreLocation.CLBeaconRegion.Major" /><see cref="P:CoreLocation.CLBeaconRegion.Minor" /> properties.</summary>
-		/// <remarks>To be added.</remarks>
-		[NoMac]
+		/// <summary>Constructor that produces a region identified by <paramref name="identifier" /> that reports iBeacons associated with the <paramref name="proximityUuid" /> and that assigns the <see cref="P:CoreLocation.CLBeaconRegion.Major" /> and <see cref="P:CoreLocation.CLBeaconRegion.Minor" /> properties.</summary>
+		[Internal]
 		[Deprecated (PlatformName.iOS, 13, 0, message: "Use the 'Create' method or the constructor using 'CLBeaconIdentityConstraint' instead.")]
 		[MacCatalyst (13, 1)]
 		[Deprecated (PlatformName.MacCatalyst, 13, 1, message: "Use the 'Create' method or the constructor using 'CLBeaconIdentityConstraint' instead.")]
 		[Export ("initWithProximityUUID:major:minor:identifier:")]
-		NativeHandle Constructor (NSUuid proximityUuid, ushort major, ushort minor, string identifier);
+		NativeHandle _InitWithProximityUuid (NSUuid proximityUuid, ushort major, ushort minor, string identifier);
 
 		[iOS (13, 0)]
 		[MacCatalyst (13, 1)]
 		[Internal] // signature conflict with deprecated API
 		[Export ("initWithUUID:major:minor:identifier:")]
-		IntPtr _Constructor (NSUuid uuid, ushort major, ushort minor, string identifier);
+		IntPtr _InitWithUuid (NSUuid uuid, ushort major, ushort minor, string identifier);
 
 		[iOS (13, 0)]
 		[MacCatalyst (13, 1)]


### PR DESCRIPTION
Improve and simplify the manually bound constructors for CLBeaconRegion by
using the same pattern we use elsewhere for manually bound constructors.