### PR TITLE
[dotnet] Build all scripts before doing surgery on the local .NET installation.

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -304,7 +304,7 @@ TARGETS += $(RUNTIME_PACKS) $(REF_PACKS) $(SDK_PACKS) $(TEMPLATE_PACKS) $(WORKLO
 
 define InstallWorkload
 # .NET comes with a workload for us, but we don't want that, we want our own. So delete the workload that comes with .NET.
-.stamp-workload-replace-$1-$(DOTNET_VERSION):
+.stamp-workload-replace-$1-$(DOTNET_VERSION): $$(ALL_SCRIPTS)
 	$(Q) echo "Removing existing workload shipped with .NET $(DOTNET_VERSION): $(shell echo $(DOTNET_SDK_MANIFESTS_PATH)/*/microsoft.net.sdk.$3)"
 	$(Q) rm -Rf $(DOTNET_SDK_MANIFESTS_PATH)/*/microsoft.net.sdk.$3
 	$(Q) rm -Rf $(DOTNET_SDK_MANIFESTS_PATH)/*/workloadsets

--- a/scripts/template.mk
+++ b/scripts/template.mk
@@ -1,6 +1,7 @@
 define TemplateScript
 $(1)=$(TOP)/scripts/$(2)/bin/Debug/$(2).dll
 $(1)_EXEC=$(DOTNET) exec $$($(1))
+ALL_SCRIPTS+=$(TOP)/scripts/$(2)/bin/Debug/$(2).dll
 
 $$($(1)): $$(wildcard $$(TOP)/scripts/$(2)/*.cs) $$(wildcard $$(TOP)/scripts/$(2)/*.csproj)
 	$$(Q) $$(DOTNET) build $(TOP)/scripts/$(2)/*.csproj /bl:$$(TOP)/scripts/$(2)/msbuild.binlog $$(DOTNET_BUILD_VERBOSITY)


### PR DESCRIPTION
Hopefully fixes this random build error:

    gmake[1]: Entering directory '[...]/macios/dotnet'
    GEN      Microsoft.iOS.Sdk.Versions.props
    GEN      Microsoft.tvOS.Sdk.Versions.props
    GEN      Microsoft.macOS.Sdk.Versions.props
    GEN      Microsoft.MacCatalyst.Sdk.Versions.props
    GEN      Microsoft.iOS.Sdk.DefaultItems.props
    GEN      Microsoft.iOS.Sdk.ImplicitNamespaceImports.props
    GEN      AutoImport.props
    GEN      Microsoft.tvOS.Sdk.ImplicitNamespaceImports.props
    GEN      Microsoft.tvOS.Sdk.DefaultItems.props
    GEN      AutoImport.props
    GEN      Microsoft.MacCatalyst.Sdk.DefaultItems.props
    GEN      Microsoft.MacCatalyst.Sdk.ImplicitNamespaceImports.props
    GEN      AutoImport.props
    GEN      AutoImport.props
    GEN      Microsoft.macOS.Sdk.ImplicitNamespaceImports.props
    GEN      Microsoft.macOS.Sdk.DefaultItems.props
    Removing existing workload shipped with .NET 9.0.106-servicing.25217.33: [...]/macios/builds/downloads/dotnet-sdk-9.0.106-servicing.25217.33/sdk-manifests/9.0.100/microsoft.net.sdk.ios
    Removing existing workload shipped with .NET 9.0.106-servicing.25217.33: [...]/macios/builds/downloads/dotnet-sdk-9.0.106-servicing.25217.33/sdk-manifests/9.0.100/microsoft.net.sdk.tvos
    Removing existing workload shipped with .NET 9.0.106-servicing.25217.33: [...]/macios/builds/downloads/dotnet-sdk-9.0.106-servicing.25217.33/sdk-manifests/9.0.100/microsoft.net.sdk.maccatalyst
    [...]/macios/builds/downloads/dotnet-sdk-9.0.106-servicing.25217.33/sdk/9.0.106/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.ImportWorkloads.props(14,38): error MSB4242:
      SDK Resolver Failure: "The SDK resolver "Microsoft.DotNet.MSBuildWorkloadSdkResolver" failed while attempting to resolve the SDK "Microsoft.NET.SDK.WorkloadAutoImportPropsLocator". Exception: "System.IO
      .DirectoryNotFoundException: Could not find a part of the path '[...]/macios/builds/downloads/dotnet-sdk-9.0.106-servicing.25217.33/sdk-manifests/9.0.100/microsoft.net.sdk.
      ios'.
         at System.IO.Enumeration.FileSystemEnumerator`1.CreateDirectoryHandle(String path, Boolean ignoreNotFound)
         at System.IO.Enumeration.FileSystemEnumerator`1.Init()
         at System.IO.Enumeration.FileSystemEnumerable`1..ctor(String directory, FindTransform transform, EnumerationOptions options, Boolean isNormalized)
         at System.IO.Enumeration.FileSystemEnu[...]/macios/builds/downloads/dotnet-sdk-9.0.106-servicing.25217.33/sdk/9.0.106/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.ImportWorkloads.props(14,38): error MSB4242:
      SDK Resolver Failure: "The SDK resolver "Microsoft.DotNet.MSBuildWorkloadSdkResolver" failed while attempting to resolve the SDK "Microsoft.NET.SDK.WorkloadAutoImportPropsLocator". Exception: "System.IO
      .DirectoryNotFoundException: Could not find a part of the path '[...]/macios/builds/downloads/dotnet-sdk-9.0.106-servicing.25217.33/sdk-manifests/9.0.100/microsoft.net.sdk.
      ios'.
         at System.IO.Enumeration.FileSystemEnumerator`1.CreateDirectoryHandle(String path, Boolean ignoreNotFound)
         at System.IO.Enumeration.FileSystemEnumerator`1.Init()
         at System.IO.Enumeration.FileSystemEnumerable`1..ctor(String directory, FindTransform transform, EnumerationOptions options, Boolean isNormalized)
         at System.IO.Enumeration.FileSystemEnumerableFactory.UserDirectories(String directory, String expression, EnumerationOptions options)
         at System.IO.Directory.InternalEnumeratePaths(String path, String searchPattern, SearchTarget searchTarget, EnumerationOptions options)
         at System.IO.Directory.GetDirectories(String path, String searchPattern, EnumerationOptions enumerationOptions)
         at Microsoft.NET.Sdk.WorkloadManifestReader.SdkDirectoryWorkloadManifestProvider.ResolveManifestDirectory(String manifestDirectory)
         at Microsoft.NET.Sdk.WorkloadManifestReader.SdkDirectoryWorkloadManifestProvider.<>c__DisplayClass22_0.<GetManifests>g__ProbeDirectory|1(String manifestDirectory, String featureBand)
         at Microsoft.NET.Sdk.WorkloadManifestReader.SdkDirectoryWorkloadManifestProvider.GetManifests()
         at Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver.LoadManifestsFromProvider(IWorkloadManifestProvider manifestProvider)
         at Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver.InitializeManifests()
         at Micr[...]/macios/builds/downloads/dotnet-sdk-9.0.106-servicing.25217.33/sdk/9.0.106/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.ImportWorkloads.props(14,38): error MSB4242:
      SDK Resolver Failure: "The SDK resolver "Microsoft.DotNet.MSBuildWorkloadSdkResolver" failed while attempting to resolve the SDK "Microsoft.NET.SDK.WorkloadAutoImportPropsLocator". Exception: "System.IO
      .DirectoryNotFoundException: Could not find a part of the path '[...]/macios/builds/downloads/dotnet-sdk-9.0.106-servicing.25217.33/sdk-manifests/9.0.100/microsoft.net.sdk.
      ios'.
         at System.IO.Enumeration.FileSystemEnumerator`1.CreateDirectoryHandle(String path, Boolean ignoreNotFound)
         at System.IO.Enumeration.FileSystemEnumerator`1.Init()
         at System.IO.Enumeration.FileSystemEnumerable`1..ctor(String directory, FindTransform transform, EnumerationOptions options, Boolean isNormalized)
         at System.IO.Enumeration.FileSystemEnumerableFactory.UserDirectories(String directory, String expression, EnumerationOptions options)
         at System.IO.Directory.InternalEnumeratePaths(String path, String searchPattern, SearchTarget searchTarget, EnumerationOptions options)
         at System.IO.merableFactory.UserDirectories(String directory, String expression, EnumerationOptions options)
         at System.IO.Directory.InternalEnumeratePaths(String path, String searchPattern, SearchTarget searchTarget, EnumerationOptions options)
         at System.IO.Directory.GetDirectories(String path, String searchPattern, EnumerationOptions enumerationOptions)
         at Microsoft.NET.Sdk.WorkloadManifestReader.SdkDirectoryWorkloadManifestProvider.ResolveManifestDirectory(String manifestDirectory)
         at Microsoft.NET.Sdk.WorkloadManifestReader.SdkDirectoryWorkloadManifestProvider.<>c__DisplayClass22_0.<GetManifests>g__ProbeDirectory|1(String manifestDirectory, String featureBand)
         at Microsoft.NET.Sdk.WorkloadManifestReader.SdkDirectoryWorkloadManifestProvider.GetManifests()
         at Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver.LoadManifestsFromProvider(IWorkloadManifestProvider manifestProvider)
         at Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver.InitializeManifests()
         at Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver.GetInstalledWorkloadPacksOfKind(WorkloadPackKind kind)+MoveNext()
         at Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.CachingWorkloadResolver.Resolve(String sdkReferenceName, IWorkloadManifestProvider manifestProvider, IWorkloadResolver workloadResolver)
         at Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.CachingWorkloadResolver.Resolve(String sdkReferenceName, String dotnetRootPath, String sdkVersion, String userProfileDir, String globalJsonPath)
         at Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.WorkloadSdkResolver.Resolve(SdkReference sdkReference, SdkResolverContext resolverContext, SdkResultFactory factory)
         at Microsoft.Build.BackEnd.SdkResolution.SdkResolverService.TryResolveSdkUsingSpecifiedResolvers(IReadOnlyList`1 resolvers, Int32 submissionId, SdkReference sdk, LoggingContext loggingContext, Elemen
      tLocation sdkReferenceLocation, String solutionPath, String projectPath, Boolean interactive, Boolean isRunningInVisualStudio, SdkResult& sdkResult, IEnumerable`1& errors, IEnumerable`1& warnings)""
    osoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver.GetInstalledWorkloadPacksOfKind(WorkloadPackKind kind)+MoveNext()
         at Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.CachingWorkloadResolver.Resolve(String sdkReferenceName, IWorkloadManifestProvider manifestProvider, IWorkloadResolver workloadResolver)
         at Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.CachingWorkloadResolver.Resolve(String sdkReferenceName, String dotnetRootPath, String sdkVersion, String userProfileDir, String globalJsonPath)
         at Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.WorkloadSdkResolver.Resolve(SdkReference sdkReference, SdkResolverContext resolverContext, SdkResultFactory factory)
         at Microsoft.Build.BackEnd.SdkResolution.SdkResolverService.TryResolveSdkUsingSpecifiedResolvers(IReadOnlyList`1 resolvers, Int32 submissionId, SdkReference sdk, LoggingContext loggingContext, Elemen
      tLocation sdkReferenceLocation, String solutionPath, String projectPath, Boolean interactive, Boolean isRunningInVisualStudio, SdkResult& sdkResult, IEnumerable`1& errors, IEnumerable`1& warnings)""
    Directory.GetDirectories(String path, String searchPattern, EnumerationOptions enumerationOptions)
         at Microsoft.NET.Sdk.WorkloadManifestReader.SdkDirectoryWorkloadManifestProvider.ResolveManifestDirectory(String manifestDirectory)
         at Microsoft.NET.Sdk.WorkloadManifestReader.SdkDirectoryWorkloadManifestProvider.<>c__DisplayClass22_0.<GetManifests>g__ProbeDirectory|1(String manifestDirectory, String featureBand)
         at Microsoft.NET.Sdk.WorkloadManifestReader.SdkDirectoryWorkloadManifestProvider.GetManifests()
         at Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver.LoadManifestsFromProvider(IWorkloadManifestProvider manifestProvider)
         at Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver.InitializeManifests()
         at Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver.GetInstalledWorkloadPacksOfKind(WorkloadPackKind kind)+MoveNext()
         at Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.CachingWorkloadResolver.Resolve(String sdkReferenceName, IWorkloadManifestProvider manifestProvider, IWorkloadResolver workloadResolver)
         at Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.CachingWorkloadResolver.Resolve(String sdkReferenceName, String dotnetRootPath, String sdkVersion, String userProfileDir, String globalJsonPath)
         at Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.WorkloadSdkResolver.Resolve(SdkReference sdkReference, SdkResolverContext resolverContext, SdkResultFactory factory)
         at Microsoft.Build.BackEnd.SdkResolution.SdkResolverService.TryResolveSdkUsingSpecifiedResolvers(IReadOnlyList`1 resolvers, Int32 submissionId, SdkReference sdk, LoggingContext loggingContext, Elemen
      tLocation sdkReferenceLocation, String solutionPath, String projectPath, Boolean interactive, Boolean isRunningInVisualStudio, SdkResult& sdkResult, IEnumerable`1& errors, IEnumerable`1& warnings)""
    [...]/macios/builds/downloads/dotnet-sdk-9.0.106-servicing.25217.33/sdk/9.0.106/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.ImportWorkloads.props(14,38): error MSB4242:
      SDK Resolver Failure: "The SDK resolver "Microsoft.DotNet.MSBuildWorkloadSdkResolver" failed while attempting to resolve the SDK "Microsoft.NET.SDK.WorkloadAutoImportPropsLocator". Exception: "System.IO
      .DirectoryNotFoundException: Could not find a part of the path '[...]/macios/builds/downloads/dotnet-sdk-9.0.106-servicing.25217.33/sdk-manifests/9.0.100/microsoft.net.sdk.
      ios'.
         at System.IO.Enumeration.FileSystemEnumerator`1.CreateDirectoryHandle(String path, Boolean ignoreNotFound)
         at System.IO.Enumeration.FileSystemEnumerator`1.Init()
         at System.IO.Enumeration.FileSystemEnumerable`1..ctor(String directory, FindTransform transform, EnumerationOptions options, Boolean isNormalized)
         at System.IO.Enumeration.FileSystemEnumerableFactory.UserDirectories(String directory, String expression, EnumerationOptions options)
         at System.IO.Directory.InternalEnumeratePaths(String path, String searchPattern, SearchTarget searchTarget, EnumerationOptions options)
         at System.IO.Directory.GetDirectories(String path, String searchPattern, EnumerationOptions enumerationOptions)
         at Microsoft.NET.Sdk.WorkloadManifestReader.SdkDirectoryWorkloadManifestProvider.ResolveManifestDirectory(String manifestDirectory)
         at Microsoft.NET.Sdk.WorkloadManifestReader.SdkDirectoryWorkloadManifestProvider.<>c__DisplayClass22_0.<GetManifests>g__ProbeDirectory|1(String manifestDirectory, String featureBand)
         at Microsoft.NET.Sdk.WorkloadManifestReader.SdkDirectoryWorkloadManifestProvider.GetManifests()
         at Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver.LoadManifestsFromProvider(IWorkloadManifestProvider manifestProvider)
         at Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver.InitializeManifests()
         at Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver.GetInstalledWorkloadPacksOfKind(WorkloadPackKind kind)+MoveNext()
         at Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.CachingWorkloadResolver.Resolve(String sdkReferenceName, IWorkloadManifestProvider manifestProvider, IWorkloadResolver workloadResolver)
         at Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.CachingWorkloadResolver.Resolve(String sdkReferenceName, String dotnetRootPath, String sdkVersion, String userProfileDir, String globalJsonPath)
         at Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.WorkloadSdkResolver.Resolve(SdkReference sdkReference, SdkResolverContext resolverContext, SdkResultFactory factory)
         at Microsoft.Build.BackEnd.SdkResolution.SdkResolverService.TryResolveSdkUsingSpecifiedResolvers(IReadOnlyList`1 resolvers, Int32 submissionId, SdkReference sdk, LoggingContext loggingContext, Elemen
      tLocation sdkReferenceLocation, String solutionPath, String projectPath, Boolean interactive, Boolean isRunningInVisualStudio, SdkResult& sdkResult, IEnumerable`1& errors, IEnumerable`1& warnings)""
    Removing existing workload shipped with .NET 9.0.106-servicing.25217.33: [...]/macios/builds/downloads/dotnet-sdk-9.0.106-servicing.25217.33/sdk-manifests/9.0.100/microsoft.net.sdk.macos
    gmake[1]: *** [../scripts/generate-workloaddependencies-json/fragment.mk:2: ../scripts/generate-workloaddependencies-json/bin/Debug/generate-workloaddependencies-json.dll] Error 1
    gmake[1]: *** Waiting for unfinished jobs....
    gmake[1]: *** [../scripts/generate-target-platforms/fragment.mk:2: ../scripts/generate-target-platforms/bin/Debug/generate-target-platforms.dll] Error 1
    gmake[1]: *** [../scripts/generate-workloadmanifest-targets/fragment.mk:2: ../scripts/generate-workloadmanifest-targets/bin/Debug/generate-workloadmanifest-targets.dll] Error 1
    gmake[1]: *** [../scripts/generate-workloadmanifest-json/fragment.mk:2: ../scripts/generate-workloadmanifest-json/bin/Debug/generate-workloadmanifest-json.dll] Error 1
    gmake[1]: Leaving directory '[...]/macios/dotnet'
    gmake: *** [mk/subdirs.mk:18: all-recurse] Error 1