### PR TITLE
[AppKit] Improve and simplify the manually bound constructors for NSTextContainer slightly.

### DIFF
--- a/src/AppKit/NSTextContainer.cs
+++ b/src/AppKit/NSTextContainer.cs
@@ -1,50 +1,50 @@
 #if !__MACCATALYST__ // there's a version in UIKit, use that one instead
 using System;
+
 using CoreGraphics;
+using Foundation;
 using ObjCRuntime;
 
 #nullable enable
 
 namespace AppKit {
 	public partial class NSTextContainer {
-#if !NET
-		[Obsoleted (PlatformName.MacOSX, 10, 11, message: "Use NSTextContainer.FromSize instead.")]
-		public NSTextContainer (CGSize size)
-		{
-			Handle = InitWithContainerSize (size);
-		}
-#endif // !NET
-
+		[SupportedOSPlatform ("macos")]
+		[ObsoletedOSPlatform ("macos", "Use 'new NSTextContainer (CGSize)' instead.")]
+		[UnsupportedOSPlatform ("ios")]
+		[UnsupportedOSPlatform ("maccatalyst")]
+		[UnsupportedOSPlatform ("tvos")]
 		internal NSTextContainer (CGSize size, bool isContainer)
+			: base (NSObjectFlag.Empty)
 		{
-			if (isContainer)
-				Handle = InitWithContainerSize (size);
-			else
-				Handle = InitWithSize (size);
+			if (isContainer) {
+				InitializeHandle (_InitWithContainerSize (size), "initWithContainerSize:");
+			} else {
+				InitializeHandle (_InitWithSize (size), "initWithSize:");
+			}
 		}
 
-		/// <param name="size">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Create a new <see cref="NSTextContainer" /> with the specified size.</summary>
+		/// <param name="size">The size of the new <see cref="NSTextContainer" />.</param>
+		/// <returns>A new <see cref="NSTextContainer" /> with the specified size.</returns>
 		[SupportedOSPlatform ("macos")]
 		[UnsupportedOSPlatform ("ios")]
 		[UnsupportedOSPlatform ("maccatalyst")]
 		[UnsupportedOSPlatform ("tvos")]
 		public static NSTextContainer FromSize (CGSize size)
 		{
-			return new NSTextContainer (size, false);
+			return new NSTextContainer (size);
 		}
 
-		/// <param name="containerSize">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
-		[UnsupportedOSPlatform ("ios")]
+		/// <summary>Create a new <see cref="NSTextContainer" /> with the specified size.</summary>
+		/// <param name="containerSize">The size of the new <see cref="NSTextContainer" />.</param>
+		/// <returns>A new <see cref="NSTextContainer" /> with the specified size.</returns>
+		/// <remarks>This method is deprecated, use <see cref="FromSize" /> instead.</remarks>
 		[SupportedOSPlatform ("macos")]
+		[ObsoletedOSPlatform ("macos", "Use 'new NSTextContainer (CGSize)' instead.")]
+		[UnsupportedOSPlatform ("ios")]
 		[UnsupportedOSPlatform ("maccatalyst")]
 		[UnsupportedOSPlatform ("tvos")]
-		[ObsoletedOSPlatform ("macos", "Use NSTextContainer.FromSize instead.")]
 		public static NSTextContainer FromContainerSize (CGSize containerSize)
 		{
 			return new NSTextContainer (containerSize, true);

--- a/src/xkit.cs
+++ b/src/xkit.cs
@@ -3795,25 +3795,25 @@ namespace UIKit {
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
 	partial interface NSTextContainer : NSTextLayoutOrientationProvider, NSSecureCoding {
-		[NoMac]
 		[MacCatalyst (13, 1)]
 		[DesignatedInitializer]
 		[Export ("initWithSize:")]
 		NativeHandle Constructor (CGSize size);
 
+		[Deprecated (PlatformName.MacOSX, 10, 11, "Use 'new NSTextContainer (CGSize)' instead.")]
 		[NoiOS]
 		[NoMacCatalyst]
 		[NoTV]
 		[Export ("initWithContainerSize:"), Internal]
 		[Sealed]
-		IntPtr InitWithContainerSize (CGSize size);
+		IntPtr _InitWithContainerSize (CGSize size);
 
 		[NoiOS]
 		[NoMacCatalyst]
 		[NoTV]
 		[Export ("initWithSize:"), Internal]
 		[Sealed]
-		IntPtr InitWithSize (CGSize size);
+		IntPtr _InitWithSize (CGSize size);
 
 		[NullAllowed] // by default this property is null
 		[Export ("layoutManager", ArgumentSemantic.Assign)]

--- a/tests/cecil-tests/ConstructorTest.KnownFailures.cs
+++ b/tests/cecil-tests/ConstructorTest.KnownFailures.cs
@@ -7,7 +7,6 @@ namespace Cecil.Tests {
 		static HashSet<string> knownFailuresNonDefaultCtorDoesNotCallBaseDefaultCtor = new HashSet<string> {
 			"AppKit.ActionDispatcher::.ctor(System.EventHandler)",
 			"AppKit.NSAlertDidEndDispatcher::.ctor(System.Action`1<System.IntPtr>)",
-			"AppKit.NSTextContainer::.ctor(CoreGraphics.CGSize,System.Boolean)",
 			"AVFoundation.InternalAVAudioSessionDelegate::.ctor(AVFoundation.AVAudioSession)",
 			"CarPlay.CPListSection::.ctor(CarPlay.CPListItem[],System.String,System.String)",
 			"CarPlay.CPListSection::.ctor(CarPlay.CPListItem[])",

--- a/tests/cecil-tests/SetHandleTest.KnownFailures.cs
+++ b/tests/cecil-tests/SetHandleTest.KnownFailures.cs
@@ -9,7 +9,6 @@ namespace Cecil.Tests {
 			"AppKit.NSBitmapImageRep::.ctor(Foundation.NSObjectFlag,Foundation.NSObjectFlag)",
 			"AppKit.NSOpenGLPixelFormat::.ctor(AppKit.NSOpenGLPixelFormatAttribute[])",
 			"AppKit.NSOpenGLPixelFormat::.ctor(System.Object[])",
-			"AppKit.NSTextContainer::.ctor(CoreGraphics.CGSize,System.Boolean)",
 			"CoreFoundation.CFMutableString::.ctor(CoreFoundation.CFString,System.IntPtr)",
 			"CoreFoundation.CFMutableString::.ctor(System.String,System.IntPtr)",
 			"CoreFoundation.CFSocket::Initialize(CoreFoundation.CFRunLoop,CoreFoundation.CFSocket/CreateSocket)",

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
@@ -59,6 +59,9 @@
 !incorrect-protocol-member! +NSPasteboardReading::readableTypesForPasteboard: is REQUIRED and should be abstract
 !incorrect-protocol-member! +NSWindowRestoration::restoreWindowWithIdentifier:state:completionHandler: is REQUIRED and should be abstract
 
+# This init method is bound manually, because the managed signature is identical to another init method.
+!missing-selector! NSTextContainer::initWithContainerSize: not bound
+
 ## unsorted
 
 !missing-enum! NSWritingDirectionFormatType not bound
@@ -133,8 +136,6 @@
 !missing-selector! NSMutableAttributedString::fixAttributesInRange: not bound
 !missing-selector! NSString::boundingRectWithSize:options:attributes: not bound
 !missing-selector! NSString::drawWithRect:options:attributes: not bound
-!missing-selector! NSTextContainer::initWithContainerSize: not bound
-!missing-selector! NSTextContainer::initWithSize: not bound
 !missing-selector! NSTextContainer::lineFragmentRectForProposedRect:sweepDirection:movementDirection:remainingRect: not bound
 !missing-selector! NSTextStorage::attributeRuns not bound
 !missing-selector! NSTextStorage::characters not bound


### PR DESCRIPTION
Improve and simplify the manually bound constructors for NSTextContainer by
using the same pattern we use elsewhere for manually bound constructors.