### PR TITLE
[Foundation] Improve and simplify the manually bound constructors for NSString slightly.

### DIFF
--- a/src/Foundation/NSString.cs
+++ b/src/Foundation/NSString.cs
@@ -156,23 +156,23 @@ namespace Foundation {
 			NSObject.DangerousRelease (handle);
 		}
 
-		/// <param name="str">A string.</param>
-		///         <summary>Creates an NSString from a C# string.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Creates an <see cref="NSString" /> from a C# string.</summary>
+		/// <param name="str">A C# string to create an <see cref="NSString" /> from.</param>
 		public NSString (string str)
+			: base (NSObjectFlag.Empty)
 		{
 			if (str is null)
-				throw new ArgumentNullException ("str");
+				throw new ArgumentNullException (nameof (str));
 
-			Handle = CreateWithCharacters (Handle, str, 0, str.Length);
+			InitializeHandle (CreateWithCharacters (Handle, str, 0, str.Length));
 		}
 
-		/// <param name="value">To be added.</param>
-		///         <param name="start">To be added.</param>
-		///         <param name="length">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Creates an <see cref="NSString" /> from a C# string.</summary>
+		/// <param name="value">A C# string to create an <see cref="NSString" /> from.</param>
+		/// <param name="start">The starting index of the <paramref name="value" /> string to create the <see cref="NSString" /> from.</param>
+		/// <param name="length">The length, starting at <paramref name="start" />, of the <paramref name="value" /> string to create the <see cref="NSString" /> from.</param>
 		public NSString (string value, int start, int length)
+			: base (NSObjectFlag.Empty)
 		{
 			if (value is null)
 				throw new ArgumentNullException (nameof (value));
@@ -183,7 +183,7 @@ namespace Foundation {
 			if (length < 0 || start > value.Length - length)
 				throw new ArgumentOutOfRangeException (nameof (length));
 
-			Handle = CreateWithCharacters (Handle, value, start, length);
+			InitializeHandle (CreateWithCharacters (Handle, value, start, length));
 		}
 
 		/// <summary>Returns a string representation of the value of the current instance.</summary>

--- a/tests/cecil-tests/ConstructorTest.KnownFailures.cs
+++ b/tests/cecil-tests/ConstructorTest.KnownFailures.cs
@@ -24,8 +24,6 @@ namespace Cecil.Tests {
 			"Foundation.NSMutableArray`1::.ctor(TValue[])",
 			"Foundation.NSObject::.ctor(Foundation.NSObjectFlag)",
 			"Foundation.NSObject::.ctor(ObjCRuntime.NativeHandle,System.Boolean)",
-			"Foundation.NSString::.ctor(System.String,System.Int32,System.Int32)",
-			"Foundation.NSString::.ctor(System.String)",
 			"Foundation.NSSynchronizationContextDispatcher::.ctor(System.Threading.SendOrPostCallback,System.Object)",
 			"Foundation.NSThread::.ctor(Foundation.NSObject,ObjCRuntime.Selector,Foundation.NSObject)",
 			"Foundation.NSTimerActionDispatcher::.ctor(System.Action`1<Foundation.NSTimer>)",

--- a/tests/cecil-tests/SetHandleTest.KnownFailures.cs
+++ b/tests/cecil-tests/SetHandleTest.KnownFailures.cs
@@ -18,8 +18,6 @@ namespace Cecil.Tests {
 			"CoreGraphics.CGPattern::.ctor(CoreGraphics.CGRect,CoreGraphics.CGAffineTransform,System.Runtime.InteropServices.NFloat,System.Runtime.InteropServices.NFloat,CoreGraphics.CGPatternTiling,System.Boolean,CoreGraphics.CGPattern/DrawPattern)",
 			"Foundation.NSHttpCookie::CreateCookie(System.String,System.String,System.String,System.String,System.String,System.String,System.Nullable`1<System.Boolean>,System.Nullable`1<System.DateTime>,System.Nullable`1<System.Int32>,System.String,System.Nullable`1<System.Boolean>,System.Nullable`1<System.Int32>)",
 			"Foundation.NSKeyedUnarchiver::.ctor(Foundation.NSData)",
-			"Foundation.NSString::.ctor(System.String,System.Int32,System.Int32)",
-			"Foundation.NSString::.ctor(System.String)",
 			"Foundation.NSThread::.ctor(Foundation.NSObject,ObjCRuntime.Selector,Foundation.NSObject)",
 			"Foundation.NSUuid::.ctor(System.Byte[])",
 			"GameplayKit.GKPath::.ctor(System.Numerics.Vector2[],System.Single,System.Boolean)",


### PR DESCRIPTION
Improve and simplify the manually bound constructors for NSString by
using the same pattern we use elsewhere for manually bound constructors.