### PR TITLE
[dotnet] Add a 'EnableProfiler' property to enable the 'diagnostics_tracing' component. Fixes #19370.

### DIFF
--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -314,6 +314,25 @@ If the .pkg that was created (if `CreatePackage` was enabled) should be signed.
 
 Only applicable to macOS and Mac Catalyst.
 
+## EnableProfiler
+
+Enable components that are required for profiling to work.
+
+It's enabled by default for debug builds (when [MtouchDebug](#MtouchDebug) or
+[MmpDebug](#MmpDebug) is enabled), but needs to be enabled manually before
+profiling release builds:
+
+```xml
+<PropertyGroup>
+  <EnableProfiler>true</EnableProfiler>
+</PropertyGroup>
+```
+
+This will increase the app size slightly.
+
+Only applicable when using the Mono runtime (CoreCLR always supports
+profiling, while NativeAOT never does).
+
 ## EnableSGenConc
 
 Enables the concurrent mode for the SGen garbage collector.

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -452,7 +452,7 @@
 		<ItemGroup>
 			<_MonoComponent Include="hot_reload" Condition="'$(MtouchInterpreter)' != ''" />
 			<_MonoComponent Include="debugger" Condition="'$(_BundlerDebug)' == 'true'" />
-			<_MonoComponent Include="diagnostics_tracing" Condition="'$(_BundlerDebug)' == 'true'" />
+			<_MonoComponent Include="diagnostics_tracing" Condition="'$(EnableProfiler)' == 'true'" />
 			<_MonoComponent Include="marshal-ilgen" Condition="'$(_AppleExcludeMarshalIlgenComponent)' != 'true'" />
 		</ItemGroup>
 	</Target>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.props
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.props
@@ -292,6 +292,8 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 		<!-- Does not apply unless we're actually building a library - and since BundleOriginalResources can be specified on the command line, use a secondary property -->
 		<!-- that also encapsulates whether we're a library or not (this makes conditions simpler) -->
 		<_BundleOriginalResources Condition="'$(OutputType)' == 'Library' And '$(IsAppExtension)' != 'true' And '$(BundleOriginalResources)' == 'true'">true</_BundleOriginalResources>
+
+		<EnableProfiling Condition="'$(EnableProfiling)' == '' And '$(_BundlerDebug)' == 'true'">true</EnableProfiling>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(IsBindingProject)' == 'true'">


### PR DESCRIPTION
Fixes https://github.com/dotnet/macios/issues/19370.