### PR TITLE
[build] Fix a few issues with the 'git-clean-all' target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,19 +82,29 @@ git-clean-all:
 	@echo "$(COLOR_RED)Cleaning and resetting all dependencies. This is a destructive operation.$(COLOR_CLEAR)"
 	@echo "$(COLOR_RED)You have 5 seconds to cancel (Ctrl-C) if you wish.$(COLOR_CLEAR)"
 	@sleep 5
-	@echo "Cleaning xamarin-macios..."
-	@git clean -xffdq -e external/mono
-	@test -d external/mono && echo "Cleaning mono..." && cd external/mono && git clean -xffdq && git submodule foreach -q --recursive 'git clean -xffdq && git reset --hard -q' || true
+	@echo "Cleaning macios..."
 	@git submodule foreach -q --recursive 'git clean -xffdq && git reset --hard -q'
-	@for dir in $(DEPENDENCY_DIRECTORIES); do if test -d $(CURDIR)/$$dir; then echo "Cleaning $$dir" && cd $(CURDIR)/$$dir && git clean -xffdq && git reset --hard -q && git submodule foreach -q --recursive 'git clean -xffdq'; else echo "Skipped  $$dir (does not exist)"; fi; done
+	@set -e; \
+	for dir in $(DEPENDENCY_DIRECTORIES); do \
+		if test -d $$dir; then \
+			echo "Cleaning $$(basename $$dir)..."; \
+			cd $$dir; \
+			git clean -xffdq; \
+			git reset --hard -q; \
+			git submodule foreach -q --recursive 'git clean -xffdq'; \
+		else \
+			echo "Skipped $$dir (does not exist)"; \
+		fi; \
+	done
 
-	@if [ -n "$(ENABLE_XAMARIN)" ]; then \
+	@set -e;  \
+	if [ -n "$(ENABLE_XAMARIN)" ]; then \
 		CONFIGURE_FLAGS=""; \
 		if [ -n "$(ENABLE_XAMARIN)" ]; then \
 			echo "Xamarin-specific build has been re-enabled"; \
 			CONFIGURE_FLAGS="$$CONFIGURE_FLAGS --enable-xamarin"; \
 		fi; \
-		./configure "$$CONFIGURE_FLAGS"; \
+		./configure $$CONFIGURE_FLAGS; \
 		$(MAKE) reset; \
 		echo "Done"; \
 	else \

--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -78,7 +78,7 @@ reset-versions-impl:: reset-$(1)
 check-versions:: check-$(1)
 print-versions:: print-$(1)
 
-DEPENDENCY_DIRECTORIES += $($(2)_PATH)
+DEPENDENCY_DIRECTORIES += $$(abspath $($(2)_PATH))
 
 endef
 


### PR DESCRIPTION
* It wasn't cleaning macios-adr, because it was assuming the path to
  macios-adr was a relative path, thus prepending the current path, leading to
  a path that didn't exist.
* Remove some dead code (we don't have a mono dependency anymore for instance).
* Misc other tweaks to improve output and readability.