### PR TITLE
[ci] Use variables to control system .NET SDK installs

### DIFF
--- a/eng/common/core-templates/job/source-index-stage1.yml
+++ b/eng/common/core-templates/job/source-index-stage1.yml
@@ -49,10 +49,10 @@ jobs:
     - ${{ preStep }}
 
   - task: UseDotNet@2
-    displayName: Use .NET 8 SDK
+    displayName: Use .NET $(DotNetSdkVersion) SDK
     inputs:
       packageType: sdk
-      version: 8.0.x
+      version: $(DotNetSdkVersion).x
       installationPath: $(Agent.TempDirectory)/dotnet
       workingDirectory: $(Agent.TempDirectory)
 

--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -160,7 +160,7 @@ steps:
 
 - task: UseDotNet@2
   inputs:
-    version: 9.x
+    version: $(DotNetSdkVersion).x
 
 - template: ../common/install-qa-provisioning-profiles.yml
   parameters:

--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -115,8 +115,8 @@ stages:
             startsWith(variables['Build.SourceBranch'], 'refs/heads/release-test/'),
             eq(variables['Build.SourceBranch'], 'refs/heads/net7.0'),
             eq(variables['Build.SourceBranch'], 'refs/heads/net8.0'),
-            eq(variables['Build.SourceBranch'], 'refs/heads/net9.0'),
-            eq(variables['Build.SourceBranch'], 'refs/heads/net10.0'),
+            eq(variables['Build.SourceBranch'], 'refs/heads/net$(DotNetSdkVersion)'),
+            eq(variables['Build.SourceBranch'], 'refs/heads/net$(DotNetPreviewSdkVersion)'),
             eq(variables['Build.SourceBranch'], 'refs/heads/xcode16'),
             eq(parameters.forceInsertion, true)
           )

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -145,9 +145,9 @@ stages:
         displayName: Create credscan dummy ignore file
 
       - task: UseDotNet@2
-        displayName: Install .NET 9.x
+        displayName: Install .NET $(DotNetPreviewSdkVersion)
         inputs:
-          version: 9.x
+          version: $(DotNetPreviewSdkVersion).x
           includePreviewVersions: true
 
       - task: DownloadPipelineArtifact@2

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -145,9 +145,9 @@ stages:
         displayName: Create credscan dummy ignore file
 
       - task: UseDotNet@2
-        displayName: Install .NET $(DotNetPreviewSdkVersion)
+        displayName: Install .NET $(DotNetSdkVersion)
         inputs:
-          version: $(DotNetPreviewSdkVersion).x
+          version: $(DotNetSdkVersion).x
           includePreviewVersions: true
 
       - task: DownloadPipelineArtifact@2

--- a/tools/devops/automation/templates/tests/build.yml
+++ b/tools/devops/automation/templates/tests/build.yml
@@ -227,7 +227,7 @@ steps:
 
 - task: UseDotNet@2
   inputs:
-    version: 9.x
+    version: $(DotNetSdkVersion).x
 
 - bash: |
     set -x

--- a/tools/devops/automation/templates/variables/common.yml
+++ b/tools/devops/automation/templates/variables/common.yml
@@ -64,3 +64,8 @@ variables:
 - name: VSDropsPrefix
   value: 'https://vsdrop.corp.microsoft.com/file/v1/$(BUILD_REPOSITORY_TITLE)/device-tests'
 
+- name: DotNetSdkVersion
+  value: 9.0
+
+- name: DotNetPreviewSdkVersion
+  value: 10.0

--- a/tools/devops/automation/templates/variables/common.yml
+++ b/tools/devops/automation/templates/variables/common.yml
@@ -68,4 +68,4 @@ variables:
   value: 9.0
 
 - name: DotNetPreviewSdkVersion
-  value: 10.0
+  value: 9.0

--- a/tools/devops/automation/templates/variables/common.yml
+++ b/tools/devops/automation/templates/variables/common.yml
@@ -68,4 +68,4 @@ variables:
   value: 9.0
 
 - name: DotNetPreviewSdkVersion
-  value: 9.0
+  value: 10.0

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -97,7 +97,7 @@ steps:
 
 - task: UseDotNet@2
   inputs:
-    version: 9.x
+    version: $(DotNetSdkVersion).x
 
 - pwsh: '& "$(Build.SourcesDirectory)/$Env:BUILD_REPOSITORY_TITLE/tools/devops/automation/scripts/initialize-test-output-variables.ps1"'
   displayName: Set output variables

--- a/tools/devops/automation/templates/windows/reserve-mac.yml
+++ b/tools/devops/automation/templates/windows/reserve-mac.yml
@@ -104,7 +104,7 @@ steps:
 
 - task: UseDotNet@2
   inputs:
-    version: 9.x
+    version: $(DotNetSdkVersion).x
 
 - bash: $(Build.SourcesDirectory)/$(BUILD_REPOSITORY_TITLE)/system-dependencies.sh --ignore-mono --ignore-visual-studio --ignore-mono --ignore-sharpie --ignore-shellcheck --ignore-yamllint --provision-simulators
   displayName: 'Provision simulators'


### PR DESCRIPTION
I noticed the net10.0 branch build was failing during the
"generate and publish BAR manifest" step with:

    D:\a\_work\1\s\dotnet\package\common.csproj(151,5): error MSB4062: The "PushToBuildStorage" task could not be loaded from the assembly D:\a\_work\1\s\packages\microsoft.dotnet.build.tasks.feed\10.0.0-beta.25228.101\build\../tools/net/Microsoft.DotNet.Build.Tasks.Feed.dll. Could not load file or assembly 'System.Runtime, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The system cannot find the file specified.

The Microsoft.DotNet.Build.Tasks.Feed tasks are seemingly now being
built against .NET 10, so we'll need to install .NET 10 to run them.

Variables that represent the current stable and preview versions of .NET
have been added to be used throughout the pipeline. These will now only