### PR TITLE
[ci][net10.0] Use variables to control system .NET SDK installs

### DIFF
--- a/dotnet/package/common.csproj
+++ b/dotnet/package/common.csproj
@@ -129,9 +129,9 @@
     <Error Condition="Exists($(AssetManifestPath))" Text="The manifest file '$(AssetManifestPath)' already exists." />
 
     <ItemGroup>
-      <ItemsToPush Include="$(NupkgPath)\*.nupkg" />
+      <ItemsToPush Include="$(NupkgPath)\*.nupkg" Kind="Package" />
       <WorkloadArtifacts Include="$(NupkgPath)\*.zip" />
-      <ItemsToPush Include="@(WorkloadArtifacts)" PublishFlatContainer="true" RelativeBlobPath="macios/$(_PackageVersion)/%(Filename)%(Extension)" />
+      <ItemsToPush Include="@(WorkloadArtifacts)" PublishFlatContainer="true" RelativeBlobPath="macios/$(_PackageVersion)/%(Filename)%(Extension)" Kind="Blob" />
     </ItemGroup>
 
     <Error Condition="'@(ItemsToPush)' == ''" Text="No packages to push." />

--- a/eng/common/core-templates/steps/install-microbuild.yml
+++ b/eng/common/core-templates/steps/install-microbuild.yml
@@ -12,11 +12,12 @@ steps:
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
     - ${{ if eq(parameters.enableMicrobuildForMacAndLinux, 'true') }}:
       # Needed to download the MicroBuild plugin nupkgs on Mac and Linux when nuget.exe is unavailable
+      # Workaround for ESRP CLI on Linux - https://github.com/dotnet/source-build/issues/4964
       - task: UseDotNet@2
-        displayName: Install .NET 8.0 SDK for MicroBuild Plugin
+        displayName: Install .NET $(DotNetSdkVersion) SDK for MicroBuild Plugin
         inputs:
           packageType: sdk
-          version: 8.0.x
+          version: $(DotNetSdkVersion).x
           installationPath: ${{ parameters.microBuildOutputFolder }}/.dotnet
           workingDirectory: ${{ parameters.microBuildOutputFolder }}
         condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
@@ -49,17 +50,7 @@ steps:
           )
         ))
 
-    # Workaround for ESRP CLI on Linux - https://github.com/dotnet/source-build/issues/4964
     - ${{ if eq(parameters.enableMicrobuildForMacAndLinux, 'true') }}:
-      - task: UseDotNet@2
-        displayName: Install .NET 9.0 SDK for ESRP CLI Workaround
-        inputs:
-          packageType: sdk
-          version: 9.0.x
-          installationPath: ${{ parameters.microBuildOutputFolder }}/.dotnet
-          workingDirectory: ${{ parameters.microBuildOutputFolder }}
-        condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
-
       - task: PowerShell@2
         displayName: Workaround for ESRP CLI on Linux
         inputs:

--- a/eng/common/core-templates/steps/source-index-stage1-publish.yml
+++ b/eng/common/core-templates/steps/source-index-stage1-publish.yml
@@ -6,10 +6,10 @@ parameters:
 
 steps:
 - task: UseDotNet@2
-  displayName: "Source Index: Use .NET 8 SDK"
+  displayName: Use .NET $(DotNetSdkVersion) SDK
   inputs:
     packageType: sdk
-    version: 8.0.x
+    version: $(DotNetSdkVersion).x
     installationPath: $(Agent.TempDirectory)/dotnet
     workingDirectory: $(Agent.TempDirectory)
 

--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -160,7 +160,7 @@ steps:
 
 - task: UseDotNet@2
   inputs:
-    version: 9.x
+    version: $(DotNetSdkVersion).x
 
 - template: ../common/install-qa-provisioning-profiles.yml
   parameters:

--- a/tools/devops/automation/templates/main-stage.yml
+++ b/tools/devops/automation/templates/main-stage.yml
@@ -115,8 +115,8 @@ stages:
             startsWith(variables['Build.SourceBranch'], 'refs/heads/release-test/'),
             eq(variables['Build.SourceBranch'], 'refs/heads/net7.0'),
             eq(variables['Build.SourceBranch'], 'refs/heads/net8.0'),
-            eq(variables['Build.SourceBranch'], 'refs/heads/net9.0'),
-            eq(variables['Build.SourceBranch'], 'refs/heads/net10.0'),
+            eq(variables['Build.SourceBranch'], 'refs/heads/net$(DotNetSdkVersion)'),
+            eq(variables['Build.SourceBranch'], 'refs/heads/net$(DotNetPreviewSdkVersion)'),
             eq(variables['Build.SourceBranch'], 'refs/heads/xcode16'),
             eq(parameters.forceInsertion, true)
           )

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -145,9 +145,9 @@ stages:
         displayName: Create credscan dummy ignore file
 
       - task: UseDotNet@2
-        displayName: Install .NET 9.x
+        displayName: Install .NET $(DotNetPreviewSdkVersion)
         inputs:
-          version: 9.x
+          version: $(DotNetPreviewSdkVersion).x
           includePreviewVersions: true
 
       - task: DownloadPipelineArtifact@2

--- a/tools/devops/automation/templates/tests/build.yml
+++ b/tools/devops/automation/templates/tests/build.yml
@@ -227,7 +227,7 @@ steps:
 
 - task: UseDotNet@2
   inputs:
-    version: 9.x
+    version: $(DotNetSdkVersion).x
 
 - bash: |
     set -x

--- a/tools/devops/automation/templates/variables/common.yml
+++ b/tools/devops/automation/templates/variables/common.yml
@@ -64,3 +64,8 @@ variables:
 - name: VSDropsPrefix
   value: 'https://vsdrop.corp.microsoft.com/file/v1/$(BUILD_REPOSITORY_TITLE)/device-tests'
 
+- name: DotNetSdkVersion
+  value: 9.0
+
+- name: DotNetPreviewSdkVersion
+  value: 10.0

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -97,7 +97,7 @@ steps:
 
 - task: UseDotNet@2
   inputs:
-    version: 9.x
+    version: $(DotNetSdkVersion).x
 
 - pwsh: '& "$(Build.SourcesDirectory)/$Env:BUILD_REPOSITORY_TITLE/tools/devops/automation/scripts/initialize-test-output-variables.ps1"'
   displayName: Set output variables

--- a/tools/devops/automation/templates/windows/reserve-mac.yml
+++ b/tools/devops/automation/templates/windows/reserve-mac.yml
@@ -104,7 +104,7 @@ steps:
 
 - task: UseDotNet@2
   inputs:
-    version: 9.x
+    version: $(DotNetSdkVersion).x
 
 - bash: $(Build.SourcesDirectory)/$(BUILD_REPOSITORY_TITLE)/system-dependencies.sh --ignore-mono --ignore-visual-studio --ignore-mono --ignore-sharpie --ignore-shellcheck --ignore-yamllint --provision-simulators
   displayName: 'Provision simulators'


### PR DESCRIPTION
I noticed the net10.0 branch build was failing during the "generate and publish BAR manifest" step with:

    D:\a\_work\1\s\dotnet\package\common.csproj(151,5): error MSB4062: The "PushToBuildStorage" task could not be loaded from the assembly D:\a\_work\1\s\packages\microsoft.dotnet.build.tasks.feed\10.0.0-beta.25228.101\build\../tools/net/Microsoft.DotNet.Build.Tasks.Feed.dll. Could not load file or assembly 'System.Runtime, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The system cannot find the file specified.

The Microsoft.DotNet.Build.Tasks.Feed tasks are seemingly now being built against .NET 10, so we'll need to install .NET 10 to run them.

Variables that represent the current stable and preview versions of .NET have been added to be used throughout the pipeline. These will now only need to be updated in one place when a new major release comes around.

Also fixes the following publishing error by setting %(ItemsToPush.Kind) metadata:

    D:\a\_work\1\s\dotnet\package\common.csproj(151,5): error : Missing 'Kind' property on artifact D:\a\_work\1\a\nuget-signed\Workload.VSDrop.iOS.MacCatalyst.macOS.tvOS.net10.0.xcode16.3.packs.zip. Possible values are 'Blob', 'PDB', 'Package'.