### PR TITLE
[Security] Add SecKeyChain.QueryAsConcreteType to macOS.

### DIFF
--- a/src/Security/Items.cs
+++ b/src/Security/Items.cs
@@ -776,7 +776,8 @@ namespace Security {
 					SecKeychainItemFreeContent (IntPtr.Zero, passwordPtr);
 			}
 		}
-#else
+#endif
+
 		/// <include file="../../docs/api/Security/SecKeyChain.xml" path="/Documentation/Docs[@DocId='M:Security.SecKeyChain.QueryAsConcreteType(Security.SecRecord,Security.SecStatusCode@)']/*" />
 		public static object? QueryAsConcreteType (SecRecord query, out SecStatusCode result)
 		{
@@ -805,7 +806,6 @@ namespace Security {
 				return null;
 			}
 		}
-#endif
 
 		/// <param name="identity">To be added.</param>
 		///         <summary>To be added.</summary>

--- a/tests/monotouch-test/Security/KeyChainTest.cs
+++ b/tests/monotouch-test/Security/KeyChainTest.cs
@@ -56,7 +56,6 @@ namespace MonoTouchFixtures.Security {
 			}
 		}
 
-#if !MONOMAC // No QueryAsConcreteType on Mac
 		[Test]
 #if __MACCATALYST__
 		[Ignore ("This test requires an app signed with the keychain-access-groups entitlement, and for Mac Catalyst that requires a custom provisioning profile.")]
@@ -92,7 +91,6 @@ namespace MonoTouchFixtures.Security {
 				Assert.Null (match, "match-3");
 			}
 		}
-#endif
 
 		[DllImport ("/System/Library/Frameworks/Security.framework/Security")]
 		internal extern static SecStatusCode SecItemAdd (IntPtr cfDictRef, IntPtr result);


### PR DESCRIPTION
It works (according to tests at least), so I don't see a reason to exclude it.