### PR TITLE
[src] Ignore warnings related to xml docs when compiling core and api definition assemblies.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -82,6 +82,11 @@ MACCATALYST_GENERATOR_WARNASERROR=$(GENERATOR_WARNASERROR)
 # this is due to deprecated APIs used in the generated code.
 BGEN_WARNINGS_TO_FIX=BI1234
 
+# We ignore some xml docs warnings when building the core and apidefinition assemblies, because
+# the xml docs might want to reference generated APIs, so the compiler would warn about not
+# finding those APIs (because they haven't been generated yet).
+XML_DOCS_WARNINGS=CS0419,CS1574,CS1580
+
 #
 # Specific warnings we're ignoring from the C# compiler
 # We should look into each of these and see if they're really needed,
@@ -368,6 +373,7 @@ $($(2)_DOTNET_BUILD_DIR)/core-$(3).rsp: Makefile frameworks.sources $($(2)_DOTNE
 		-nullable+ \
 		-warnaserror+ \
 		-nowarn:1591 \
+		-nowarn:$(XML_DOCS_WARNINGS) \
 		-out:$($(2)_DOTNET_BUILD_DIR)/core-$(3).dll \
 		-doc:$($(2)_DOTNET_BUILD_DIR)/core-$(3).xml \
 		> $$@.tmp
@@ -383,6 +389,7 @@ $($(2)_DOTNET_BUILD_DIR)/apidefinition-$(3).rsp: Makefile frameworks.sources $($
 		-unsafe \
 		-target:library \
 		-nowarn:436,1591,CA1416,CS8981 \
+		-nowarn:$(XML_DOCS_WARNINGS) \
 		-warnaserror+ \
 		-out:$($(2)_DOTNET_BUILD_DIR)/apidefinition-$(3).dll \
 		-doc:$($(2)_DOTNET_BUILD_DIR)/apidefinition-$(3).xml \

--- a/src/bgen/BindingTouch.cs
+++ b/src/bgen/BindingTouch.cs
@@ -454,6 +454,9 @@ public class BindingTouch : IDisposable {
 		cargs.Add ("-unsafe");
 		cargs.Add ("-target:library");
 		cargs.Add ("-nowarn:436");
+		cargs.Add ("-nowarn:CS0419"); // "Ambiguous reference in cref attribute: '...'. Assuming '...', but could have also matched other overloads including '...'." => we want to be able to write xml comments in api definition code for APIs that don't exist until all the code has been generated, so we ignore these warnings.
+		cargs.Add ("-nowarn:CS1574"); // "XML comment has cref attribute '...' that could not be resolved" => we want to be able to write xml comments in api definition code for APIs that don't exist until all the code has been generated, so we ignore these warnings.
+		cargs.Add ("-nowarn:CS1580"); // "Invalid type for parameter '#' in XML comment cref attribute" => we want to be able to write xml comments in api definition code for APIs that don't exist until all the code has been generated, so we ignore these warnings.
 		cargs.Add ("-out:" + tmpass);
 		cargs.Add ("-r:" + LibraryManager.GetAttributeLibraryPath (libraryInfo, CurrentPlatform));
 		cargs.AddRange (config.References);


### PR DESCRIPTION
The compiler will validate the xml docs as much as it can, and will raise a warning
if it sees xml docs talking about APIs that don't exist.

However, in api definitions we might want to write xml docs that reference APIs that
are generated, and they won't exist yet. So ignore any such warnings - in any case,
if they're actually wrong, the compiler will show a warning when compiling the final
code.