### PR TITLE
[devops] Enable long paths on Windows bots. Fixes #22697.

### DIFF
--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -166,6 +166,15 @@ steps:
     }
   displayName: "Cleanup temporary files"
 
+- pwsh: |
+    Write-Host "Current long paths state:"
+    Get-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem -Name LongPathsEnabled
+    Write-Host "Enabling long paths":
+    Set-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem -Name LongPathsEnabled -Value 1
+    Write-Host "Updated long paths state:"
+    Get-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem -Name LongPathsEnabled
+  displayName: 'Enable long paths'
+
 # This task fixes errors such as these:
 #     error MSB4242: SDK Resolver Failure: "The SDK resolver "NuGetSdkResolver" failed while attempting to resolve the SDK "Microsoft.Build.NoTargets/3.3.0".
 #                    Exception: "NuGet.Packaging.Core.PackagingException: Unable to find fallback package folder 'D:\Program Files (x86)\Microsoft Visual Studio\Shared\NuGetPackages'.


### PR DESCRIPTION
Our tests require long paths to be enabled on Windows, so do that.

Fixes https://github.com/dotnet/macios/issues/22697.