### PR TITLE
[runtime] Implement workaround for an interpreter bug where it returns incorrect small integer values to reverse P/Invokes.

### DIFF
--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -123,7 +123,7 @@
 			OnlyDynamicUsage = true,
 		},
 
-		new XDelegate ("int8_t", "sbyte", "xamarin_has_nsobject",
+		new XDelegate ("NSInteger", "nint", "xamarin_has_nsobject",
 			"id", "IntPtr", "obj"
 		) {
 			WrappedManagedFunction = "HasNSObject",
@@ -208,7 +208,7 @@
 			OnlyDynamicUsage = false,
 		},
 
-		new XDelegate ("int8_t", "sbyte", "xamarin_is_parameter_transient",
+		new XDelegate ("NSInteger", "nint", "xamarin_is_parameter_transient",
 			"GCHandle->MonoReflectionMethod *", "IntPtr", "method",
 			"int", "int", "parameter"
 		) {
@@ -216,7 +216,7 @@
 			OnlyDynamicUsage = true,
 		},
 
-		new XDelegate ("int8_t", "sbyte", "xamarin_is_parameter_out",
+		new XDelegate ("NSInteger", "nint", "xamarin_is_parameter_out",
 			"GCHandle->MonoReflectionMethod *", "IntPtr", "method",
 			"int", "int", "parameter"
 		) {
@@ -656,14 +656,14 @@
 			OnlyDynamicUsage = false,
 		},
 
-		new XDelegate ("int8_t", "sbyte", "xamarin_attempt_retain_nsobject",
+		new XDelegate ("NSInteger", "nint", "xamarin_attempt_retain_nsobject",
 			"GCHandle->MonoObject *", "IntPtr", "obj"
 		) {
 			WrappedManagedFunction = "AttemptRetainNSObject",
 			OnlyDynamicUsage = false,
 		},
 
-		new XDelegate ("int8_t", "sbyte", "xamarin_invoke_conforms_to_protocol",
+		new XDelegate ("NSInteger", "nint", "xamarin_invoke_conforms_to_protocol",
 			"id", "IntPtr", "obj",
 			"Protocol *", "IntPtr", "protocol"
 		) {

--- a/runtime/trampolines-invoke.m
+++ b/runtime/trampolines-invoke.m
@@ -90,7 +90,7 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 	MonoType *sig_ret_type = NULL;
 
 	if (is_ctor) {
-		bool has_nsobject = xamarin_has_nsobject (self, &exception_gchandle);
+		bool has_nsobject = xamarin_has_nsobject (self, &exception_gchandle) != 0;
 		if (exception_gchandle != INVALID_GCHANDLE) {
 			xamarin_process_managed_exception_gchandle (exception_gchandle);
 			return; // we shouldn't get here.
@@ -292,7 +292,7 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 								goto exception_handling;
 							}
 							MonoReflectionMethod *rmethod = mono_method_get_object (domain, method, NULL);
-							bool is_parameter_out = xamarin_is_parameter_out (rmethod, (int) i, &exception_gchandle);
+							bool is_parameter_out = xamarin_is_parameter_out (rmethod, (int) i, &exception_gchandle) != 0;
 							ADD_TO_MONOOBJECT_RELEASE_LIST (rmethod);
 							if (exception_gchandle != INVALID_GCHANDLE)
 								goto exception_handling;
@@ -498,7 +498,7 @@ xamarin_invoke_trampoline (enum TrampolineType type, id self, SEL sel, iterator_
 
 							if (created && obj) {
 								MonoReflectionMethod *rmethod = mono_method_get_object (domain, method, NULL);
-								bool is_transient = xamarin_is_parameter_transient (rmethod, (int32_t) i, &exception_gchandle);
+								bool is_transient = xamarin_is_parameter_transient (rmethod, (int32_t) i, &exception_gchandle) != 0;
 								ADD_TO_MONOOBJECT_RELEASE_LIST (rmethod);
 								if (exception_gchandle != INVALID_GCHANDLE)
 									goto exception_handling;

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -188,7 +188,7 @@ xamarin_marshal_return_value_impl (MonoType *mtype, const char *type, MonoObject
 					} else {
 						// This will try to retain the object if and only if it's an NSObject -
 						// in which case we known it's 'id' here and we can call autorelease on it.
-						bool retained = xamarin_attempt_retain_nsobject (retval, exception_gchandle);
+						bool retained = xamarin_attempt_retain_nsobject (retval, exception_gchandle) != 0;
 						if (*exception_gchandle != INVALID_GCHANDLE)
 							return returnValue;
 						if (retained) {

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -756,7 +756,7 @@ namespace ObjCRuntime {
 			return TryGetNSObject (ptr, evenInFinalizerQueue: false) is not null;
 		}
 
-		internal static sbyte HasNSObject (IntPtr ptr)
+		internal static nint HasNSObject (IntPtr ptr)
 		{
 			var rv = TryGetNSObject (ptr, evenInFinalizerQueue: false) is not null;
 			return (sbyte) (rv ? 1 : 0);
@@ -837,7 +837,7 @@ namespace ObjCRuntime {
 			((IDisposable?) GetGCHandleTarget (gchandle))?.Dispose ();
 		}
 
-		static sbyte IsParameterTransient (IntPtr info, int parameter)
+		static nint IsParameterTransient (IntPtr info, int parameter)
 		{
 			var minfo = GetGCHandleTarget (info) as MethodInfo;
 			if (minfo is null)
@@ -847,10 +847,10 @@ namespace ObjCRuntime {
 			if (parameters.Length <= parameter)
 				return 0;
 			var rv = parameters [parameter].IsDefined (typeof (TransientAttribute), false);
-			return (sbyte) (rv ? 1 : 0);
+			return rv ? 1 : 0;
 		}
 
-		static sbyte IsParameterOut (IntPtr info, int parameter)
+		static nint IsParameterOut (IntPtr info, int parameter)
 		{
 			var minfo = GetGCHandleTarget (info) as MethodInfo;
 			if (minfo is null)
@@ -860,7 +860,7 @@ namespace ObjCRuntime {
 			if (parameters.Length <= parameter)
 				return 0;
 			var rv = parameters [parameter].IsOut;
-			return (sbyte) (rv ? 1 : 0);
+			return rv ? 1 : 0;
 		}
 
 		unsafe static void GetMethodAndObjectForSelector (IntPtr klass, IntPtr sel, sbyte is_static, IntPtr obj, IntPtr* mthisPtr, IntPtr desc)
@@ -2331,12 +2331,12 @@ namespace ObjCRuntime {
 
 		// Check if the input is an NSObject, and in that case retain it (and return true)
 		// This way the caller knows if it can call 'autorelease' on our input.
-		static sbyte AttemptRetainNSObject (IntPtr gchandle)
+		static nint AttemptRetainNSObject (IntPtr gchandle)
 		{
 			var obj = GetGCHandleTarget (gchandle) as NSObject;
 			obj?.DangerousRetain ();
 			var rv = obj is not null;
-			return (sbyte) (rv ? 1 : 0);
+			return rv ? 1 : 0;
 		}
 #endif // !COREBUILD
 
@@ -2636,13 +2636,13 @@ namespace ObjCRuntime {
 		[DllImport ("__Internal")]
 		static extern IntPtr xamarin_get_original_working_directory_path ();
 
-		static sbyte InvokeConformsToProtocol (IntPtr handle, IntPtr protocol)
+		static nint InvokeConformsToProtocol (IntPtr handle, IntPtr protocol)
 		{
 			var obj = Runtime.GetNSObject (handle);
 			if (obj is null)
 				return 0;
 			var rv = obj.ConformsToProtocol (protocol);
-			return (sbyte) (rv ? 1 : 0);
+			return rv ? 1 : 0;
 		}
 
 		static IntPtr LookupUnmanagedFunction (IntPtr assembly, IntPtr symbol, int id)

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3490,7 +3490,7 @@ namespace Registrar {
 					sb.AppendLine ("-(BOOL) conformsToProtocol: (void *) protocol");
 					sb.AppendLine ("{");
 					sb.AppendLine ("GCHandle exception_gchandle;");
-					sb.AppendLine ("BOOL rv = xamarin_invoke_conforms_to_protocol (self, (Protocol *) protocol, &exception_gchandle);");
+					sb.AppendLine ("BOOL rv = xamarin_invoke_conforms_to_protocol (self, (Protocol *) protocol, &exception_gchandle) != 0;");
 					sb.AppendLine ("xamarin_process_managed_exception_gchandle (exception_gchandle);");
 					sb.AppendLine ("return rv;");
 					sb.AppendLine ("}");
@@ -4518,7 +4518,7 @@ namespace Registrar {
 						// If xamarin_attempt_retain_nsobject returns true, the input is an NSObject, so it's safe to call the 'autorelease' selector on it.
 						// We don't retain retval if it's not an NSObject, because we'd have to immediately release it,
 						// and that serves no purpose.
-						setup_return.AppendLine ("bool retained = xamarin_attempt_retain_nsobject (retval, &exception_gchandle);");
+						setup_return.AppendLine ("bool retained = xamarin_attempt_retain_nsobject (retval, &exception_gchandle) != 0;");
 						setup_return.AppendLine ("if (exception_gchandle != INVALID_GCHANDLE) goto exception_handling;");
 						setup_return.AppendLine ("if (retained) {");
 						setup_return.AppendLine ("[retobj autorelease];");


### PR DESCRIPTION
The interpreter has a bug where it doesn't correctly zero-extend small integer
values (such as bytes) upon returning from managed to native code (in a
reverse P/Invoke): https://github.com/dotnet/runtime/issues/110649.

Work around this by always using at least register-sized integer values
instead, which makes the interpreter return the correct values.

Fixes https://github.com/dotnet/macios/issues/22205.