### PR TITLE
[net10.0] [tests] Revert ignored NativeAOT tests that were failing due to a dotnet/sdk issue.

### DIFF
--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -2017,7 +2017,6 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.iOS, "iossimulator-x64")]
 		[TestCase (ApplePlatform.MacOSX, "osx-arm64")]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64")]
-		[Ignore ("https://github.com/dotnet/sdk/issues/46790")]
 		public void PublishAotDuringBuild (ApplePlatform platform, string runtimeIdentifiers)
 		{
 			var project = "MySimpleApp";
@@ -2035,7 +2034,6 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.iOS, "ios-arm64")]
 		[TestCase (ApplePlatform.iOS, "iossimulator-arm64")]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64")]
-		[Ignore ("https://github.com/dotnet/sdk/issues/46790")]
 		public void BuildMyNativeAotAppWithTrimAnalysisWarning (ApplePlatform platform, string runtimeIdentifiers)
 		{
 			var project = "MyNativeAotAppWithTrimAnalysisWarning";


### PR DESCRIPTION
This reverts commit c5711236eba170cf66b3f6c7039b9bd63de0e3ce.

Fixes https://github.com/dotnet/macios/issues/22187.