### PR TITLE
[msbuild] `<WriteItemsToFile/>` task creates empty outputs for Windows

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/WriteItemsToFile.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/WriteItemsToFile.cs
@@ -91,10 +91,10 @@ namespace Xamarin.MacDev.Tasks {
 		}
 
 		//We are expecting the files to be already present in the Mac
- 		public bool ShouldCopyToBuildServer (ITaskItem item) => false;
- 
+		public bool ShouldCopyToBuildServer (ITaskItem item) => false;
+
 		//We want empty output files to be created in Windows
- 		public bool ShouldCreateOutputFile (ITaskItem item) => true;
+		public bool ShouldCreateOutputFile (ITaskItem item) => true;
 
 		public IEnumerable<ITaskItem> GetAdditionalItemsToBeCopied () => [];
 	}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/WriteItemsToFile.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/WriteItemsToFile.cs
@@ -11,7 +11,7 @@ using System.Xml.Linq;
 using Xamarin.Messaging.Build.Client;
 
 namespace Xamarin.MacDev.Tasks {
-	public class WriteItemsToFile : XamarinTask, ICancelableTask {
+	public class WriteItemsToFile : XamarinTask, ICancelableTask, ITaskCallback {
 		static readonly XNamespace XmlNs = XNamespace.Get ("http://schemas.microsoft.com/developer/msbuild/2003");
 
 		static readonly XName ProjectElementName = XmlNs + "Project";
@@ -89,5 +89,13 @@ namespace Xamarin.MacDev.Tasks {
 			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
+
+		//We are expecting the files to be already present in the Mac
+ 		public bool ShouldCopyToBuildServer (ITaskItem item) => false;
+ 
+		//We want empty output files to be created in Windows
+ 		public bool ShouldCreateOutputFile (ITaskItem item) => true;
+
+		public IEnumerable<ITaskItem> GetAdditionalItemsToBeCopied () => [];
 	}
 }

--- a/tests/dotnet/UnitTests/WindowsTest.cs
+++ b/tests/dotnet/UnitTests/WindowsTest.cs
@@ -234,11 +234,13 @@ namespace Xamarin.Tests {
 			Configuration.Touch (appDelegatePath);
 
 			rv = DotNet.AssertBuild (project_path, properties);
+			var allTargets = BinLog.GetAllTargets (rv.BinLogPath);
 			warnings = BinLog.GetBuildLogWarnings (rv.BinLogPath).ToArray ();
 			warningMessages = BundleStructureTest.FilterWarnings (warnings, canonicalizePaths: true);
 
 			BundleStructureTest.CheckZippedAppBundleContents (platform, zippedAppBundlePath, rids, signature, isReleaseBuild);
 			AssertWarningsEqual (expectedWarnings, warningMessages, "Warnings Rebuild 1");
+			AssertTargetNotExecuted (allTargets, "_CoreCompileImageAssets", "_CoreCompileImageAssets Rebuild 1");
 			ExecuteWithMagicWordAndAssert (platform, runtimeIdentifiers, appExecutable);
 
 			// remove the bin directory, and rebuild should succeed and do the right thing
@@ -246,20 +248,24 @@ namespace Xamarin.Tests {
 			Directory.Delete (binDirectory, true);
 
 			rv = DotNet.AssertBuild (project_path, properties);
+			allTargets = BinLog.GetAllTargets (rv.BinLogPath);
 			warnings = BinLog.GetBuildLogWarnings (rv.BinLogPath).ToArray ();
 			warningMessages = BundleStructureTest.FilterWarnings (warnings, canonicalizePaths: true);
 
 			BundleStructureTest.CheckZippedAppBundleContents (platform, zippedAppBundlePath, rids, signature, isReleaseBuild);
 			AssertWarningsEqual (expectedWarnings, warningMessages, "Warnings Rebuild 2");
+			AssertTargetNotExecuted (allTargets, "_CoreCompileImageAssets", "_CoreCompileImageAssets Rebuild 2");
 			ExecuteWithMagicWordAndAssert (platform, runtimeIdentifiers, appExecutable);
 
 			// a simple rebuild should succeed
 			rv = DotNet.AssertBuild (project_path, properties);
+			allTargets = BinLog.GetAllTargets (rv.BinLogPath);
 			warnings = BinLog.GetBuildLogWarnings (rv.BinLogPath).ToArray ();
 			warningMessages = BundleStructureTest.FilterWarnings (warnings, canonicalizePaths: true);
 
 			BundleStructureTest.CheckZippedAppBundleContents (platform, zippedAppBundlePath, rids, signature, isReleaseBuild);
 			AssertWarningsEqual (expectedWarnings, warningMessages, "Warnings Rebuild 3");
+			AssertTargetNotExecuted (allTargets, "_CoreCompileImageAssets", "_CoreCompileImageAssets Rebuild 3");
 			ExecuteWithMagicWordAndAssert (platform, runtimeIdentifiers, appExecutable);
 		}
 


### PR DESCRIPTION
Context: https://github.com/dotnet/macios/issues/19611

Ignoring tasks related to AOT and trimming, one of the slower steps during a remote iOS build from Windows for me is:

    Task _CoreCompileImageAssets 524ms
    Building target "_CoreCompileImageAssets" completely.
    Output file "obj\Debug\net9.0-ios\iossimulator-arm64\actool\_PartialAppManifest.items" does not exist.

When building locally on Mac, the same build will say:

    Target _CoreCompileImageAssets
    Skipping target "_CoreCompileImageAssets" because all output files are up-to-date with respect to the input files.

The MSBuild target has the code:

    <Target Name="_CoreCompileImageAssets"
        Inputs="@(ImageAsset);$(_TemporaryAppManifest)"
        Outputs="$(_ACTool_PartialAppManifestCache);$(_ACTool_BundleResourceCache)"
        ...>

        <ACTool ... />

        <WriteItemsToFile Items="@(_ACTool_PartialAppManifest)" ... />
        <WriteItemsToFile Items="@(_ACTool_BundleResources)" ... />
        <ItemGroup>
            <FileWrites Include="$(_ACTool_PartialAppManifestCache);$(_ACTool_BundleResourceCache)" />
        </ItemGroup>
    </Target>

I think all that needs to be done is to implement `ITaskCallback` in the `<WriteItemsToFile/>` MSBuild task:

    public bool ShouldCreateOutputFile (ITaskItem item) => true;

I updated `WindowsTest.cs` to verify that the
`_CoreCompileImageAssets` MSBuild target is skipped on incremental builds.