### PR TITLE
[RGen] Use the nomenglator to decide the names of the temp vars in trampolines

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
@@ -114,13 +114,13 @@ class Nomenclator {
 	/// <returns>The name to be used for the temporary variable or null if it was unknown.</returns>
 	public static string? GetNameForTempTrampolineVariable (in Parameter parameterInfo)
 	{
-#pragma warning disable forma
+#pragma warning disable format
 		return parameterInfo switch {
 			{ Type.IsReferenceType: false, Type.IsNullable: true } => $"__xamarin_nullified__{parameterInfo.Position}",
 			{ Type.SpecialType: SpecialType.System_Boolean } => $"__xamarin_bool__{parameterInfo.Position}",
 			{ Type.IsReferenceType: true } => $"__xamarin_pref{parameterInfo.Position}",
 			_ => null,
 		};
-#pragma warning restore forma
+#pragma warning restore format
 	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
@@ -114,8 +114,13 @@ class Nomenclator {
 	/// <returns>The name to be used for the temporary variable or null if it was unknown.</returns>
 	public static string? GetNameForTempTrampolineVariable (in Parameter parameterInfo)
 	{
-		return parameterInfo switch { { Type.IsReferenceType: false, Type.IsNullable: true } => $"__xamarin_nullified__{parameterInfo.Position}", { Type.SpecialType: SpecialType.System_Boolean } => $"__xamarin_bool__{parameterInfo.Position}", { Type.IsReferenceType: true } => $"__xamarin_pref{parameterInfo.Position}",
+#pragma warning disable forma
+		return parameterInfo switch {
+			{ Type.IsReferenceType: false, Type.IsNullable: true } => $"__xamarin_nullified__{parameterInfo.Position}",
+			{ Type.SpecialType: SpecialType.System_Boolean } => $"__xamarin_bool__{parameterInfo.Position}",
+			{ Type.IsReferenceType: true } => $"__xamarin_pref{parameterInfo.Position}",
 			_ => null,
 		};
+#pragma warning restore forma
 	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
@@ -105,7 +105,7 @@ class Nomenclator {
 	/// </summary>
 	/// <param name="typeInfo">The type info whose name we want for the return type.</param>
 	public static string GetReturnVariableName (in TypeInfo typeInfo) => "ret"; // nothing fancy for now
-	
+
 	/// <summary>
 	/// Returns the name of the trampoline variable for the given parameter info. This variables are used as
 	/// temporary variables to hold the value of the parameter before passing it to the trampoline.
@@ -114,10 +114,7 @@ class Nomenclator {
 	/// <returns>The name to be used for the temporary variable or null if it was unknown.</returns>
 	public static string? GetNameForTempTrampolineVariable (in Parameter parameterInfo)
 	{
-		return parameterInfo switch {
-			{ Type.IsReferenceType: false, Type.IsNullable: true } => $"__xamarin_nullified__{parameterInfo.Position}",
-			{ Type.SpecialType: SpecialType.System_Boolean } => $"__xamarin_bool__{parameterInfo.Position}",
-			{ Type.IsReferenceType: true } => $"__xamarin_pref{parameterInfo.Position}",
+		return parameterInfo switch { { Type.IsReferenceType: false, Type.IsNullable: true } => $"__xamarin_nullified__{parameterInfo.Position}", { Type.SpecialType: SpecialType.System_Boolean } => $"__xamarin_bool__{parameterInfo.Position}", { Type.IsReferenceType: true } => $"__xamarin_pref{parameterInfo.Position}",
 			_ => null,
 		};
 	}

--- a/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
@@ -115,10 +115,7 @@ class Nomenclator {
 	public static string? GetNameForTempTrampolineVariable (in Parameter parameterInfo)
 	{
 #pragma warning disable forma
-		return parameterInfo switch {
-			{ Type.IsReferenceType: false, Type.IsNullable: true } => $"__xamarin_nullified__{parameterInfo.Position}",
-			{ Type.SpecialType: SpecialType.System_Boolean } => $"__xamarin_bool__{parameterInfo.Position}",
-			{ Type.IsReferenceType: true } => $"__xamarin_pref{parameterInfo.Position}",
+		return parameterInfo switch { { Type.IsReferenceType: false, Type.IsNullable: true } => $"__xamarin_nullified__{parameterInfo.Position}", { Type.SpecialType: SpecialType.System_Boolean } => $"__xamarin_bool__{parameterInfo.Position}", { Type.IsReferenceType: true } => $"__xamarin_pref{parameterInfo.Position}",
 			_ => null,
 		};
 #pragma warning restore forma

--- a/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
@@ -115,7 +115,10 @@ class Nomenclator {
 	public static string? GetNameForTempTrampolineVariable (in Parameter parameterInfo)
 	{
 #pragma warning disable forma
-		return parameterInfo switch { { Type.IsReferenceType: false, Type.IsNullable: true } => $"__xamarin_nullified__{parameterInfo.Position}", { Type.SpecialType: SpecialType.System_Boolean } => $"__xamarin_bool__{parameterInfo.Position}", { Type.IsReferenceType: true } => $"__xamarin_pref{parameterInfo.Position}",
+		return parameterInfo switch {
+			{ Type.IsReferenceType: false, Type.IsNullable: true } => $"__xamarin_nullified__{parameterInfo.Position}",
+			{ Type.SpecialType: SpecialType.System_Boolean } => $"__xamarin_bool__{parameterInfo.Position}",
+			{ Type.IsReferenceType: true } => $"__xamarin_pref{parameterInfo.Position}",
 			_ => null,
 		};
 #pragma warning restore forma

--- a/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
 using Microsoft.Macios.Generator.DataModel;
+using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
 
 namespace Microsoft.Macios.Generator;
 
@@ -103,4 +105,20 @@ class Nomenclator {
 	/// </summary>
 	/// <param name="typeInfo">The type info whose name we want for the return type.</param>
 	public static string GetReturnVariableName (in TypeInfo typeInfo) => "ret"; // nothing fancy for now
+	
+	/// <summary>
+	/// Returns the name of the trampoline variable for the given parameter info. This variables are used as
+	/// temporary variables to hold the value of the parameter before passing it to the trampoline.
+	/// </summary>
+	/// <param name="parameterInfo">The parameter information for the trampoline.</param>
+	/// <returns>The name to be used for the temporary variable or null if it was unknown.</returns>
+	public static string? GetNameForTempTrampolineVariable (in Parameter parameterInfo)
+	{
+		return parameterInfo switch {
+			{ Type.IsReferenceType: false, Type.IsNullable: true } => $"__xamarin_nullified__{parameterInfo.Position}",
+			{ Type.SpecialType: SpecialType.System_Boolean } => $"__xamarin_bool__{parameterInfo.Position}",
+			{ Type.IsReferenceType: true } => $"__xamarin_pref{parameterInfo.Position}",
+			_ => null,
+		};
+	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/NomenclatorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/NomenclatorTests.cs
@@ -86,7 +86,7 @@ public class Example {
 	[ClassData (typeof (TestDataGetVariableName))]
 	void GetNameForVariableTypeTests (Parameter parameter, Nomenclator.VariableType variableType, string expectedName)
 		=> Assert.Equal (expectedName, Nomenclator.GetNameForVariableType (parameter.Name, variableType));
-	
+
 	class TestDataGetNameForTempTrampolineVariable : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -95,13 +95,13 @@ public class Example {
 			yield return [exampleParameter, $"__xamarin_bool__{exampleParameter.Position}"];
 			exampleParameter = new Parameter (4, ReturnTypeForBool (), "firstParameter");
 			yield return [exampleParameter, $"__xamarin_bool__{exampleParameter.Position}"];
-			
+
 			// nullable value type, diff pos
 			exampleParameter = new Parameter (0, ReturnTypeForInt (isNullable: true), "firstParameter");
 			yield return [exampleParameter, $"__xamarin_nullified__{exampleParameter.Position}"];
 			exampleParameter = new Parameter (4, ReturnTypeForInt (isNullable: true), "firstParameter");
 			yield return [exampleParameter, $"__xamarin_nullified__{exampleParameter.Position}"];
-			
+
 			exampleParameter = new Parameter (0, ReturnTypeForNSObject ("MyNSObject"), "firstParameter");
 			yield return [exampleParameter, $"__xamarin_pref{exampleParameter.Position}"];
 			exampleParameter = new Parameter (4, ReturnTypeForNSObject ("MyNSObject"), "firstParameter");
@@ -110,7 +110,7 @@ public class Example {
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
-	
+
 	[Theory]
 	[ClassData (typeof (TestDataGetNameForTempTrampolineVariable))]
 	void GetNameForTempTrampolineVariable (Parameter parameter, string expectedName)

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/NomenclatorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/NomenclatorTests.cs
@@ -86,5 +86,34 @@ public class Example {
 	[ClassData (typeof (TestDataGetVariableName))]
 	void GetNameForVariableTypeTests (Parameter parameter, Nomenclator.VariableType variableType, string expectedName)
 		=> Assert.Equal (expectedName, Nomenclator.GetNameForVariableType (parameter.Name, variableType));
+	
+	class TestDataGetNameForTempTrampolineVariable : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			var exampleParameter = new Parameter (0, ReturnTypeForBool (), "firstParameter");
+			// bool, diff pos
+			yield return [exampleParameter, $"__xamarin_bool__{exampleParameter.Position}"];
+			exampleParameter = new Parameter (4, ReturnTypeForBool (), "firstParameter");
+			yield return [exampleParameter, $"__xamarin_bool__{exampleParameter.Position}"];
+			
+			// nullable value type, diff pos
+			exampleParameter = new Parameter (0, ReturnTypeForInt (isNullable: true), "firstParameter");
+			yield return [exampleParameter, $"__xamarin_nullified__{exampleParameter.Position}"];
+			exampleParameter = new Parameter (4, ReturnTypeForInt (isNullable: true), "firstParameter");
+			yield return [exampleParameter, $"__xamarin_nullified__{exampleParameter.Position}"];
+			
+			exampleParameter = new Parameter (0, ReturnTypeForNSObject ("MyNSObject"), "firstParameter");
+			yield return [exampleParameter, $"__xamarin_pref{exampleParameter.Position}"];
+			exampleParameter = new Parameter (4, ReturnTypeForNSObject ("MyNSObject"), "firstParameter");
+			yield return [exampleParameter, $"__xamarin_pref{exampleParameter.Position}"];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	
+	[Theory]
+	[ClassData (typeof (TestDataGetNameForTempTrampolineVariable))]
+	void GetNameForTempTrampolineVariable (Parameter parameter, string expectedName)
+		=> Assert.Equal (expectedName, Nomenclator.GetNameForTempTrampolineVariable (parameter));
 }
 


### PR DESCRIPTION
This way we have a centralized place in which the naming is calculated and its easier to change/fix.