### PR TITLE
[RGen] Retrieve the CCalback and BlockCallback attrs in a delegate.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/DelegateInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/DelegateInfo.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Microsoft.Macios.Generator.Extensions;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
@@ -22,6 +23,16 @@ sealed record DelegateInfo {
 	/// Method return type.
 	/// </summary>
 	public TypeInfo ReturnType { get; }
+	
+	/// <summary>
+	/// True if the delegate was decorated with the BlockCallbackAttribute.
+	/// </summary>
+	public bool IsBlockCallback { get; init; }
+	
+	/// <summary>
+	/// True if the delegate was decorated with the CCallbackAttribute.
+	/// </summary>
+	public bool IsCCallback { get; init; }
 
 	/// <summary>
 	/// Parameters list.
@@ -35,8 +46,14 @@ sealed record DelegateInfo {
 		Parameters = parameters;
 	}
 
-	public static bool TryCreate (IMethodSymbol method, [NotNullWhen (true)] out DelegateInfo? change)
+	public static bool TryCreate (INamedTypeSymbol symbol, [NotNullWhen (true)] out DelegateInfo? change)
 	{
+		if (symbol.DelegateInvokeMethod is null) {
+			change = null;
+			return false;
+		}
+			
+		var method = symbol.DelegateInvokeMethod;
 		var parametersBucket = ImmutableArray.CreateBuilder<DelegateParameter> ();
 		// loop over the parameters of the construct since changes on those implies a change in the generated code
 		foreach (var parameter in method.Parameters) {
@@ -45,10 +62,14 @@ sealed record DelegateInfo {
 			parametersBucket.Add (parameterChange.Value);
 		}
 
-		change = new (
+		change = new(
 			name: method.Name,
-			returnType: new (method.ReturnType),
-			parameters: parametersBucket.ToImmutableArray ());
+			returnType: new(method.ReturnType),
+			parameters: parametersBucket.ToImmutableArray ()) 
+		{
+			IsBlockCallback = symbol.HasAttribute ("ObjCRuntime.BlockCallbackAttribute"),
+			IsCCallback = symbol.HasAttribute ("ObjCRuntime.CCallbackAttribute"),
+		};
 		return true;
 	}
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/DelegateInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/DelegateInfo.cs
@@ -23,12 +23,12 @@ sealed record DelegateInfo {
 	/// Method return type.
 	/// </summary>
 	public TypeInfo ReturnType { get; }
-	
+
 	/// <summary>
 	/// True if the delegate was decorated with the BlockCallbackAttribute.
 	/// </summary>
 	public bool IsBlockCallback { get; init; }
-	
+
 	/// <summary>
 	/// True if the delegate was decorated with the CCallbackAttribute.
 	/// </summary>
@@ -52,7 +52,7 @@ sealed record DelegateInfo {
 			change = null;
 			return false;
 		}
-			
+
 		var method = symbol.DelegateInvokeMethod;
 		var parametersBucket = ImmutableArray.CreateBuilder<DelegateParameter> ();
 		// loop over the parameters of the construct since changes on those implies a change in the generated code
@@ -62,11 +62,10 @@ sealed record DelegateInfo {
 			parametersBucket.Add (parameterChange.Value);
 		}
 
-		change = new(
+		change = new (
 			name: method.Name,
-			returnType: new(method.ReturnType),
-			parameters: parametersBucket.ToImmutableArray ()) 
-		{
+			returnType: new (method.ReturnType),
+			parameters: parametersBucket.ToImmutableArray ()) {
 			IsBlockCallback = symbol.HasAttribute ("ObjCRuntime.BlockCallbackAttribute"),
 			IsCCallback = symbol.HasAttribute ("ObjCRuntime.CCallbackAttribute"),
 		};

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -286,7 +286,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 			];
 
 			if (namedTypeSymbol.DelegateInvokeMethod is not null &&
-				DelegateInfo.TryCreate (namedTypeSymbol.DelegateInvokeMethod, out var delegateInfo))
+				DelegateInfo.TryCreate (namedTypeSymbol, out var delegateInfo))
 				Delegate = delegateInfo;
 		}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/DelegateInfoTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/DelegateInfoTests.cs
@@ -399,6 +399,131 @@ namespace NS {
 					]
 				)
 			];
+			
+			const string customDelegateCcallback= @"
+using System;
+using Foundation;
+using ObjCRuntime;
+using ObjCBindings;
+
+namespace NS {
+
+	public class MyNSObject : NSObject {
+	}
+
+	public class MyClass {
+		public delegate int? Callback([ForcedType] MyNSObject name);
+
+		public void MyMethod ([CCallback] Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				customDelegateCcallback,
+				new Method (
+					type: "NS.MyClass",
+					name: "MyMethod",
+					returnType: ReturnTypeForVoid (),
+					symbolAvailability: new (),
+					exportMethodData: new (),
+					attributes: [],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					parameters: [
+						new (
+							position: 0,
+							type: ReturnTypeForDelegate (
+								"NS.MyClass.Callback",
+								delegateInfo: new (
+									name: "Invoke",
+									returnType: ReturnTypeForInt (isNullable: true),
+									parameters: [
+										new (
+											position: 0,
+											type: ReturnTypeForNSObject (nsObjectName: "NS.MyNSObject"),
+											name: "name"
+										) {
+											ForcedType = new (),
+										},
+									]
+								) {
+									IsCCallback = true,
+								}
+							),
+							name: "cb"
+						)
+						{
+							Attributes = [
+								new ("ObjCRuntime.CCallbackAttribute")
+							]
+						}
+					]
+				)
+			];
+			
+			const string customDelegateBlockcallback= @"
+using System;
+using Foundation;
+using ObjCRuntime;
+using ObjCBindings;
+
+namespace NS {
+
+	public class MyNSObject : NSObject {
+	}
+
+	public class MyClass {
+		public delegate int? Callback([ForcedType] MyNSObject name);
+
+		public void MyMethod ([BlockCallback] Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				customDelegateBlockcallback,
+				new Method (
+					type: "NS.MyClass",
+					name: "MyMethod",
+					returnType: ReturnTypeForVoid (),
+					symbolAvailability: new (),
+					exportMethodData: new (),
+					attributes: [],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					parameters: [
+						new (
+							position: 0,
+							type: ReturnTypeForDelegate (
+								"NS.MyClass.Callback",
+								delegateInfo: new (
+									name: "Invoke",
+									returnType: ReturnTypeForInt (isNullable: true),
+									parameters: [
+										new (
+											position: 0,
+											type: ReturnTypeForNSObject (nsObjectName: "NS.MyNSObject"),
+											name: "name"
+										) {
+											ForcedType = new (),
+										},
+									]
+								) {
+									IsBlockCallback = true,
+								}
+							),
+							name: "cb"
+						) {
+							Attributes = [ 
+								new ("ObjCRuntime.BlockCallbackAttribute")
+							]
+						}
+					]
+				)
+			];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/DelegateInfoTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/DelegateInfoTests.cs
@@ -399,8 +399,8 @@ namespace NS {
 					]
 				)
 			];
-			
-			const string customDelegateCcallback= @"
+
+			const string customDelegateCcallback = @"
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -453,8 +453,7 @@ namespace NS {
 								}
 							),
 							name: "cb"
-						)
-						{
+						) {
 							Attributes = [
 								new ("ObjCRuntime.CCallbackAttribute")
 							]
@@ -462,8 +461,8 @@ namespace NS {
 					]
 				)
 			];
-			
-			const string customDelegateBlockcallback= @"
+
+			const string customDelegateBlockcallback = @"
 using System;
 using Foundation;
 using ObjCRuntime;
@@ -517,7 +516,7 @@ namespace NS {
 							),
 							name: "cb"
 						) {
-							Attributes = [ 
+							Attributes = [
 								new ("ObjCRuntime.BlockCallbackAttribute")
 							]
 						}


### PR DESCRIPTION
In order for tramplones to be able to take delegates as parameters, we need to identify the type of callback.

We need to check if the CCallbackAttribute or BlockCallbackAttribute have been used in a parameter that is a delegate. This has been added as part of the TryCreate method. Tests got added to ensure that we indeed check the presence of the attrs.