### PR TITLE
[msbuild] introduce `_CompileAppManifestInputs`

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileAppManifest.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileAppManifest.cs
@@ -171,8 +171,8 @@ namespace Xamarin.MacDev.Tasks {
 			Validation (plist);
 
 			// write the resulting app manifest
-			if (FileUtils.UpdateFile (CompiledAppManifest!.ItemSpec, (tmpfile) => plist.Save (tmpfile, true, true)))
-				Log.LogMessage (MessageImportance.Low, "The file {0} is up-to-date.", CompiledAppManifest.ItemSpec);
+			plist.Save (CompiledAppManifest!.ItemSpec, true, true);
+			Log.LogMessage (MessageImportance.Low, "The app manifest {0} was updated.", CompiledAppManifest.ItemSpec);
 
 			return !Log.HasLoggedErrors;
 		}

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -601,6 +601,8 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		>
 		<PropertyGroup>
 			<_CompileAppManifestInputsFile>$(DeviceSpecificIntermediateOutputPath)_CompileAppManifest.inputs</_CompileAppManifestInputsFile>
+			<_CompileAppManifestFontFilesToRegister>@(_FontFilesToRegister)</_CompileAppManifestFontFilesToRegister>
+			<_CompileAppManifestPartialAppManifest>@(PartialAppManifest)</_CompileAppManifestPartialAppManifest>
 		</PropertyGroup>
 		<ItemGroup>
 			<_CompileAppManifestInputLine Include="SessionId=$(BuildSessionId)" />
@@ -614,14 +616,14 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<_CompileAppManifestInputLine Include="CompiledAppManifest=$(_TemporaryAppManifest)" />
 			<_CompileAppManifestInputLine Include="Debug=$(_BundlerDebug)" />
 			<_CompileAppManifestInputLine Include="DefaultSdkVersion=$(_SdkVersion)" />
-			<_CompileAppManifestInputLine Include="FontFilesToRegister=@(_FontFilesToRegister)" />
+			<_CompileAppManifestInputLine Include="FontFilesToRegister=$(_CompileAppManifestFontFilesToRegister)" />
 			<_CompileAppManifestInputLine Include="GenerateApplicationManifest=$(GenerateApplicationManifest)" />
 			<_CompileAppManifestInputLine Include="IsAppExtension=$(IsAppExtension)" />
 			<_CompileAppManifestInputLine Include="IsWatchApp=$(IsWatchApp)" />
 			<_CompileAppManifestInputLine Include="IsWatchExtension=$(IsWatchExtension)" />
 			<_CompileAppManifestInputLine Include="IsXPCService=$(IsXPCService)" />
 			<_CompileAppManifestInputLine Include="MinSupportedOSPlatformVersion=$(MinSupportedOSPlatformVersion)" />
-			<_CompileAppManifestInputLine Include="PartialAppManifests=@(PartialAppManifest)" />
+			<_CompileAppManifestInputLine Include="PartialAppManifests=$(_CompileAppManifestPartialAppManifest)" />
 			<_CompileAppManifestInputLine Include="ProjectDir=$(MSBuildProjectDirectory)" />
 			<_CompileAppManifestInputLine Include="ResourcePrefix=$(_ResourcePrefix)" />
 			<_CompileAppManifestInputLine Include="ResourceRules=$(_PreparedResourceRules)" />

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -637,7 +637,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		</ItemGroup>
 		<!-- If any of the above values change, the file will be written and invalidate _CompileAppManifest -->
 		<WriteLinesToFile
-			SessionId="$(BuildSessionId)"
 			File="$(_CompileAppManifestInputsFile)"
 			Lines="@(_CompileAppManifestInputLine)"
 			Overwrite="true"

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -600,21 +600,22 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		Condition="'$(IsMacEnabled)' == 'true' Or '$(IsHotRestartBuild)' == 'true'"
 		>
 		<PropertyGroup>
-			<_CompileAppManifestInputsFile>$(DeviceSpecificIntermediateOutputPath)_CompileAppManifest.inputs</_CompileAppManifestInputsFile>
+			<_CompileAppManifestInputFile>$(DeviceSpecificIntermediateOutputPath)_CompileAppManifest.inputs</_CompileAppManifestInputFile>
 			<_CompileAppManifestFontFilesToRegister>@(_FontFilesToRegister)</_CompileAppManifestFontFilesToRegister>
 			<_CompileAppManifestPartialAppManifest>@(PartialAppManifest)</_CompileAppManifestPartialAppManifest>
 		</PropertyGroup>
 		<ItemGroup>
-			<_CompileAppManifestInputLine Include="SessionId=$(BuildSessionId)" />
+			<!-- @(_CompileAppManifestInputLine) are lines to write in $(_CompileAppManifestInputFile) -->
+			<_CompileAppManifestInputLine Include="AppBundleName=$(_AppBundleName)" />
+			<_CompileAppManifestInputLine Include="ApplicationDisplayVersion=$(ApplicationDisplayVersion)" />
 			<_CompileAppManifestInputLine Include="ApplicationId=$(ApplicationId)" />
 			<_CompileAppManifestInputLine Include="ApplicationTitle=$(ApplicationTitle)" />
 			<_CompileAppManifestInputLine Include="ApplicationVersion=$(ApplicationVersion)" />
-			<_CompileAppManifestInputLine Include="ApplicationDisplayVersion=$(ApplicationDisplayVersion)" />
-			<_CompileAppManifestInputLine Include="AppBundleName=$(_AppBundleName)" />
 			<_CompileAppManifestInputLine Include="AppManifest=$(AppBundleManifest)" />
 			<_CompileAppManifestInputLine Include="AssemblyName=$(AssemblyName)" />
 			<_CompileAppManifestInputLine Include="CompiledAppManifest=$(_TemporaryAppManifest)" />
 			<_CompileAppManifestInputLine Include="Debug=$(_BundlerDebug)" />
+			<_CompileAppManifestInputLine Include="DebugIPAddresses=$(_DebugIPAddresses)" />
 			<_CompileAppManifestInputLine Include="DefaultSdkVersion=$(_SdkVersion)" />
 			<_CompileAppManifestInputLine Include="FontFilesToRegister=$(_CompileAppManifestFontFilesToRegister)" />
 			<_CompileAppManifestInputLine Include="GenerateApplicationManifest=$(GenerateApplicationManifest)" />
@@ -627,23 +628,26 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<_CompileAppManifestInputLine Include="ProjectDir=$(MSBuildProjectDirectory)" />
 			<_CompileAppManifestInputLine Include="ResourcePrefix=$(_ResourcePrefix)" />
 			<_CompileAppManifestInputLine Include="ResourceRules=$(_PreparedResourceRules)" />
-			<_CompileAppManifestInputLine Include="TargetArchitectures=$(TargetArchitectures)" />
-			<_CompileAppManifestInputLine Include="TargetFrameworkMoniker=$(_ComputedTargetFrameworkMoniker)" />
 			<_CompileAppManifestInputLine Include="SdkIsSimulator=$(_SdkIsSimulator)" />
 			<_CompileAppManifestInputLine Include="SdkVersion=$(_SdkVersion)" />
 			<_CompileAppManifestInputLine Include="SupportedOSPlatformVersion=$(SupportedOSPlatformVersion)" />
-			<_CompileAppManifestInputLine Include="DebugIPAddresses=$(_DebugIPAddresses)" />
+			<_CompileAppManifestInputLine Include="TargetArchitectures=$(TargetArchitectures)" />
+			<_CompileAppManifestInputLine Include="TargetFrameworkMoniker=$(_ComputedTargetFrameworkMoniker)" />
 			<_CompileAppManifestInputLine Include="Validate=$(_CreateAppManifest)" />
+			<!-- @(_CompileAppManifestInputFile) contains additional files to use as Inputs -->
+			<_CompileAppManifestInputFile Include="$(_CompileAppManifestInputFile)" />
+			<_CompileAppManifestInputFile Include="@(_FontFilesToRegister)" />
+			<_CompileAppManifestInputFile Include="@(PartialAppManifest)" />
 		</ItemGroup>
 		<!-- If any of the above values change, the file will be written and invalidate _CompileAppManifest -->
 		<WriteLinesToFile
-			File="$(_CompileAppManifestInputsFile)"
+			File="$(_CompileAppManifestInputFile)"
 			Lines="@(_CompileAppManifestInputLine)"
 			Overwrite="true"
 			WriteOnlyWhenDifferent="true"
 		/>
 		<ItemGroup>
-			<FileWrites Include="$(_CompileAppManifestInputsFile)" />
+			<FileWrites Include="$(_CompileAppManifestInputFile)" />
 		</ItemGroup>
 	</Target>
 
@@ -651,7 +655,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<Target Name="_CompileAppManifest"
 		Condition="'$(_BundleOriginalResources)' != 'true'"
 		DependsOnTargets="$(_CompileAppManifestDependsOn)"
-		Inputs="$(_CompileAppManifestInputsFile)"
+		Inputs="@(_CompileAppManifestInputFile)"
 		Outputs="$(_TemporaryAppManifest)"
 		>
 
@@ -662,15 +666,16 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<CompileAppManifest
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true' Or '$(IsHotRestartBuild)' == 'true'"
+			AppBundleName="$(_AppBundleName)"
+			ApplicationDisplayVersion="$(ApplicationDisplayVersion)"
 			ApplicationId="$(ApplicationId)"
 			ApplicationTitle="$(ApplicationTitle)"
 			ApplicationVersion="$(ApplicationVersion)"
-			ApplicationDisplayVersion="$(ApplicationDisplayVersion)"
-			AppBundleName="$(_AppBundleName)"
 			AppManifest="$(AppBundleManifest)"
 			AssemblyName="$(AssemblyName)"
 			CompiledAppManifest="$(_TemporaryAppManifest)"
 			Debug="$(_BundlerDebug)"
+			DebugIPAddresses="$(_DebugIPAddresses)"
 			DefaultSdkVersion="$(_SdkVersion)"
 			FontFilesToRegister="@(_FontFilesToRegister)"
 			GenerateApplicationManifest="$(GenerateApplicationManifest)"
@@ -683,12 +688,11 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			ProjectDir="$(MSBuildProjectDirectory)"
 			ResourcePrefix="$(_ResourcePrefix)"
 			ResourceRules="$(_PreparedResourceRules)"
-			TargetArchitectures="$(TargetArchitectures)"
-			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 			SdkIsSimulator="$(_SdkIsSimulator)"
 			SdkVersion="$(_SdkVersion)"
 			SupportedOSPlatformVersion="$(SupportedOSPlatformVersion)"
-			DebugIPAddresses="$(_DebugIPAddresses)"
+			TargetArchitectures="$(TargetArchitectures)"
+			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 			Validate="$(_CreateAppManifest)"
 			>
 		</CompileAppManifest>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -579,6 +579,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<PropertyGroup>
 		<_CompileAppManifestDependsOn>
 			CollectAppManifests;
+			_CompileAppManifestInputs;
 			$(_CompileAppManifestDependsOn);
 			_DetectBuildType;
 			_DetectAppManifest;
@@ -595,10 +596,61 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		 to the CollectAppManifestsDependsOn property. -->
 	<Target Name="CollectAppManifests" DependsOnTargets="$(CollectAppManifestsDependsOn)" />
 
-	<!-- This target has no inputs, because it must still be run if there are no input app manifests, to set default values -->
+	<Target Name="_CompileAppManifestInputs"
+		Condition="'$(IsMacEnabled)' == 'true' Or '$(IsHotRestartBuild)' == 'true'"
+		>
+		<PropertyGroup>
+			<_CompileAppManifestInputsFile>$(DeviceSpecificIntermediateOutputPath)_CompileAppManifest.inputs</_CompileAppManifestInputsFile>
+		</PropertyGroup>
+		<ItemGroup>
+			<_CompileAppManifestInputLine Include="SessionId=$(BuildSessionId)" />
+			<_CompileAppManifestInputLine Include="ApplicationId=$(ApplicationId)" />
+			<_CompileAppManifestInputLine Include="ApplicationTitle=$(ApplicationTitle)" />
+			<_CompileAppManifestInputLine Include="ApplicationVersion=$(ApplicationVersion)" />
+			<_CompileAppManifestInputLine Include="ApplicationDisplayVersion=$(ApplicationDisplayVersion)" />
+			<_CompileAppManifestInputLine Include="AppBundleName=$(_AppBundleName)" />
+			<_CompileAppManifestInputLine Include="AppManifest=$(AppBundleManifest)" />
+			<_CompileAppManifestInputLine Include="AssemblyName=$(AssemblyName)" />
+			<_CompileAppManifestInputLine Include="CompiledAppManifest=$(_TemporaryAppManifest)" />
+			<_CompileAppManifestInputLine Include="Debug=$(_BundlerDebug)" />
+			<_CompileAppManifestInputLine Include="DefaultSdkVersion=$(_SdkVersion)" />
+			<_CompileAppManifestInputLine Include="FontFilesToRegister=@(_FontFilesToRegister)" />
+			<_CompileAppManifestInputLine Include="GenerateApplicationManifest=$(GenerateApplicationManifest)" />
+			<_CompileAppManifestInputLine Include="IsAppExtension=$(IsAppExtension)" />
+			<_CompileAppManifestInputLine Include="IsWatchApp=$(IsWatchApp)" />
+			<_CompileAppManifestInputLine Include="IsWatchExtension=$(IsWatchExtension)" />
+			<_CompileAppManifestInputLine Include="IsXPCService=$(IsXPCService)" />
+			<_CompileAppManifestInputLine Include="MinSupportedOSPlatformVersion=$(MinSupportedOSPlatformVersion)" />
+			<_CompileAppManifestInputLine Include="PartialAppManifests=@(PartialAppManifest)" />
+			<_CompileAppManifestInputLine Include="ProjectDir=$(MSBuildProjectDirectory)" />
+			<_CompileAppManifestInputLine Include="ResourcePrefix=$(_ResourcePrefix)" />
+			<_CompileAppManifestInputLine Include="ResourceRules=$(_PreparedResourceRules)" />
+			<_CompileAppManifestInputLine Include="TargetArchitectures=$(TargetArchitectures)" />
+			<_CompileAppManifestInputLine Include="TargetFrameworkMoniker=$(_ComputedTargetFrameworkMoniker)" />
+			<_CompileAppManifestInputLine Include="SdkIsSimulator=$(_SdkIsSimulator)" />
+			<_CompileAppManifestInputLine Include="SdkVersion=$(_SdkVersion)" />
+			<_CompileAppManifestInputLine Include="SupportedOSPlatformVersion=$(SupportedOSPlatformVersion)" />
+			<_CompileAppManifestInputLine Include="DebugIPAddresses=$(_DebugIPAddresses)" />
+			<_CompileAppManifestInputLine Include="Validate=$(_CreateAppManifest)" />
+		</ItemGroup>
+		<!-- If any of the above values change, the file will be written and invalidate _CompileAppManifest -->
+		<WriteLinesToFile
+			SessionId="$(BuildSessionId)"
+			File="$(_CompileAppManifestInputsFile)"
+			Lines="@(_CompileAppManifestInputLine)"
+			Overwrite="true"
+			WriteOnlyWhenDifferent="true"
+		/>
+		<ItemGroup>
+			<FileWrites Include="$(_CompileAppManifestInputsFile)" />
+		</ItemGroup>
+	</Target>
+
+	<!-- NOTE: Keep new parameters to <CompileAppManifest/> in sync with @(_CompileAppManifestInputLine) above -->
 	<Target Name="_CompileAppManifest"
 		Condition="'$(_BundleOriginalResources)' != 'true'"
 		DependsOnTargets="$(_CompileAppManifestDependsOn)"
+		Inputs="$(_CompileAppManifestInputsFile)"
 		Outputs="$(_TemporaryAppManifest)"
 		>
 

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -599,6 +599,10 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<Target Name="_CompileAppManifestInputs"
 		Condition="'$(IsMacEnabled)' == 'true' Or '$(IsHotRestartBuild)' == 'true'"
 		>
+		<ItemGroup>
+			<_FontFilesToRegister Include="@(BundleResource)" Condition="'%(BundleResource.RegisterFont)' == 'true'" />
+		</ItemGroup>
+
 		<PropertyGroup>
 			<_CompileAppManifestInputFile>$(DeviceSpecificIntermediateOutputPath)_CompileAppManifest.inputs</_CompileAppManifestInputFile>
 			<_CompileAppManifestFontFilesToRegister>@(_FontFilesToRegister)</_CompileAppManifestFontFilesToRegister>
@@ -658,10 +662,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		Inputs="@(_CompileAppManifestInputFile)"
 		Outputs="$(_TemporaryAppManifest)"
 		>
-
-		<ItemGroup>
-			<_FontFilesToRegister Include="@(BundleResource)" Condition="'%(BundleResource.RegisterFont)' == 'true'" />
-		</ItemGroup>
 
 		<CompileAppManifest
 			SessionId="$(BuildSessionId)"

--- a/tests/dotnet/UnitTests/PartialAppManifestTest.cs
+++ b/tests/dotnet/UnitTests/PartialAppManifestTest.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Tests {
 
 			rv = DotNet.AssertBuild (project_path, GetDefaultProperties (runtimeIdentifiers));
 			allTargets = BinLog.GetAllTargets (rv.BinLogPath);
-			AssertTargetExecuted (allTargets, "_CompileAppManifest", "_CompileAppManifest rebuild 2");
+			AssertTargetNotExecuted (allTargets, "_CompileAppManifest", "_CompileAppManifest rebuild 2");
 		}
 	}
 }

--- a/tests/dotnet/UnitTests/PartialAppManifestTest.cs
+++ b/tests/dotnet/UnitTests/PartialAppManifestTest.cs
@@ -23,6 +23,16 @@ namespace Xamarin.Tests {
 			Assert.AreEqual ("3.14", infoPlist.GetString ("CFBundleVersion").Value, "CFBundleVersion");
 			Assert.AreEqual ("3.14", infoPlist.GetString ("CFBundleShortVersionString").Value, "CFBundleShortVersionString");
 			Assert.AreEqual ("SomeValue", infoPlist.GetString ("Something").Value, "Something");
+
+			var partialAppManifestPath = Path.Combine (Path.GetDirectoryName (project_path)!, "..", "Partial.plist");
+			Configuration.Touch (partialAppManifestPath);
+			var rv = DotNet.AssertBuild (project_path, GetDefaultProperties (runtimeIdentifiers));
+			var allTargets = BinLog.GetAllTargets (rv.BinLogPath);
+			AssertTargetExecuted (allTargets, "_CompileAppManifest", "_CompileAppManifest rebuild");
+
+			rv = DotNet.AssertBuild (project_path, GetDefaultProperties (runtimeIdentifiers));
+			allTargets = BinLog.GetAllTargets (rv.BinLogPath);
+			AssertTargetExecuted (allTargets, "_CompileAppManifest", "_CompileAppManifest rebuild 2");
 		}
 	}
 }

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -786,6 +786,16 @@ namespace Xamarin.Tests {
 			Assert.AreEqual (runtimeIdentifiers.Split (';').Any (v => v.EndsWith ("-arm64")), File.Exists (arm64txt), "arm64.txt");
 			Assert.AreEqual (runtimeIdentifiers.Split (';').Any (v => v.EndsWith ("-arm")), File.Exists (armtxt), "arm.txt");
 			Assert.AreEqual (runtimeIdentifiers.Split (';').Any (v => v.EndsWith ("-x64")), File.Exists (x64txt), "x64.txt");
+
+			var b_otf = Path.Combine (Path.GetDirectoryName (project_path)!, "Resources", "B.otf");
+			Configuration.Touch (b_otf);
+			var rv = DotNet.AssertBuild (project_path, GetDefaultProperties (runtimeIdentifiers));
+			var allTargets = BinLog.GetAllTargets (rv.BinLogPath);
+			AssertTargetExecuted (allTargets, "_CompileAppManifest", "_CompileAppManifest rebuild");
+
+			rv = DotNet.AssertBuild (project_path, GetDefaultProperties (runtimeIdentifiers));
+			allTargets = BinLog.GetAllTargets (rv.BinLogPath);
+			AssertTargetNotExecuted (allTargets, "_CompileAppManifest", "_CompileAppManifest rebuild 2");
 		}
 
 		[Category ("Windows")]

--- a/tests/dotnet/UnitTests/WindowsTest.cs
+++ b/tests/dotnet/UnitTests/WindowsTest.cs
@@ -234,11 +234,13 @@ namespace Xamarin.Tests {
 			Configuration.Touch (appDelegatePath);
 
 			rv = DotNet.AssertBuild (project_path, properties);
+			var allTargets = BinLog.GetAllTargets (rv.BinLogPath);
 			warnings = BinLog.GetBuildLogWarnings (rv.BinLogPath).ToArray ();
 			warningMessages = BundleStructureTest.FilterWarnings (warnings, canonicalizePaths: true);
 
 			BundleStructureTest.CheckZippedAppBundleContents (platform, zippedAppBundlePath, rids, signature, isReleaseBuild);
 			AssertWarningsEqual (expectedWarnings, warningMessages, "Warnings Rebuild 1");
+			AssertTargetNotExecuted (allTargets, "_CompileAppManifest", "_CompileAppManifest Rebuild 1");
 			ExecuteWithMagicWordAndAssert (platform, runtimeIdentifiers, appExecutable);
 
 			// remove the bin directory, and rebuild should succeed and do the right thing
@@ -246,20 +248,24 @@ namespace Xamarin.Tests {
 			Directory.Delete (binDirectory, true);
 
 			rv = DotNet.AssertBuild (project_path, properties);
+			allTargets = BinLog.GetAllTargets (rv.BinLogPath);
 			warnings = BinLog.GetBuildLogWarnings (rv.BinLogPath).ToArray ();
 			warningMessages = BundleStructureTest.FilterWarnings (warnings, canonicalizePaths: true);
 
 			BundleStructureTest.CheckZippedAppBundleContents (platform, zippedAppBundlePath, rids, signature, isReleaseBuild);
 			AssertWarningsEqual (expectedWarnings, warningMessages, "Warnings Rebuild 2");
+			AssertTargetNotExecuted (allTargets, "_CompileAppManifest", "_CompileAppManifest Rebuild 2");
 			ExecuteWithMagicWordAndAssert (platform, runtimeIdentifiers, appExecutable);
 
 			// a simple rebuild should succeed
 			rv = DotNet.AssertBuild (project_path, properties);
+			allTargets = BinLog.GetAllTargets (rv.BinLogPath);
 			warnings = BinLog.GetBuildLogWarnings (rv.BinLogPath).ToArray ();
 			warningMessages = BundleStructureTest.FilterWarnings (warnings, canonicalizePaths: true);
 
 			BundleStructureTest.CheckZippedAppBundleContents (platform, zippedAppBundlePath, rids, signature, isReleaseBuild);
 			AssertWarningsEqual (expectedWarnings, warningMessages, "Warnings Rebuild 3");
+			AssertTargetNotExecuted (allTargets, "_CompileAppManifest", "_CompileAppManifest Rebuild 3");
 			ExecuteWithMagicWordAndAssert (platform, runtimeIdentifiers, appExecutable);
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/macios/issues/19607

The `_CompileAppManifest` MSBuild target currently runs on every build because it has no `Inputs` defined.

In cases where the inputs are not discretely known, we can use a pattern we've used in dotnet/android:

https://github.com/dotnet/android/blob/b61cac33ea1a1a8c4751b8f9f1eade8cf27313c6/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets#L960-L990

* Write a file with `<WriteLinesToFile WriteOnlyWhenDifferent="true">` to the `obj` directory with all the parameters to the `<CompileAppManifest/>` MSBuild task.

* Use this file as the `Inputs` for the `_CompileAppManifest` target.

* If any of the parameters change, the file will be different and `_CompileAppManifest` will run again.

I updated `tests/dotnet/UnitTests/WindowsTest.cs` to verify this target is skipped appropriately.