### PR TITLE
[RGen] Create syntax for the GetDelegateForFunctionPointer static call.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
@@ -225,7 +225,7 @@ static partial class BindingSyntaxFactory {
 		=> IdentifierName (@class);
 
 	/// <summary>
-	/// Create the needed expression to call the AsRef method from the Unsafe class.
+	/// Create the necessary expression to call the AsRef method from the Unsafe class.
 	/// </summary>
 	/// <param name="objectType">The target type for get the ref from.</param>
 	/// <param name="arguments">The arguments to pass to the AsRef method.</param>
@@ -239,5 +239,24 @@ static partial class BindingSyntaxFactory {
 		var argsList = ArgumentList (SeparatedList<ArgumentSyntax> (arguments.ToSyntaxNodeOrTokenArray ()));
 		return StaticInvocationGenericExpression (unsafeType, "AsRef",
 			objectType, argsList);
+	}
+
+	/// <summary>
+	/// Create the necessary expression to call the GetDelegateForFunctionPointer method from the Marshal class.
+	/// </summary>
+	/// <param name="delegateType">The type of the delegate function pointer to cast to.</param>
+	/// <param name="arguments">Arguments for the GetDelegateForFunctionPointer call.</param>
+	/// <returns>The needed expression to call the GetDelegateForFunctionPointer method.</returns>
+	internal static ExpressionSyntax GetDelegateForFunctionPointer (string delegateType,
+		ImmutableArray<ArgumentSyntax> arguments)
+	{
+		var marshalType = GetIdentifierName (
+			@namespace: ["System", "Runtime", "InteropServices"],
+			@class: "Marshal",
+			isGlobal: true);
+		// Marshal.GetDelegateForFunctionPointer<T>(IntPtr)
+		var argsList = ArgumentList (SeparatedList<ArgumentSyntax> (arguments.ToSyntaxNodeOrTokenArray ()));
+		return StaticInvocationGenericExpression (marshalType, "GetDelegateForFunctionPointer",
+			delegateType, argsList);
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -931,7 +931,7 @@ public class BindingSyntaxFactoryRuntimeTests {
 		var declaration = AsRef (objectType, arguments);
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
 	}
-	
+
 	class TestDataGetDelegateForFunctionPointer : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -955,7 +955,7 @@ public class BindingSyntaxFactoryRuntimeTests {
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
-	
+
 	[Theory]
 	[ClassData (typeof (TestDataGetDelegateForFunctionPointer))]
 	void GetDelegateForFunctionPointerTests (string objectType, ImmutableArray<ArgumentSyntax> arguments, string expectedDeclaration)

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -931,5 +931,37 @@ public class BindingSyntaxFactoryRuntimeTests {
 		var declaration = AsRef (objectType, arguments);
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
 	}
+	
+	class TestDataGetDelegateForFunctionPointer : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			yield return [
+				"MyDelegateType",
+				ImmutableArray.Create (
+					Argument (IdentifierName ("arg1"))
+				),
+				"global::System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<MyDelegateType> (arg1)"
+			];
+
+			yield return [
+				"Action<string>",
+				ImmutableArray.Create (
+					Argument (IdentifierName ("arg1")),
+					Argument (IdentifierName ("arg2")),
+					Argument (IdentifierName ("arg3"))),
+				"global::System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<Action<string>> (arg1, arg2, arg3)"
+			];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	
+	[Theory]
+	[ClassData (typeof (TestDataGetDelegateForFunctionPointer))]
+	void GetDelegateForFunctionPointerTests (string objectType, ImmutableArray<ArgumentSyntax> arguments, string expectedDeclaration)
+	{
+		var declaration = GetDelegateForFunctionPointer (objectType, arguments);
+		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
+	}
 
 }


### PR DESCRIPTION
This is later needed for the trampoline.g.cs code.