### PR TITLE
[RGen] Add factory that will generate the correct Create call on a tr…

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -54,5 +55,18 @@ static partial class BindingSyntaxFactory {
 
 		};
 #pragma warning restore format
+	}
+
+	/// <summary>
+	/// Returns the expression for the creation of the NativeInvocationClass for a given trampoline.
+	/// </summary>
+	/// <param name="trampolineName">The name of the trampoline whose class we want to create.</param>
+	/// <param name="arguments">The arguments for pass to the create method.</param>
+	/// <returns>The expression needed to create the native invocation class.</returns>
+	internal static ExpressionSyntax CreateTrampolineNativeInvocationClass (string trampolineName, ImmutableArray<ArgumentSyntax> arguments)
+	{
+		var className = Nomenclator.GetTrampolineClassName (trampolineName, Nomenclator.TrampolineClassType.NativeInvocationClass);
+		var staticClassName = IdentifierName (className);
+		return StaticInvocationExpression (staticClassName, "Create", arguments, suppressNullableWarning: true);
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.DataModel;
@@ -10,6 +11,7 @@ using Xamarin.Tests;
 using Xamarin.Utils;
 using Xunit;
 using static Microsoft.Macios.Generator.Emitters.BindingSyntaxFactory;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Microsoft.Macios.Generator.Tests.Emitters;
 
@@ -251,4 +253,43 @@ namespace NS {
 		var expression = GetTrampolineInvokeReturnType (parameter.Type, auxVariableName);
 		Assert.Equal (expectedExpression, expression?.ToString ());
 	}
+	
+	class TestDataCreateNativeClass : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			yield return [
+				"GetGeolocationCallback", 
+				ImmutableArray.Create (
+					Argument (IdentifierName ("arg0"))
+				), 
+				"NIDGetGeolocationCallback.Create (arg0)!"
+			];
+			
+			yield return [
+				"AVAssetImageGenerateAsynchronouslyForTimeCompletionHandler", 
+				ImmutableArray.Create (
+					Argument (IdentifierName ("arg0")),
+					Argument (IdentifierName ("arg1"))
+				), 
+				"NIDAVAssetImageGenerateAsynchronouslyForTimeCompletionHandler.Create (arg0, arg1)!"
+			];
+			
+			yield return [
+				"AVAssetImageGeneratorCompletionHandler", 
+				ImmutableArray.Create<ArgumentSyntax> (), 
+				"NIDAVAssetImageGeneratorCompletionHandler.Create ()!"
+			];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[ClassData (typeof (TestDataCreateNativeClass))]
+	public void CreateTrampolineNativeInvocationClassTest (string trampolineName, ImmutableArray<ArgumentSyntax> arguments, string expectedExpression)
+	{
+		var expression = CreateTrampolineNativeInvocationClass (trampolineName, arguments);
+		Assert.Equal (expectedExpression, expression.ToString ());
+	}
+	
 }


### PR DESCRIPTION
…ampoline class.

There are 3 different types that are declared for a trampoline:

1. The delegate type.
2. The static bridge class.
3. The nativce invocation delegate class.

When passing a delegate as a parameter for a delegate we need to pass the native inbocation delegate class. This new factory method generates the needed Create call expression syntax to use in the trampoline generation.