### PR TITLE
[devops] Treat lego/ branches as dev (PR) branches.

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -76,6 +76,7 @@ trigger:
       - refs/heads/dev/*
       - refs/heads/darc-*
       - refs/heads/backport-pr-*
+      - refs/heads/lego/*
   paths:
     exclude:
       - .github

--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -61,6 +61,7 @@ trigger:
     - refs/heads/dev/*
     - refs/heads/darc-*
     - refs/heads/backport-pr-*
+    - refs/heads/lego/*
 
 pr:
   autoCancel: true


### PR DESCRIPTION
This way CI for localization PRs is automatically started correctly.