### PR TITLE
[workload] Add Microsoft.$(platform).Runtimes frameworks

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -444,6 +444,7 @@ DOTNET_NATIVEAOT_PLATFORMS+=iOS
 XCFRAMEWORK_PLATFORMS+=iossimulator
 XCFRAMEWORK_iOS_PLATFORMS+=iossimulator
 XCFRAMEWORK_iossimulator_RUNTIME_IDENTIFIERS=iossimulator-x64 iossimulator-arm64
+DOTNET_IOS_RUNTIME_IDENTIFIERS_NO_ARCH=ios
 
 # 64-bit architectures
 DOTNET_IOS_RUNTIME_IDENTIFIERS_64=ios-arm64
@@ -465,6 +466,7 @@ XCFRAMEWORK_PLATFORMS+=tvossimulator
 XCFRAMEWORK_tvOS_PLATFORMS+=tvossimulator
 XCFRAMEWORK_tvossimulator_RUNTIME_IDENTIFIERS=tvossimulator-x64 tvossimulator-arm64
 
+DOTNET_TVOS_RUNTIME_IDENTIFIERS_NO_ARCH=tvos
 DOTNET_TVOS_RUNTIME_IDENTIFIERS=tvos-arm64 tvossimulator-x64 tvossimulator-arm64
 XCFRAMEWORK_PLATFORMS+=tvos
 XCFRAMEWORK_tvOS_PLATFORMS+=tvos
@@ -477,6 +479,7 @@ DOTNET_PLATFORMS+=MacCatalyst
 DOTNET_MONOVM_PLATFORMS+=MacCatalyst
 DOTNET_MACCATALYST_BITNESSES+=64
 DOTNET_NATIVEAOT_PLATFORMS+=MacCatalyst
+DOTNET_MACCATALYST_RUNTIME_IDENTIFIERS_NO_ARCH=maccatalyst
 DOTNET_MACCATALYST_RUNTIME_IDENTIFIERS=maccatalyst-x64 maccatalyst-arm64
 DOTNET_MACCATALYST_RUNTIME_IDENTIFIERS_64+=$(DOTNET_MACCATALYST_RUNTIME_IDENTIFIERS)
 XCFRAMEWORK_PLATFORMS+=maccatalyst
@@ -490,6 +493,7 @@ DOTNET_PLATFORMS+=macOS
 DOTNET_CORECLR_PLATFORMS+=macOS
 DOTNET_MACOS_BITNESSES+=64
 DOTNET_NATIVEAOT_PLATFORMS+=macOS
+DOTNET_MACOS_RUNTIME_IDENTIFIERS_NO_ARCH=osx
 DOTNET_MACOS_RUNTIME_IDENTIFIERS=osx-x64 osx-arm64
 DOTNET_MACOS_RUNTIME_IDENTIFIERS_64=$(DOTNET_MACOS_RUNTIME_IDENTIFIERS)
 XCFRAMEWORK_PLATFORMS+=macos
@@ -503,6 +507,7 @@ DOTNET_WINDOWS_PLATFORMS = iOS
 endif
 
 # Create variables prefixed with the correctly cased platform name from the upper-cased platform name. This simplifies code in a few areas (whenever we foreach over DOTNET_PLATFORMS).
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval DOTNET_$(platform)_RUNTIME_IDENTIFIERS_NO_ARCH:=$(DOTNET_$(shell echo $(platform) | tr a-z A-Z)_RUNTIME_IDENTIFIERS_NO_ARCH)))
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval DOTNET_$(platform)_RUNTIME_IDENTIFIERS:=$(DOTNET_$(shell echo $(platform) | tr a-z A-Z)_RUNTIME_IDENTIFIERS)))
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(platform)_NUGET_OS_VERSION:=$($(shell echo $(platform) | tr a-z A-Z)_NUGET_OS_VERSION)))
 
@@ -590,12 +595,14 @@ SWIFTC_osx-arm64_VERSION_MIN=-target arm64-apple-macos$(DOTNET_MIN_MACOS_SDK_VER
 # Misc other computed variables
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(shell echo $(platform) | tr a-z A-Z)_NUGET_SDK_NAME=Microsoft.$(platform).Sdk.$(DOTNET_TFM)_$($(platform)_NUGET_OS_VERSION)))
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(shell echo $(platform) | tr a-z A-Z)_NUGET_REF_NAME=Microsoft.$(platform).Ref.$(DOTNET_TFM)_$($(platform)_NUGET_OS_VERSION)))
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(shell echo $(platform) | tr a-z A-Z)_NUGET_RUNTIME_MANAGED_NAME=Microsoft.$(platform).Runtime.$(DOTNET_$(shell echo $(platform) | tr a-z A-Z)_RUNTIME_IDENTIFIERS_NO_ARCH).$(DOTNET_TFM)_$($(platform)_NUGET_OS_VERSION)))
 $(foreach platform,$(DOTNET_PLATFORMS),$(foreach rid,$(DOTNET_$(shell echo $(platform) | tr a-z A-Z)_RUNTIME_IDENTIFIERS),$(eval $(rid)_NUGET_RUNTIME_NAME=Microsoft.$(platform).Runtime.$(rid).$(DOTNET_TFM)_$($(platform)_NUGET_OS_VERSION))))
 $(foreach platform,$(DOTNET_WINDOWS_PLATFORMS),$(eval $(shell echo $(platform) | tr a-z A-Z)_NUGET_WINDOWS_SDK_NAME=Microsoft.$(platform).Windows.Sdk.$(DOTNET_TFM)_$($(platform)_NUGET_OS_VERSION)))
 
 # Create variables prefixed with the correctly cased platform name from the upper-cased platform name. This simplifies code in a few areas (whenever we foreach over DOTNET_PLATFORMS).
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(platform)_NUGET_SDK_NAME:=$($(shell echo $(platform) | tr a-z A-Z)_NUGET_SDK_NAME)))
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(platform)_NUGET_REF_NAME:=$($(shell echo $(platform) | tr a-z A-Z)_NUGET_REF_NAME)))
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(platform)_NUGET_RUNTIME_MANAGED_NAME:=$($(shell echo $(platform) | tr a-z A-Z)_NUGET_RUNTIME_MANAGED_NAME)))
 $(foreach platform,$(DOTNET_WINDOWS_PLATFORMS),$(eval $(platform)_NUGET_WINDOWS_SDK_NAME:=$($(shell echo $(platform) | tr a-z A-Z)_NUGET_WINDOWS_SDK_NAME)))
 
 # A local feed to place test nugets.

--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -75,6 +75,7 @@ DIRECTORIES += \
 	$(DOTNET_TEMPLATE_PACKS_PATH) \
 	$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_PACKS_PATH)/$($(platform)_NUGET_SDK_NAME)) \
 	$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_PACKS_PATH)/$($(platform)_NUGET_REF_NAME)) \
+	$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_PACKS_PATH)/$($(platform)_NUGET_RUNTIME_MANAGED_NAME)) \
 	$(foreach platform,$(DOTNET_PLATFORMS),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),$(DOTNET_PACKS_PATH)/$($(rid)_NUGET_RUNTIME_NAME))) \
 	$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_TEMPLATE_PACKS_PATH)/Microsoft.$(platform).Templates) \
 	$(TMP_PKG_DIR) \
@@ -129,13 +130,14 @@ targets/Microsoft.$(1).Sdk.Versions.props: targets/Microsoft.Sdk.Versions.templa
 		-e 's/@XCODE_IS_PREVIEW@/$(XCODE_IS_PREVIEW)/g' \
 		-e 's/@DOTNET_TFM@/$(DOTNET_TFM)/g' \
 		-e 's/@NUGET_OS_VERSION@/$$($(2)_NUGET_OS_VERSION)/g' \
+		-e "s/@PLATFORM_LOWER@/$(5)/g" \
 		$$< > $$@.tmp
 	$$(Q) mv $$@.tmp $$@
 
 Microsoft.$1.Sdk/targets/Microsoft.$1.Sdk.Versions.props: targets/Microsoft.$1.Sdk.Versions.props
 	$$(Q) $$(CP) $$< $$@
 endef
-$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call VersionsTemplate,$(platform),$(shell echo $(platform) | tr a-z A-Z),$(DOTNET_$(shell echo $(platform) | tr a-z A-Z)_RUNTIME_IDENTIFIERS),$(shell echo $(DOTNET_$(shell echo $(platform) | tr a-z A-Z)_RUNTIME_IDENTIFIERS) | tr ' ' ';'))))
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call VersionsTemplate,$(platform),$(shell echo $(platform) | tr a-z A-Z),$(DOTNET_$(shell echo $(platform) | tr a-z A-Z)_RUNTIME_IDENTIFIERS),$(shell echo $(DOTNET_$(shell echo $(platform) | tr a-z A-Z)_RUNTIME_IDENTIFIERS) | tr ' ' ';'),$(DOTNET_$(shell echo $(platform) | tr a-z A-Z)_RUNTIME_IDENTIFIERS_NO_ARCH))))
 
 version-props: $(foreach platform,$(DOTNET_PLATFORMS),targets/Microsoft.$(platform).Sdk.Versions.props)
 
@@ -187,7 +189,7 @@ include $(TOP)/scripts/generate-workloaddependencies-json/fragment.mk
 define WorkloadTargets
 Workloads/Microsoft.NET.Sdk.$(1)/WorkloadManifest.json: Makefile $(TOP)/Make.config.inc $(GIT_DIRECTORY)/HEAD $(GIT_DIRECTORY)/index Makefile $(GENERATE_WORKLOADMANIFEST_JSON) | Workloads/Microsoft.NET.Sdk.$(1)
 	$$(Q) rm -f $$@.tmp
-	$$(Q_GEN) $(GENERATE_WORKLOADMANIFEST_JSON_EXEC) "$(1)" "$(3)" "$(5)" "$$(DOTNET_$(4)_RUNTIME_IDENTIFIERS)" "$$@.tmp" "$$(DOTNET_WINDOWS_PLATFORMS)" "$(DOTNET_TFM)_$$($(4)_NUGET_OS_VERSION)" "$(SUPPORTED_API_VERSIONS_$(4))" $(TOP)/eng/Versions.props
+	$$(Q_GEN) $(GENERATE_WORKLOADMANIFEST_JSON_EXEC) "$(1)" "$(3)" "$(5)" "$$(DOTNET_$(4)_RUNTIME_IDENTIFIERS)" "$$@.tmp" "$$(DOTNET_WINDOWS_PLATFORMS)" "$(DOTNET_TFM)_$$($(4)_NUGET_OS_VERSION)" "$(SUPPORTED_API_VERSIONS_$(4))" $(TOP)/eng/Versions.props "$$(DOTNET_$(4)_RUNTIME_IDENTIFIERS_NO_ARCH)"
 	$$(Q) mv $$@.tmp $$@
 
 Workloads/Microsoft.NET.Sdk.$(1)/WorkloadManifest.targets: Makefile $(TOP)/Make.config.inc $(GIT_DIRECTORY)/HEAD $(GIT_DIRECTORY)/index Makefile $(GENERATE_WORKLOADMANIFEST_TARGETS) | Workloads/Microsoft.NET.Sdk.$(1)
@@ -272,6 +274,7 @@ $(foreach platform,$(DOTNET_WINDOWS_PLATFORMS),$(eval $(call CreateWindowsNuGetT
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call CreateNuGetTemplate,Microsoft.$(platform).Ref,$($(platform)_NUGET_VERSION_NO_METADATA),,,$(DOTNET_VERSION_BAND),$(platform))))
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call CreateNuGetTemplateNoTargetFramework,Microsoft.$(platform).Templates,$($(platform)_NUGET_VERSION_NO_METADATA),,,$(DOTNET_VERSION_BAND),$(platform))))
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call CreateNuGetTemplateNoTargetFramework,Microsoft.NET.Sdk.$(platform),$($(platform)_NUGET_VERSION_NO_METADATA),,.Manifest-$(MACIOS_MANIFEST_VERSION_BAND),$(MACIOS_MANIFEST_VERSION_BAND),$(platform))))
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call CreateNuGetTemplate,Microsoft.$(platform).Runtime.$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS_NO_ARCH),$($(platform)_NUGET_VERSION_NO_METADATA),,,$(DOTNET_VERSION_BAND),$(platform))))
 $(foreach platform,$(DOTNET_PLATFORMS),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),$(eval $(call CreateNuGetTemplate,Microsoft.$(platform).Runtime.$(rid),$($(platform)_NUGET_VERSION_NO_METADATA),,,$(DOTNET_VERSION_BAND),$(platform)))))
 
 # Copy the nuget from the temporary directory into the final directory
@@ -286,8 +289,9 @@ endif
 pack-ios-windows: $(SDK_PACKS_IOS_WINDOWS)
 
 define PacksDefinitions
+RUNTIME_MANAGED_PACKS_$(1) = $(DOTNET_NUPKG_DIR)/$($(1)_NUGET_RUNTIME_MANAGED_NAME).$($(1)_NUGET_VERSION_NO_METADATA).nupkg
 RUNTIME_PACKS_$(1) = $$(foreach rid,$$(DOTNET_$(1)_RUNTIME_IDENTIFIERS),$(DOTNET_NUPKG_DIR)/$$($$(rid)_NUGET_RUNTIME_NAME).$($(1)_NUGET_VERSION_NO_METADATA).nupkg)
-RUNTIME_PACKS += $$(RUNTIME_PACKS_$(1))
+RUNTIME_PACKS += $$(RUNTIME_MANAGED_PACKS_$(1)) $$(RUNTIME_PACKS_$(1))
 REF_PACKS_$(1) = $(DOTNET_NUPKG_DIR)/$($(1)_NUGET_REF_NAME).$($(1)_NUGET_VERSION_NO_METADATA).nupkg
 REF_PACKS += $$(REF_PACKS_$(1))
 SDK_PACKS_$(1) = $(DOTNET_NUPKG_DIR)/$($(1)_NUGET_SDK_NAME).$($(1)_NUGET_VERSION_NO_METADATA).nupkg
@@ -329,6 +333,15 @@ WORKLOAD_TARGETS += \
 	$(DOTNET_PACKS_PATH)/$($(1)_NUGET_REF_NAME)/$2
 endef
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call InstallWorkload,$(platform),$($(platform)_NUGET_VERSION_NO_METADATA),$(shell echo $(platform) | tr A-Z a-z))))
+
+define InstallRuntimeManagedWorkload
+$(DOTNET_PACKS_PATH)/$$($(1)_NUGET_RUNTIME_MANAGED_NAME)/$2: | $(DOTNET_PACKS_PATH)/$$($(1)_NUGET_RUNTIME_MANAGED_NAME)
+	$$(Q_LN) ln -Fhs $$(abspath $(DOTNET_DESTDIR)/$$($(1)_NUGET_RUNTIME_MANAGED_NAME)) $$(abspath $$@)
+
+WORKLOAD_TARGETS += \
+	$(DOTNET_PACKS_PATH)/$$($(1)_NUGET_RUNTIME_MANAGED_NAME)/$2
+endef
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call InstallRuntimeManagedWorkload,$(platform),$($(platform)_NUGET_VERSION_NO_METADATA))))
 
 define InstallRuntimeWorkload
 $(DOTNET_PACKS_PATH)/$$($(2)_NUGET_RUNTIME_NAME)/$3: | $(DOTNET_PACKS_PATH)/$$($(2)_NUGET_RUNTIME_NAME)

--- a/dotnet/package/Microsoft.MacCatalyst.Runtime.maccatalyst/package.csproj
+++ b/dotnet/package/Microsoft.MacCatalyst.Runtime.maccatalyst/package.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.DotNet.SharedFramework.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" />
+
+  <PropertyGroup>
+    <_PlatformName>MacCatalyst</_PlatformName>
+    <_RuntimeIdentifier>maccatalyst</_RuntimeIdentifier>
+  </PropertyGroup>
+
+  <Import Project="../microsoft.runtime.managed.csproj" />
+</Project>

--- a/dotnet/package/Microsoft.iOS.Runtime.ios/package.csproj
+++ b/dotnet/package/Microsoft.iOS.Runtime.ios/package.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.DotNet.SharedFramework.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" />
+
+  <PropertyGroup>
+    <_PlatformName>iOS</_PlatformName>
+    <_RuntimeIdentifier>ios</_RuntimeIdentifier>
+  </PropertyGroup>
+
+  <Import Project="../microsoft.runtime.managed.csproj" />
+</Project>

--- a/dotnet/package/Microsoft.macOS.Runtime.osx/package.csproj
+++ b/dotnet/package/Microsoft.macOS.Runtime.osx/package.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.DotNet.SharedFramework.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" />
+
+  <PropertyGroup>
+    <_PlatformName>macOS</_PlatformName>
+    <_RuntimeIdentifier>osx</_RuntimeIdentifier>
+  </PropertyGroup>
+
+  <Import Project="../microsoft.runtime.managed.csproj" />
+</Project>

--- a/dotnet/package/Microsoft.tvOS.Runtime.tvos/package.csproj
+++ b/dotnet/package/Microsoft.tvOS.Runtime.tvos/package.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.DotNet.SharedFramework.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" />
+
+  <PropertyGroup>
+    <_PlatformName>tvOS</_PlatformName>
+    <_RuntimeIdentifier>tvos</_RuntimeIdentifier>
+  </PropertyGroup>
+
+  <Import Project="../microsoft.runtime.managed.csproj" />
+</Project>

--- a/dotnet/package/common.csproj
+++ b/dotnet/package/common.csproj
@@ -66,6 +66,7 @@
       BeforeTargets="ProcessFrameworkReferences" >
     <ItemGroup>
       <KnownFrameworkReference Remove="Microsoft.$(_PlatformName)" />
+      <KnownFrameworkReference Remove="Microsoft.$(_PlatformName).Runtimes" />
     </ItemGroup>
   </Target>
 

--- a/dotnet/package/microsoft.runtime.managed.csproj
+++ b/dotnet/package/microsoft.runtime.managed.csproj
@@ -1,0 +1,10 @@
+<Project>
+  <PropertyGroup>
+    <PackageId>Microsoft.$(_PlatformName).Runtime.$(_RuntimeIdentifier).$(PackageOSTargetVersion)</PackageId>
+    <Description>Microsoft $(_PlatformName) managed runtime pack for $(_RuntimeIdentifier). Please do not reference directly.</Description>
+    <RuntimeIdentifier>$(_RuntimeIdentifier)</RuntimeIdentifier>
+    <OverridePackageId>$(PackageId)</OverridePackageId>
+    <PlatformPackageType>RuntimePack</PlatformPackageType>
+  </PropertyGroup>
+  <Import Project="common.csproj" />
+</Project>

--- a/dotnet/targets/Microsoft.Sdk.Versions.template.props
+++ b/dotnet/targets/Microsoft.Sdk.Versions.template.props
@@ -26,6 +26,18 @@
 			LatestRuntimeFrameworkVersion="@NUGET_VERSION_NO_METADATA@"
 			TargetingPackName="Microsoft.@PLATFORM@.Ref.@DOTNET_TFM@_@NUGET_OS_VERSION@"
 			TargetingPackVersion="@NUGET_VERSION_NO_METADATA@"
+			RuntimePackNamePatterns="Microsoft.@PLATFORM@.Runtime.@PLATFORM_LOWER@.@DOTNET_TFM@_@NUGET_OS_VERSION@"
+			RuntimePackRuntimeIdentifiers="@RUNTIME_PACK_RUNTIME_IDENTIFIERS@"
+			Profile="@PLATFORM@"
+		/>
+		<KnownFrameworkReference
+			Include="Microsoft.@PLATFORM@.Runtimes"
+			TargetFramework="@DOTNET_TFM@"
+			RuntimeFrameworkName="Microsoft.@PLATFORM@.Runtimes"
+			DefaultRuntimeFrameworkVersion="@NUGET_VERSION_NO_METADATA@"
+			LatestRuntimeFrameworkVersion="@NUGET_VERSION_NO_METADATA@"
+			TargetingPackName="Microsoft.@PLATFORM@.Ref.@DOTNET_TFM@_@NUGET_OS_VERSION@"
+			TargetingPackVersion="@NUGET_VERSION_NO_METADATA@"
 			RuntimePackNamePatterns="Microsoft.@PLATFORM@.Runtime.**RID**.@DOTNET_TFM@_@NUGET_OS_VERSION@"
 			RuntimePackRuntimeIdentifiers="@RUNTIME_PACK_RUNTIME_IDENTIFIERS@"
 			Profile="@PLATFORM@"

--- a/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
@@ -76,6 +76,7 @@
 
 	<ItemGroup Condition="'$(DisableImplicitFrameworkReferences)' != 'true'">
 		<FrameworkReference Include="Microsoft.$(_PlatformName)" IsImplicitlyDefined="true" Pack="false" PrivateAssets="All" />
+		<FrameworkReference Include="Microsoft.$(_PlatformName).Runtimes" IsImplicitlyDefined="true" Pack="false" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/scripts/generate-workloadmanifest-json/generate-workloadmanifest-json.cs
+++ b/scripts/generate-workloadmanifest-json/generate-workloadmanifest-json.cs
@@ -3,7 +3,7 @@
 using System.IO;
 using System.Xml;
 
-var expectedArgumentCount = 9;
+var expectedArgumentCount = 10;
 if (args.Length != expectedArgumentCount) {
 	Console.WriteLine ($"Need {expectedArgumentCount} arguments, got {args.Length}");
 	return 1;
@@ -20,6 +20,7 @@ var hasWindows = Array.IndexOf (windowsPlatforms, platform) >= 0;
 var currentApiVersion = args [argumentIndex++];
 var supportedApiVersions = args [argumentIndex++].Split (new char [] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
 var versionsPropsPath = args [argumentIndex++];
+var ridNoArch = args [argumentIndex++];
 
 var platformLowerCase = platform.ToLowerInvariant ();
 
@@ -66,6 +67,7 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 		}
 	}
 	writer.WriteLine ($"				\"Microsoft.{platform}.Ref.{currentApiVersion}\",");
+	writer.WriteLine ($"				\"Microsoft.{platform}.Runtime.{ridNoArch}.{currentApiVersion}\",");
 	foreach (var rid in runtimeIdentifiers) {
 		writer.WriteLine ($"				\"Microsoft.{platform}.Runtime.{rid}.{currentApiVersion}\",");
 	}
@@ -128,6 +130,10 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 		}
 	}
 	writer.WriteLine ($"		\"Microsoft.{platform}.Ref.{currentApiVersion}\": {{");
+	writer.WriteLine ($"			\"kind\": \"framework\",");
+	writer.WriteLine ($"			\"version\": \"{version}\"");
+	writer.WriteLine ($"		}},");
+	writer.WriteLine ($"		\"Microsoft.{platform}.Runtime.{ridNoArch}.{currentApiVersion}\": {{");
 	writer.WriteLine ($"			\"kind\": \"framework\",");
 	writer.WriteLine ($"			\"version\": \"{version}\"");
 	writer.WriteLine ($"		}},");

--- a/src/Makefile
+++ b/src/Makefile
@@ -578,17 +578,17 @@ dotnet-$(3):: $($(2)_DOTNET_BUILD_DIR)/$(4)/Microsoft.$(1).dll
 
 DOTNET_TARGETS_$(3) += \
 	$($(2)_DOTNET_BUILD_DIR)/$(4)/Microsoft.$(1).dll \
-	$(foreach rid,$(DOTNET_$(2)_RUNTIME_IDENTIFIERS_$(4)),$(DOTNET_DESTDIR)/$($(rid)_NUGET_RUNTIME_NAME)/runtimes/$(rid)/lib/$(DOTNET_TFM)/Microsoft.$(1).dll) \
-	$(foreach rid,$(DOTNET_$(2)_RUNTIME_IDENTIFIERS_$(4)),$(DOTNET_DESTDIR)/$($(rid)_NUGET_RUNTIME_NAME)/runtimes/$(rid)/lib/$(DOTNET_TFM)/Microsoft.$(1).pdb) \
+	$(DOTNET_DESTDIR)/$($(2)_NUGET_RUNTIME_MANAGED_NAME)/runtimes/$(DOTNET_$(2)_RUNTIME_IDENTIFIERS_NO_ARCH)/lib/$(DOTNET_TFM)/Microsoft.$(1).dll \
+	$(DOTNET_DESTDIR)/$($(2)_NUGET_RUNTIME_MANAGED_NAME)/runtimes/$(DOTNET_$(2)_RUNTIME_IDENTIFIERS_NO_ARCH)/lib/$(DOTNET_TFM)/Microsoft.$(1).pdb \
 
 DOTNET_TARGETS_DIRS_$(3) += \
 	$($(2)_DOTNET_BUILD_DIR)/$(4) \
-	$(foreach rid,$(DOTNET_$(2)_RUNTIME_IDENTIFIERS_$(4)),$(DOTNET_DESTDIR)/$($(rid)_NUGET_RUNTIME_NAME)/runtimes/$(rid)/lib/$(DOTNET_TFM)) \
+	$(DOTNET_DESTDIR)/$($(2)_NUGET_RUNTIME_MANAGED_NAME)/runtimes/$(DOTNET_$(2)_RUNTIME_IDENTIFIERS_NO_ARCH)/lib/$(DOTNET_TFM) \
 
-$(foreach rid,$(DOTNET_$(2)_RUNTIME_IDENTIFIERS_$(4)),$(DOTNET_DESTDIR)/$($(rid)_NUGET_RUNTIME_NAME)/runtimes/$(rid)/lib/$(DOTNET_TFM)/Microsoft.$(1).dll): $($(2)_DOTNET_BUILD_DIR)/$(4)/Microsoft.$(1).dll | $(foreach rid,$(DOTNET_$(2)_RUNTIME_IDENTIFIERS_$(4)),$(DOTNET_DESTDIR)/$($(rid)_NUGET_RUNTIME_NAME)/runtimes/$(rid)/lib/$(DOTNET_TFM))
+$(DOTNET_DESTDIR)/$($(2)_NUGET_RUNTIME_MANAGED_NAME)/runtimes/$(DOTNET_$(2)_RUNTIME_IDENTIFIERS_NO_ARCH)/lib/$(DOTNET_TFM)/Microsoft.$(1).dll: $($(2)_DOTNET_BUILD_DIR)/$(4)/Microsoft.$(1).dll | $(DOTNET_DESTDIR)/$($(2)_NUGET_RUNTIME_MANAGED_NAME)/runtimes/$(DOTNET_$(2)_RUNTIME_IDENTIFIERS_NO_ARCH)/lib/$(DOTNET_TFM)
 	$(Q) $(CP) $$< $$@
 
-$(foreach rid,$(DOTNET_$(2)_RUNTIME_IDENTIFIERS_$(4)),$(DOTNET_DESTDIR)/$($(rid)_NUGET_RUNTIME_NAME)/runtimes/$(rid)/lib/$(DOTNET_TFM)/Microsoft.$(1).pdb): $($(2)_DOTNET_BUILD_DIR)/$(4)/Microsoft.$(1).pdb | $(foreach rid,$(DOTNET_$(2)_RUNTIME_IDENTIFIERS_$(4)),$(DOTNET_DESTDIR)/$($(rid)_NUGET_RUNTIME_NAME)/runtimes/$(rid)/lib/$(DOTNET_TFM))
+$(DOTNET_DESTDIR)/$($(2)_NUGET_RUNTIME_MANAGED_NAME)/runtimes/$(DOTNET_$(2)_RUNTIME_IDENTIFIERS_NO_ARCH)/lib/$(DOTNET_TFM)/Microsoft.$(1).pdb: $($(2)_DOTNET_BUILD_DIR)/$(4)/Microsoft.$(1).pdb | $(DOTNET_DESTDIR)/$($(2)_NUGET_RUNTIME_MANAGED_NAME)/runtimes/$(DOTNET_$(2)_RUNTIME_IDENTIFIERS_NO_ARCH)/lib/$(DOTNET_TFM)
 	$(Q) $(CP) $$< $$@
 
 DOTNET_TARGETS += $$(DOTNET_TARGETS_$(3))


### PR DESCRIPTION
Context: https://github.com/dotnet/sdk/issues/24077
Context: https://github.com/dotnet/android/commit/893a981c029b89f6b73807618b3edd945f2fcb7d

New "architecture-less" runtime packs have been added to distribute Microsoft.$(platform).dll and any other runtime assets that are not architecture specific:

  * Microsoft.iOS.Runtime.ios.$(version).nupkg
  * Microsoft.MacCatalyst.Runtime.maccatalyst.$(version).nupkg
  * Microsoft.macOS.Runtime.osx.$(version).nupkg
  * Microsoft.tvOS.Runtime.tvos.$(version).nupkg

To support this, new `Microsoft.$(platform).Runtimes` FrameworkReference items have been added to include the architecture specific runtime packs. The existing `Microsoft.$(platform)` FrameworkReference has been updated to bring in the new runtime pack instead.