### PR TITLE
[xtro] Improve make output.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -417,7 +417,7 @@ $$(APIDEFINITION_$(1)_CSPROJ): $($(2)_DOTNET_BUILD_DIR)/apidefinition-$(3).rsp $
 	$$(Q) mv $$@.tmp $$@
 
 apidefinition:: $($(2)_DOTNET_BUILD_DIR)/apidefinition-$(3).dll
-$($(2)_DOTNET_BUILD_DIR)/apidefinition-$(3).dll: $($(2)_DOTNET_BUILD_DIR)/apidefinition-$(3).rsp $($(2)_DOTNET_BUILD_DIR)/core-$(3).dll $(DOTNET_BINDING_ATTRIBUTES)
+$($(2)_DOTNET_BUILD_DIR)/apidefinition-$(3).dll: $($(2)_DOTNET_BUILD_DIR)/apidefinition-$(3).rsp $($(2)_DOTNET_BUILD_DIR)/core-$(3).dll $(DOTNET_BINDING_ATTRIBUTES) $($(2)_APIS)
 	$$(Q_GEN) $(DOTNET_CSC) $(DOTNET_FLAGS) @$$<
 
 apidefinition:: $(3)-apidefinition

--- a/src/Makefile
+++ b/src/Makefile
@@ -417,7 +417,7 @@ $$(APIDEFINITION_$(1)_CSPROJ): $($(2)_DOTNET_BUILD_DIR)/apidefinition-$(3).rsp $
 	$$(Q) mv $$@.tmp $$@
 
 apidefinition:: $($(2)_DOTNET_BUILD_DIR)/apidefinition-$(3).dll
-$($(2)_DOTNET_BUILD_DIR)/apidefinition-$(3).dll: $($(2)_DOTNET_BUILD_DIR)/apidefinition-$(3).rsp $($(2)_DOTNET_BUILD_DIR)/core-$(3).dll $(DOTNET_BINDING_ATTRIBUTES) $($(2)_APIS)
+$($(2)_DOTNET_BUILD_DIR)/apidefinition-$(3).dll: $($(2)_DOTNET_BUILD_DIR)/apidefinition-$(3).rsp $($(2)_DOTNET_BUILD_DIR)/core-$(3).dll $(DOTNET_BINDING_ATTRIBUTES)
 	$$(Q_GEN) $(DOTNET_CSC) $(DOTNET_FLAGS) @$$<
 
 apidefinition:: $(3)-apidefinition

--- a/tests/xtro-sharpie/Makefile
+++ b/tests/xtro-sharpie/Makefile
@@ -143,7 +143,8 @@ X$(2)_DOTNET ?= $(DOTNET_DESTDIR)/$($(X$(2)_RID)_NUGET_RUNTIME_NAME)/runtimes/$(
 endif
 
 $(3)-$($(2)_SDK_VERSION).g.cs: .stamp-check-sharpie $$(X$(2)_PCH)
-	$$(SHARPIE) query -bind $$(XIOS_$(2)) > $$@
+	$$(Q_GEN) $$(SHARPIE) query -bind $$(X$(2)_PCH) > $$@.tmp
+	$$(Q) mv $$@.tmp $$@
 
 gen-$(3): $(3)-$$($(2)_SDK_VERSION).g.cs
 gen-all:: gen-$(3)


### PR DESCRIPTION
Also use a temporary file when generating C# code to not fail to rebuild if
generation failed for whatever reason.