### PR TITLE
[runtime/src] Raise the AppDomain.UnhandledException event on CoreCLR. Fixes #15252.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -1179,8 +1179,7 @@ mono_string_new (MonoDomain *domain, const char *text)
 void
 xamarin_bridge_raise_unhandled_exception_event (GCHandle exception_gchandle)
 {
-	// There's no way to raise the AppDomain.UnhandledException event.
-	// https://github.com/dotnet/runtime/issues/102730
+	xamarin_bridge_raise_appdomain_unhandled_exception_event (exception_gchandle);
 }
 
 #endif // CORECLR_RUNTIME

--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -677,6 +677,14 @@
 		) {
 			WrappedManagedFunction = "LookupUnmanagedFunction",
 		},
+
+		new XDelegate ("void", "void", "xamarin_bridge_raise_appdomain_unhandled_exception_event",
+			"GCHandle", "IntPtr", "gchandle"
+		) {
+			WrappedManagedFunction = "RaiseAppDomainUnhandledExceptionEvent",
+			OnlyDynamicUsage = false,
+			OnlyCoreCLR = true,
+		},
 	};
 	delegates.CalculateLengths ();
 #><#+

--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -203,6 +203,13 @@ namespace ObjCRuntime {
 			return exceptionHandler;
 		}
 
+		static void RaiseAppDomainUnhandledExceptionEvent (IntPtr gchandle)
+		{
+			var exception = GetGCHandleTarget (gchandle);
+			if (exception is not null)
+				ExceptionHandling.RaiseAppDomainUnhandledExceptionEvent (exception);
+		}
+
 		// Size: 2 pointers
 		internal struct TrackedObjectInfo {
 			public IntPtr Handle;

--- a/tests/dotnet/ExceptionalTestApp/AppDelegate.cs
+++ b/tests/dotnet/ExceptionalTestApp/AppDelegate.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 
 using Foundation;
+using ObjCRuntime;
 
 namespace MySimpleApp {
 	public class Program {
@@ -26,6 +27,21 @@ namespace MySimpleApp {
 					Environment.Exit (0);
 				};
 				throw new TestCaseException ();
+			case 2:
+				AppDomain.CurrentDomain.UnhandledException += (object sender, UnhandledExceptionEventArgs e) => {
+					if (e.ExceptionObject is TestCaseException) {
+						Console.WriteLine (Environment.GetEnvironmentVariable ("MAGIC_WORD"));
+					} else {
+						Console.WriteLine ($"Unexpected exception type: {e.ExceptionObject?.GetType ()}");
+					}
+					Environment.Exit (0);
+				};
+
+				var obj = new ThrowExceptionClass ();
+				var thread = new NSThread (obj, new Selector ("throwException:"), null);
+				thread.Start ();
+				System.Threading.Thread.Sleep (10000);
+				break;
 			default:
 				Console.WriteLine ($"Unknown test case: {testCase}");
 				return 3;
@@ -33,6 +49,14 @@ namespace MySimpleApp {
 
 			return 1;
 		}
+	}
+}
+
+class ThrowExceptionClass : NSObject {
+	[Export ("throwException:")]
+	public void ThrowException (NSObject obj)
+	{
+		throw new TestCaseException ();
 	}
 }
 

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -2343,7 +2343,7 @@ namespace Xamarin.Tests {
 		[Test]
 		// [TestCase (ApplePlatform.iOS)] // Skipping because we're not executing tvOS apps anyway (but it should work)
 		// [TestCase (ApplePlatform.TVOS)] // Skipping because we're not executing tvOS apps anyway (but it should work)
-		[TestCase (ApplePlatform.MacOSX)] // https://github.com/dotnet/runtime/issues/102730
+		[TestCase (ApplePlatform.MacOSX)]
 		[TestCase (ApplePlatform.MacCatalyst)]
 		public void RaisesAppDomainUnhandledExceptionEvent (ApplePlatform platform)
 		{


### PR DESCRIPTION
Fixes https://github.com/dotnet/macios/issues/15252.