### PR TITLE
[msbuild] Don't try to log a null exception.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/XamarinTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/XamarinTask.cs
@@ -250,7 +250,8 @@ namespace Xamarin.MacDev.Tasks {
 		void ICustomLogger.LogError (string message, Exception ex)
 		{
 			Log.LogError (message);
-			Log.LogErrorFromException (ex);
+			if (ex is not null)
+				Log.LogErrorFromException (ex);
 		}
 
 		void ICustomLogger.LogWarning (string messageFormat, params object [] args)


### PR DESCRIPTION
It will end up throwing an exception, and it will just make the build log a
whole lot more confusing.