### PR TITLE
[Metal] Fix a few issues in MTLRasterizationRateLayerDescriptor.

### DIFF
--- a/src/Metal/MTLRasterizationRateLayerDescriptor.cs
+++ b/src/Metal/MTLRasterizationRateLayerDescriptor.cs
@@ -1,4 +1,3 @@
-#if IOS
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
@@ -12,34 +11,55 @@ namespace Metal {
 	public partial class MTLRasterizationRateLayerDescriptor {
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("ios13.0")]
-		[UnsupportedOSPlatform ("macos")]
-		[UnsupportedOSPlatform ("tvos")]
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("tvos16.0")]
+#if XAMCORE_5_0
+		public float [] HorizontalSampleStorage {
+#else
 		public double [] HorizontalSampleStorage {
+#endif
 			get {
 				var width = (int) SampleCount.Width;
-				var floatArray = new double [width];
+				var floatArray = new float [width];
 				Marshal.Copy (_HorizontalSampleStorage, floatArray, 0, width);
+#if XAMCORE_5_0
 				return floatArray;
+#else
+				return Array.ConvertAll (floatArray, v => (double) v);
+#endif
 			}
 		}
 
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("ios13.0")]
-		[UnsupportedOSPlatform ("tvos")]
-		[UnsupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("tvos16.0")]
+#if XAMCORE_5_0
+		public float [] VerticalSampleStorage {
+#else
 		public double [] VerticalSampleStorage {
+#endif
 			get {
 				var height = (int) SampleCount.Height;
-				var floatArray = new double [height];
+				var floatArray = new float [height];
 				Marshal.Copy (_VerticalSampleStorage, floatArray, 0, height);
+#if XAMCORE_5_0
 				return floatArray;
+#else
+				return Array.ConvertAll (floatArray, v => (double) v);
+#endif
 			}
 		}
 
+		/// <summary>Create a new <see cref="MTLRasterizationRateLayerDescriptor" /> instance with the specified rasterization rates.</summary>
+		/// <param name="sampleCount">The number of horizontal (<see cref="MTLSize.Width" />) and vertical (<see cref="MTLSize.Height" />) rasterization rates. The depth component (<see cref="MTLSize.Depth" />) is ignored.</param>
+		/// <param name="horizontal">The horizontal rasterization rates for the new <see cref="MTLRasterizationRateLayerDescriptor" /> instance.</param>
+		/// <param name="vertical">The vertical rasterization rates for the new <see cref="MTLRasterizationRateLayerDescriptor" /> instance.</param>
+		/// <returns>A new <see cref="MTLRasterizationRateLayerDescriptor" /> instance with the specified rasterization rates.</returns>
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("ios13.0")]
-		[UnsupportedOSPlatform ("tvos")]
-		[UnsupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("tvos16.0")]
 		static public MTLRasterizationRateLayerDescriptor Create (MTLSize sampleCount, float [] horizontal, float [] vertical)
 		{
 			if (horizontal is null)
@@ -58,6 +78,23 @@ namespace Metal {
 				}
 			}
 		}
+
+		/// <summary>Create a new <see cref="MTLRasterizationRateLayerDescriptor" /> instance with the specified rasterization rates.</summary>
+		/// <param name="horizontal">The horizontal rasterization rates for the new <see cref="MTLRasterizationRateLayerDescriptor" /> instance.</param>
+		/// <param name="vertical">The vertical rasterization rates for the new <see cref="MTLRasterizationRateLayerDescriptor" /> instance.</param>
+		/// <returns>A new <see cref="MTLRasterizationRateLayerDescriptor" /> instance with the specified rasterization rates.</returns>
+		[SupportedOSPlatform ("maccatalyst")]
+		[SupportedOSPlatform ("ios13.0")]
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("tvos16.0")]
+		public static MTLRasterizationRateLayerDescriptor Create (float [] horizontal, float [] vertical)
+		{
+			if (horizontal is null)
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (horizontal));
+			if (vertical is null)
+				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (vertical));
+
+			return Create (new MTLSize (horizontal.Length, vertical.Length, 0), horizontal, vertical);
+		}
 	}
 }
-#endif

--- a/src/metal.cs
+++ b/src/metal.cs
@@ -5668,7 +5668,6 @@ namespace Metal {
 		[Export ("maxSampleCount")]
 		MTLSize MaxSampleCount { get; }
 
-		[iOS (15, 0), MacCatalyst (15, 0)]
 		[Export ("sampleCount", ArgumentSemantic.Assign)]
 		MTLSize SampleCount { get; set; }
 	}

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -12986,7 +12986,6 @@ M:Metal.MTLLibrary_Extensions.CreateFunctionAsync(Metal.IMTLLibrary,System.Strin
 M:Metal.MTLLibrary_Extensions.CreateIntersectionFunction(Metal.IMTLLibrary,Metal.MTLIntersectionFunctionDescriptor,Foundation.NSError@)
 M:Metal.MTLLibrary_Extensions.CreateIntersectionFunction(Metal.IMTLLibrary,Metal.MTLIntersectionFunctionDescriptor,System.Action{Metal.IMTLFunction,Foundation.NSError})
 M:Metal.MTLOrigin.#ctor(System.IntPtr,System.IntPtr,System.IntPtr)
-M:Metal.MTLRasterizationRateLayerDescriptor.Create(Metal.MTLSize,System.Single[],System.Single[])
 M:Metal.MTLRegion.Create1D(System.IntPtr,System.IntPtr)
 M:Metal.MTLRegion.Create1D(System.UIntPtr,System.UIntPtr)
 M:Metal.MTLRegion.Create2D(System.IntPtr,System.IntPtr,System.IntPtr,System.IntPtr)

--- a/tests/monotouch-test/Metal/MTLRasterizationRateLayerDescriptorTest.cs
+++ b/tests/monotouch-test/Metal/MTLRasterizationRateLayerDescriptorTest.cs
@@ -1,4 +1,5 @@
-#if __IOS__ || __MACOS__
+using System;
+
 using Foundation;
 using Metal;
 
@@ -50,6 +51,52 @@ namespace MonoTouchFixtures.Metal {
 			=> Assert.DoesNotThrow (() => {
 				var c = descriptor.SampleCount;
 			});
+
+		[Test]
+		public void Create_1 ()
+		{
+			var horizontal = new float [] { 1, 2, 3 };
+			var vertical = new float [] { 5, 6, 7, 8 };
+			using var obj = MTLRasterizationRateLayerDescriptor.Create (new MTLSize (horizontal.Length, vertical.Length, 42), horizontal, vertical);
+			Assert.AreEqual ((nint) horizontal.Length, obj.SampleCount.Width, "Width");
+			Assert.AreEqual ((nint) vertical.Length, obj.SampleCount.Height, "Height");
+			Assert.AreEqual ((nint) 0, obj.SampleCount.Depth, "Depth");
+			Assert.That (obj.HorizontalSampleStorage, Is.EqualTo (horizontal), "HorizontalSampleStorage");
+			Assert.That (obj.VerticalSampleStorage, Is.EqualTo (vertical), "VerticalSampleStorage");
+
+			Assert.Throws<ArgumentNullException> (() => MTLRasterizationRateLayerDescriptor.Create (new MTLSize (horizontal.Length, vertical.Length, 0), null, vertical), "H-Null");
+			Assert.Throws<ArgumentNullException> (() => MTLRasterizationRateLayerDescriptor.Create (new MTLSize (horizontal.Length, vertical.Length, 0), horizontal, null), "V-Null");
+			Assert.Throws<ArgumentOutOfRangeException> (() => MTLRasterizationRateLayerDescriptor.Create (new MTLSize (horizontal.Length + 1, vertical.Length, 0), horizontal, vertical), "H-AOORE");
+			Assert.Throws<ArgumentOutOfRangeException> (() => MTLRasterizationRateLayerDescriptor.Create (new MTLSize (horizontal.Length, vertical.Length - 1, 0), horizontal, vertical), "V-AOORE");
+		}
+
+		[Test]
+		public void Create_2 ()
+		{
+			var horizontal = new float [] { 1, 2, 3 };
+			var vertical = new float [] { 5, 6, 7, 8 };
+			using var obj = MTLRasterizationRateLayerDescriptor.Create (horizontal, vertical);
+			Assert.AreEqual ((nint) horizontal.Length, obj.SampleCount.Width, "Width");
+			Assert.AreEqual ((nint) vertical.Length, obj.SampleCount.Height, "Height");
+			Assert.AreEqual ((nint) 0, obj.SampleCount.Depth, "Depth");
+			Assert.That (obj.HorizontalSampleStorage, Is.EqualTo (horizontal), "HorizontalSampleStorage");
+			Assert.That (obj.VerticalSampleStorage, Is.EqualTo (vertical), "VerticalSampleStorage");
+
+			Assert.Throws<ArgumentNullException> (() => MTLRasterizationRateLayerDescriptor.Create (null, vertical), "H-Null");
+			Assert.Throws<ArgumentNullException> (() => MTLRasterizationRateLayerDescriptor.Create (horizontal, null), "V-Null");
+		}
+
+		[Test]
+		public void Ctor ()
+		{
+			var horizontal = new float [3];
+			var vertical = new float [4];
+			using var obj = new MTLRasterizationRateLayerDescriptor (new MTLSize (horizontal.Length, vertical.Length, 0));
+			Assert.AreEqual ((nint) horizontal.Length, obj.SampleCount.Width, "Width");
+			Assert.AreEqual ((nint) vertical.Length, obj.SampleCount.Height, "Height");
+			Assert.AreEqual ((nint) 0, obj.SampleCount.Depth, "Depth");
+			Assert.That (obj.HorizontalSampleStorage, Is.EqualTo (horizontal), "HorizontalSampleStorage");
+			Assert.That (obj.VerticalSampleStorage, Is.EqualTo (vertical), "VerticalSampleStorage");
+		}
 	}
 }
-#endif


### PR DESCRIPTION
* Fix availability for the SampleCount property.
* Fix the [Horizontal|Vertical]SampleStorage properties to actually work by marshalling
  a float array instead of double array.
* Add tests.