### PR TITLE
[devops] Reorder windows steps a bit.

### DIFF
--- a/tests/dotnet/Windows/collect-binlogs.sh
+++ b/tests/dotnet/Windows/collect-binlogs.sh
@@ -18,7 +18,9 @@ ps auxww || true
 
 # Collect and zip up all the binlogs
 mkdir -p ~/remote_build_testing/binlogs
-rsync -avv --prune-empty-dirs --exclude 'artifacts/' --include '*/' --include '*.binlog' --exclude '*' "$TOPLEVEL/.." ~/remote_build_testing/binlogs
+if ! rsync -avv --prune-empty-dirs --exclude 'artifacts/' --include '*/' --include '*.binlog' --exclude '*' "$TOPLEVEL/.." ~/remote_build_testing/binlogs; then
+	echo "rsync failed, but continuing collecting binlogs"
+fi
 
 rm -f ~/remote_build_testing/windows-remote-logs.zip
 zip -9r ~/remote_build_testing/windows-remote-logs.zip ~/remote_build_testing/binlogs

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -272,14 +272,6 @@ steps:
   env:
     XMA_PASSWORD: $(XMA.Password)
 
-- pwsh: $(Build.SourcesDirectory)\$(BUILD_REPOSITORY_TITLE)\tools\devops\automation\scripts\fetch-remote-binlogs.ps1
-  displayName: 'Fetch remote binlogs'
-  timeoutInMinutes: 5
-  condition: always()
-  continueOnError: true
-  env:
-    XMA_PASSWORD: $(XMA.Password)
-
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\\$Env:BUILD_REPOSITORY_TITLE\\tools\\devops\\automation\\scripts\\MaciosCI.psd1
     $configFile = "$(Build.SourcesDirectory)\\artifacts\\${{ parameters.uploadPrefix }}build-configuration\\configuration.json"
@@ -299,6 +291,14 @@ steps:
   displayName: 'Fail if test failures'
   timeoutInMinutes: 1
   condition: eq(variables['Agent.JobStatus'], 'SucceededWithIssues')
+
+- pwsh: $(Build.SourcesDirectory)\$(BUILD_REPOSITORY_TITLE)\tools\devops\automation\scripts\fetch-remote-binlogs.ps1
+  displayName: 'Fetch remote binlogs'
+  timeoutInMinutes: 5
+  condition: always()
+  continueOnError: true
+  env:
+    XMA_PASSWORD: $(XMA.Password)
 
 # Copy the binlogs to the html report
 - pwsh: |


### PR DESCRIPTION
Run the 'Fetch remote binlogs' after 'Fail if test failures', because the
'Fetch remote binlogs' step is not required to pass, but if it fails before
'Fail if test failures', it will be treated as a test failure and the job will
fail.