### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 14411: Build ID 11605235

### DIFF
--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
@@ -13,12 +13,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="M0001" xml:space="preserve">
-        <value>Tool {0} execution started with arguments: {1}
-        </value>
+        <value>Started external tool execution #{0}: {1} {2}</value>
     </data>
   <data name="M0002" xml:space="preserve">
-        <value>Tool {0} execution finished (exit code = {1}).
-        </value>
+        <value>Finished external tool execution #{0} in {1} and with exit code {2}.</value>
     </data>
   <data name="E0004" xml:space="preserve">
         <value>Failed to codesign '{0}': {1}

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.de.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.de.resx
@@ -13,12 +13,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="M0001" xml:space="preserve">
-        <value>Tool {0} execution started with arguments: {1}
-        </value>
+        <value>Started external tool execution #{0}: {1} {2}</value>
     </data>
   <data name="M0002" xml:space="preserve">
-        <value>Tool {0} execution finished (exit code = {1}).
-        </value>
+        <value>Finished external tool execution #{0} in {1} and with exit code {2}.</value>
     </data>
   <data name="E0004" xml:space="preserve">
         <value>Failed to codesign '{0}': {1}

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.es.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.es.resx
@@ -13,12 +13,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="M0001" xml:space="preserve">
-        <value>Tool {0} execution started with arguments: {1}
-        </value>
+        <value>Started external tool execution #{0}: {1} {2}</value>
     </data>
   <data name="M0002" xml:space="preserve">
-        <value>Tool {0} execution finished (exit code = {1}).
-        </value>
+        <value>Finished external tool execution #{0} in {1} and with exit code {2}.</value>
     </data>
   <data name="E0004" xml:space="preserve">
         <value>Failed to codesign '{0}': {1}

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.fr.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.fr.resx
@@ -13,12 +13,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="M0001" xml:space="preserve">
-        <value>Tool {0} execution started with arguments: {1}
-        </value>
+        <value>Started external tool execution #{0}: {1} {2}</value>
     </data>
   <data name="M0002" xml:space="preserve">
-        <value>Tool {0} execution finished (exit code = {1}).
-        </value>
+        <value>Finished external tool execution #{0} in {1} and with exit code {2}.</value>
     </data>
   <data name="E0004" xml:space="preserve">
         <value>Failed to codesign '{0}': {1}

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.it.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.it.resx
@@ -13,12 +13,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="M0001" xml:space="preserve">
-        <value>Tool {0} execution started with arguments: {1}
-        </value>
+        <value>Started external tool execution #{0}: {1} {2}</value>
     </data>
   <data name="M0002" xml:space="preserve">
-        <value>Tool {0} execution finished (exit code = {1}).
-        </value>
+        <value>Finished external tool execution #{0} in {1} and with exit code {2}.</value>
     </data>
   <data name="E0004" xml:space="preserve">
         <value>Failed to codesign '{0}': {1}

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
@@ -13,12 +13,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="M0001" xml:space="preserve">
-        <value>Tool {0} execution started with arguments: {1}
-        </value>
+        <value>Started external tool execution #{0}: {1} {2}</value>
     </data>
   <data name="M0002" xml:space="preserve">
-        <value>Tool {0} execution finished (exit code = {1}).
-        </value>
+        <value>Finished external tool execution #{0} in {1} and with exit code {2}.</value>
     </data>
   <data name="E0004" xml:space="preserve">
         <value>Failed to codesign '{0}': {1}

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ko.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ko.resx
@@ -13,12 +13,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="M0001" xml:space="preserve">
-        <value>Tool {0} execution started with arguments: {1}
-        </value>
+        <value>Started external tool execution #{0}: {1} {2}</value>
     </data>
   <data name="M0002" xml:space="preserve">
-        <value>Tool {0} execution finished (exit code = {1}).
-        </value>
+        <value>Finished external tool execution #{0} in {1} and with exit code {2}.</value>
     </data>
   <data name="E0004" xml:space="preserve">
         <value>Failed to codesign '{0}': {1}

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
@@ -13,12 +13,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="M0001" xml:space="preserve">
-        <value>Tool {0} execution started with arguments: {1}
-        </value>
+        <value>Started external tool execution #{0}: {1} {2}</value>
     </data>
   <data name="M0002" xml:space="preserve">
-        <value>Tool {0} execution finished (exit code = {1}).
-        </value>
+        <value>Finished external tool execution #{0} in {1} and with exit code {2}.</value>
     </data>
   <data name="E0004" xml:space="preserve">
         <value>Failed to codesign '{0}': {1}

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pt-BR.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pt-BR.resx
@@ -13,12 +13,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="M0001" xml:space="preserve">
-        <value>Tool {0} execution started with arguments: {1}
-        </value>
+        <value>Started external tool execution #{0}: {1} {2}</value>
     </data>
   <data name="M0002" xml:space="preserve">
-        <value>Tool {0} execution finished (exit code = {1}).
-        </value>
+        <value>Finished external tool execution #{0} in {1} and with exit code {2}.</value>
     </data>
   <data name="E0004" xml:space="preserve">
         <value>Failed to codesign '{0}': {1}

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ru.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ru.resx
@@ -13,12 +13,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="M0001" xml:space="preserve">
-        <value>Tool {0} execution started with arguments: {1}
-        </value>
+        <value>Started external tool execution #{0}: {1} {2}</value>
     </data>
   <data name="M0002" xml:space="preserve">
-        <value>Tool {0} execution finished (exit code = {1}).
-        </value>
+        <value>Finished external tool execution #{0} in {1} and with exit code {2}.</value>
     </data>
   <data name="E0004" xml:space="preserve">
         <value>Failed to codesign '{0}': {1}

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
@@ -13,12 +13,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="M0001" xml:space="preserve">
-        <value>Tool {0} execution started with arguments: {1}
-        </value>
+        <value>Started external tool execution #{0}: {1} {2}</value>
     </data>
   <data name="M0002" xml:space="preserve">
-        <value>Tool {0} execution finished (exit code = {1}).
-        </value>
+        <value>Finished external tool execution #{0} in {1} and with exit code {2}.</value>
     </data>
   <data name="E0004" xml:space="preserve">
         <value>Failed to codesign '{0}': {1}

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hans.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hans.resx
@@ -13,12 +13,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="M0001" xml:space="preserve">
-        <value>Tool {0} execution started with arguments: {1}
-        </value>
+        <value>Started external tool execution #{0}: {1} {2}</value>
     </data>
   <data name="M0002" xml:space="preserve">
-        <value>Tool {0} execution finished (exit code = {1}).
-        </value>
+        <value>Finished external tool execution #{0} in {1} and with exit code {2}.</value>
     </data>
   <data name="E0004" xml:space="preserve">
         <value>Failed to codesign '{0}': {1}

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hant.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hant.resx
@@ -13,12 +13,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="M0001" xml:space="preserve">
-        <value>Tool {0} execution started with arguments: {1}
-        </value>
+        <value>Started external tool execution #{0}: {1} {2}</value>
     </data>
   <data name="M0002" xml:space="preserve">
-        <value>Tool {0} execution finished (exit code = {1}).
-        </value>
+        <value>Finished external tool execution #{0} in {1} and with exit code {2}.</value>
     </data>
   <data name="E0004" xml:space="preserve">
         <value>Failed to codesign '{0}': {1}


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.