### PR TITLE
[RGen] Add method that can calculate the low level parameter for a trampoline.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -37,6 +37,10 @@ static partial class BindingSyntaxFactory {
 		@namespace: ["ObjCRuntime"],
 		@class: "NativeHandle",
 		isGlobal: true);
+	public readonly static TypeSyntax IntPtr = GetIdentifierName (
+		@namespace: ["System"],
+		@class: "IntPtr",
+		isGlobal: true);
 
 	/// <summary>
 	/// Returns the expression needed to cast a parameter to its native type.

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.DataModel;
 using Microsoft.Macios.Generator.Extensions;
+using Microsoft.Macios.Generator.Formatters;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
 
@@ -74,6 +75,92 @@ static partial class BindingSyntaxFactory {
 		return StaticInvocationExpression (staticClassName, "Create", arguments, suppressNullableWarning: true);
 	}
 
+
+	/// <summary>
+	/// Returns the needed data to build the parameter syntax for the native trampoline delegate.
+	/// </summary>
+	/// <param name="trampolineName">The trampoline name of the parameter we want to generate.</param>
+	/// <param name="parameter">The parameter we want to generate for the lower invoke method.</param>
+	/// <returns>The parameter syntax needed for the parameter.</returns>
+	internal static ParameterSyntax GetTrampolineInvokeParameter (string trampolineName, in DelegateParameter parameter)
+	{
+		var parameterIdentifier = Identifier (parameter.Name);
+#pragma warning disable format
+		(SyntaxToken ParameterName, TypeSyntax? ParameterType) parameterInfo = parameter switch {
+			// pointer parameter 
+			{ Type.IsPointer: true } 
+				=> (parameterIdentifier, 
+					parameter.Type.GetIdentifierSyntax ()),
+			
+			// parameters that are passed by reference, depend on the type that is referenced
+			{ IsByRef: true, Type.IsReferenceType: false, Type.IsNullable: true} 
+				=> (parameterIdentifier, 
+					PointerType (IdentifierName (parameter.Type.FullyQualifiedName))),
+			
+			{ IsByRef: true, Type.SpecialType: SpecialType.System_Boolean} 
+				=> (parameterIdentifier,
+					PointerType (PredefinedType (Token(SyntaxKind.ByteKeyword)))),
+			
+			{ IsByRef: true, Type.IsReferenceType: true, Type.IsNullable: false} 
+				=> (parameterIdentifier,
+					PointerType (NativeHandle)),
+			
+			// delegate parameter is a NativeHandle
+			{ Type.IsDelegate: true } => (parameterIdentifier, IntPtr),
+			
+			// native enum, return the conversion expression to the native type
+			{ Type.IsNativeEnum: true}
+				=> (parameterIdentifier, IdentifierName(parameter.Type.EnumUnderlyingType!.Value.GetKeyword ())),
+
+			// boolean, convert it to byte
+			{ Type.SpecialType: SpecialType.System_Boolean }
+				=> (parameterIdentifier, 
+					PredefinedType (Token(SyntaxKind.ByteKeyword))),
+
+			// same name, native handle
+			{ Type.IsArray: true }
+				=> (parameterIdentifier, NativeHandle),
+
+			// string
+			// same name, native handle
+			{ Type.SpecialType: SpecialType.System_String }
+				=> (parameterIdentifier, NativeHandle),
+
+			// same name, NativeHandle
+			{ Type.IsProtocol: true } => (parameterIdentifier, NativeHandle),
+
+			// same name, NativeHandle
+			{ ForcedType: not null } => (parameterIdentifier, NativeHandle),
+
+			// special types
+
+			// CoreMedia.CMSampleBuffer
+			// same name, native handle
+			{ Type.FullyQualifiedName: "CoreMedia.CMSampleBuffer" } => (parameterIdentifier, NativeHandle),
+
+			// AudioToolbox.AudioBuffers
+			// same name, native handle
+			{ Type.FullyQualifiedName: "AudioToolbox.AudioBuffers" } => (parameterIdentifier, NativeHandle),
+
+			// general NSObject/INativeObject, has to be after the special types otherwise the special types will
+			// fall into the NSObject/INativeObject case
+
+			// same name, native handle
+			{ Type.IsNSObject: true } => (parameterIdentifier, NativeHandle),
+
+			// same name, native handle
+			{ Type.IsINativeObject: true } => (parameterIdentifier, NativeHandle),
+			
+			// by default, we will use the parameter name as is and the type of the parameter
+			_ => (parameterIdentifier, parameter.Type.GetIdentifierSyntax ()),
+		};
+#pragma warning restore format
+		
+		return Parameter (parameterInfo.ParameterName)
+			.WithType (parameterInfo.ParameterType)
+			.NormalizeWhitespace ();
+	}
+	
 	/// <summary>
 	/// Returns the argument syntax of a parameter to be used for the trampoliner to invoke a delegate.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
@@ -160,7 +160,7 @@ static partial class BindingSyntaxFactory {
 			.WithType (parameterInfo.ParameterType)
 			.NormalizeWhitespace ();
 	}
-	
+
 	/// <summary>
 	/// Returns the argument syntax of a parameter to be used for the trampoliner to invoke a delegate.
 	/// </summary>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -1667,7 +1667,7 @@ namespace NS {
 		var invocation = CallTrampolineDelegate (parameter.Type.Delegate, argumentSyntax);
 		Assert.Equal (expectedExpression, invocation.ToFullString ());
 	}
-	
+
 	class TestDataGetTrampolineInvokeParameter : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -1686,7 +1686,7 @@ namespace NS {
 				pointerParameter,
 				"int* pointerParameter"
 			];
-			
+
 
 			var ccallbackParameter = @"
 using System;
@@ -1705,7 +1705,7 @@ namespace NS {
 				ccallbackParameter,
 				"global::System.IntPtr callbackParameter"
 			];
-			
+
 			var blockParameter = @"
 using System;
 using ObjCRuntime;
@@ -1723,7 +1723,7 @@ namespace NS {
 				blockParameter,
 				"global::System.IntPtr callbackParameter",
 			];
-			
+
 			var nativeEnumParameter = @"
 using System;
 using ObjCBindings;
@@ -1750,7 +1750,7 @@ namespace NS {
 				nativeEnumParameter,
 				"long enumParameter",
 			];
-			
+
 			var boolParameter = @"
 using System;
 using ObjCRuntime;
@@ -1768,7 +1768,7 @@ namespace NS {
 				boolParameter,
 				"byte boolParameter",
 			];
-			
+
 			var nsObjectArray = @"
 using System;
 using Foundation;
@@ -1787,7 +1787,7 @@ namespace NS {
 				nsObjectArray,
 				"global::ObjCRuntime.NativeHandle nsObjectArray",
 			];
-			
+
 
 
 			var iNativeObjectArray = @"
@@ -1809,7 +1809,7 @@ namespace NS {
 				iNativeObjectArray,
 				"global::ObjCRuntime.NativeHandle inativeArray",
 			];
-			
+
 
 			var stringArray = @"
 using System;
@@ -1829,7 +1829,7 @@ namespace NS {
 				stringArray,
 				"global::ObjCRuntime.NativeHandle stringArray",
 			];
-			
+
 			var stringParameter = @"
 using System;
 using Foundation;
@@ -1848,7 +1848,7 @@ namespace NS {
 				stringParameter,
 				"global::ObjCRuntime.NativeHandle stringParameter",
 			];
-			
+
 			var protocolParameter = @"
 using System;
 using Foundation;
@@ -1867,7 +1867,7 @@ namespace NS {
 				protocolParameter,
 				"global::ObjCRuntime.NativeHandle protocolParameter",
 			];
-			
+
 
 			var forcedParameterOwnsFalse = @"
 using System;
@@ -1887,7 +1887,7 @@ namespace NS {
 				forcedParameterOwnsFalse,
 				"global::ObjCRuntime.NativeHandle forcedParameter",
 			];
-			
+
 			var nsObjectParameter = @"
 using System;
 using Foundation;
@@ -1946,7 +1946,7 @@ namespace NS {
 				cmSampleBuffer,
 				"global::ObjCRuntime.NativeHandle cmSampleBuffer",
 			];
-			
+
 			var audioBuffer = @"
 using System;
 using AudioToolbox;
@@ -1966,7 +1966,7 @@ namespace NS {
 				audioBuffer,
 				"global::ObjCRuntime.NativeHandle audioBuffer",
 			];
-			
+
 			var outNullableInt = @"
 using System;
 using Foundation;
@@ -1985,7 +1985,7 @@ namespace NS {
 				outNullableInt,
 				"int* outNullableInt",
 			];
-			
+
 			var outBoolean = @"
 using System;
 using Foundation;
@@ -2004,7 +2004,7 @@ namespace NS {
 				outBoolean,
 				"byte* outBool",
 			];
-			
+
 			var outNSObject = @"
 using System;
 using Foundation;
@@ -2023,7 +2023,7 @@ namespace NS {
 				outNSObject,
 				"global::ObjCRuntime.NativeHandle* outNSObject",
 			];
-			
+
 			var valueType = @"
 using System;
 using Foundation;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -1667,5 +1667,406 @@ namespace NS {
 		var invocation = CallTrampolineDelegate (parameter.Type.Delegate, argumentSyntax);
 		Assert.Equal (expectedExpression, invocation.ToFullString ());
 	}
+	
+	class TestDataGetTrampolineInvokeParameter : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			var pointerParameter = @"
+using System;
+
+namespace NS {
+	public delegate void Callback (int* pointerParameter);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				"someTrampolineName",
+				pointerParameter,
+				"int* pointerParameter"
+			];
+			
+
+			var ccallbackParameter = @"
+using System;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback ([CCallback] Action callbackParameter);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				"someTrampolineName",
+				ccallbackParameter,
+				"global::System.IntPtr callbackParameter"
+			];
+			
+			var blockParameter = @"
+using System;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback ([BlockCallback] Action callbackParameter);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				"someTrampolineName",
+				blockParameter,
+				"global::System.IntPtr callbackParameter",
+			];
+			
+			var nativeEnumParameter = @"
+using System;
+using ObjCBindings;
+using ObjCRuntime;
+
+namespace NS {
+
+        [Native (""""GKErrorCode"""")]
+        [BindingType<SmartEnum> (Flags = SmartEnum.ErrorCode, ErrorDomain = """"GKErrorDomain"""")]
+        public enum NativeSampleEnum : long {
+                None = 0,
+                Unknown = 1,
+        }
+
+        public delegate void Callback (NativeSampleEnum enumParameter);
+        public class MyClass {
+                public void MyMethod (Callback cb) {}
+        }
+}
+";
+
+			yield return [
+				"someTrampolineName",
+				nativeEnumParameter,
+				"long enumParameter",
+			];
+			
+			var boolParameter = @"
+using System;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback (bool boolParameter);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				"someTrampolineName",
+				boolParameter,
+				"byte boolParameter",
+			];
+			
+			var nsObjectArray = @"
+using System;
+using Foundation;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback (NSObject[] nsObjectArray);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				"someTrampolineName",
+				nsObjectArray,
+				"global::ObjCRuntime.NativeHandle nsObjectArray",
+			];
+			
+
+
+			var iNativeObjectArray = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback (CMTimebase[] inativeArray);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				"someTrampolineName",
+				iNativeObjectArray,
+				"global::ObjCRuntime.NativeHandle inativeArray",
+			];
+			
+
+			var stringArray = @"
+using System;
+using Foundation;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback (string [] stringArray);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				"someTrampolineName",
+				stringArray,
+				"global::ObjCRuntime.NativeHandle stringArray",
+			];
+			
+			var stringParameter = @"
+using System;
+using Foundation;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback (string stringParameter);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				"someTrampolineName",
+				stringParameter,
+				"global::ObjCRuntime.NativeHandle stringParameter",
+			];
+			
+			var protocolParameter = @"
+using System;
+using Foundation;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback (INSUrlConnectionDataDelegate protocolParameter);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				"someTrampolineName",
+				protocolParameter,
+				"global::ObjCRuntime.NativeHandle protocolParameter",
+			];
+			
+
+			var forcedParameterOwnsFalse = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public delegate void Callback ([ForcedType (false)]INSUrlConnectionDataDelegate forcedParameter);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				"someTrampolineName",
+				forcedParameterOwnsFalse,
+				"global::ObjCRuntime.NativeHandle forcedParameter",
+			];
+			
+			var nsObjectParameter = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public delegate void Callback (NSObject nsObjectParameter);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				"someTrampolineName",
+				nsObjectParameter,
+				"global::ObjCRuntime.NativeHandle nsObjectParameter",
+			];
+
+			var iNativeParameter = @"
+using System;
+using CoreMedia;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public delegate void Callback (CMTimebase inativeParameter);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				"someTrampolineName",
+				iNativeParameter,
+				"global::ObjCRuntime.NativeHandle inativeParameter",
+			];
+
+			var cmSampleBuffer = @"
+using System;
+using CoreMedia;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public delegate void Callback (CMSampleBuffer cmSampleBuffer);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				"someTrampolineName",
+				cmSampleBuffer,
+				"global::ObjCRuntime.NativeHandle cmSampleBuffer",
+			];
+			
+			var audioBuffer = @"
+using System;
+using AudioToolbox;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public delegate void Callback (AudioBuffers audioBuffer);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				"someTrampolineName",
+				audioBuffer,
+				"global::ObjCRuntime.NativeHandle audioBuffer",
+			];
+			
+			var outNullableInt = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public delegate void Callback (out int? outNullableInt);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				"someTrampolineName",
+				outNullableInt,
+				"int* outNullableInt",
+			];
+			
+			var outBoolean = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public delegate void Callback (out bool outBool);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				"someTrampolineName",
+				outBoolean,
+				"byte* outBool",
+			];
+			
+			var outNSObject = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public delegate void Callback (out NSObject outNSObject);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				"someTrampolineName",
+				outNSObject,
+				"global::ObjCRuntime.NativeHandle* outNSObject",
+			];
+			
+			var valueType = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public delegate void Callback (int valueType);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				"someTrampolineName",
+				valueType,
+				"int valueType",
+			];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataGetTrampolineInvokeParameter>]
+	void GetTrampolineInvokeParameterTests (ApplePlatform platform, string trampolineName, string inputText, string expectedExpression)
+	{
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
+		Assert.Single (syntaxTrees);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ().OfType<MethodDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		Assert.True (Method.TryCreate (declaration, semanticModel, out var changes));
+		Assert.NotNull (changes);
+		// we know the first parameter of the method is the delegate
+		Assert.Single (changes.Value.Parameters);
+		var parameter = changes.Value.Parameters [0];
+		// assert it is indeed a delegate
+		Assert.NotNull (parameter.Type.Delegate);
+		var expression = GetTrampolineInvokeParameter (trampolineName, parameter.Type.Delegate!.Parameters [0]);
+		Assert.Equal (expectedExpression, expression.ToString ());
+	}
 
 }


### PR DESCRIPTION
Add a new method that will take a managed delegate parameter and will generate the needed parameter syntax for the Invoke and delegate in a trampoline.

Example of conversions:

Action -> IntrPtr
NSObject -> NativeHandle
Pointer -> Pointer
Array -> NativeHandle

The tests take care to verify that the correct conversions is done for all the known parameter types.

We need this conversion to fix the reviews in https://github.com/dotnet/macios/pull/22813