### PR TITLE
[ModelIO] Improve and simplify the manually bound constructors for MDLNoiseTexture slightly.

### DIFF
--- a/src/ModelIO/MDLNoiseTexture.cs
+++ b/src/ModelIO/MDLNoiseTexture.cs
@@ -1,4 +1,5 @@
 using System;
+using Foundation;
 using ObjCRuntime;
 
 #if NET
@@ -24,17 +25,18 @@ namespace ModelIO {
 		[SupportedOSPlatform ("tvos")]
 #endif
 		public MDLNoiseTexture (float input, string name, Vector2i textureDimensions, MDLTextureChannelEncoding channelEncoding, MDLNoiseTextureType type)
+			: base (NSObjectFlag.Empty)
 		{
 			// two different `init*` would share the same C# signature
 			switch (type) {
 			case MDLNoiseTextureType.Vector:
-				Handle = InitVectorNoiseWithSmoothness (input, name, textureDimensions, channelEncoding);
+				InitializeHandle (_InitVectorNoiseWithSmoothness (input, name, textureDimensions, channelEncoding), "initVectorNoiseWithSmoothness:name:textureDimensions:channelEncoding:");
 				break;
 			case MDLNoiseTextureType.Cellular:
-				Handle = InitCellularNoiseWithFrequency (input, name, textureDimensions, channelEncoding);
+				InitializeHandle (_InitCellularNoiseWithFrequency (input, name, textureDimensions, channelEncoding), "initCellularNoiseWithFrequency:name:textureDimensions:channelEncoding:");
 				break;
 			default:
-				throw new ArgumentException ("type");
+				throw new ArgumentException (nameof (type));
 			}
 		}
 	}

--- a/src/modelio.cs
+++ b/src/modelio.cs
@@ -2150,7 +2150,7 @@ namespace ModelIO {
 		[Internal]
 		[Export ("initVectorNoiseWithSmoothness:name:textureDimensions:channelEncoding:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr InitVectorNoiseWithSmoothness (float smoothness, [NullAllowed] string name, Vector2i textureDimensions, MDLTextureChannelEncoding channelEncoding);
+		IntPtr _InitVectorNoiseWithSmoothness (float smoothness, [NullAllowed] string name, Vector2i textureDimensions, MDLTextureChannelEncoding channelEncoding);
 
 		/// <param name="smoothness">To be added.</param>
 		/// <param name="name">
@@ -2171,7 +2171,7 @@ namespace ModelIO {
 		[MacCatalyst (13, 1)]
 		[Export ("initCellularNoiseWithFrequency:name:textureDimensions:channelEncoding:")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
-		IntPtr InitCellularNoiseWithFrequency (float frequency, [NullAllowed] string name, Vector2i textureDimensions, MDLTextureChannelEncoding channelEncoding);
+		IntPtr _InitCellularNoiseWithFrequency (float frequency, [NullAllowed] string name, Vector2i textureDimensions, MDLTextureChannelEncoding channelEncoding);
 	}
 
 	/// <summary>Class that generates a texture that contains surface normal data.</summary>

--- a/tests/cecil-tests/ConstructorTest.KnownFailures.cs
+++ b/tests/cecil-tests/ConstructorTest.KnownFailures.cs
@@ -43,7 +43,6 @@ namespace Cecil.Tests {
 			"ModelIO.MDLMesh::.ctor(System.Numerics.Vector3,CoreGraphics.NVector2i,System.Boolean,System.Boolean,System.Boolean,ModelIO.MDLGeometryType,ModelIO.IMDLMeshBufferAllocator)",
 			"ModelIO.MDLMesh::.ctor(System.Numerics.Vector3,CoreGraphics.NVector3i,System.Boolean,ModelIO.MDLGeometryType,ModelIO.IMDLMeshBufferAllocator)",
 			"ModelIO.MDLMesh::.ctor(System.Numerics.Vector3,System.Boolean,ModelIO.MDLGeometryType,ModelIO.IMDLMeshBufferAllocator)",
-			"ModelIO.MDLNoiseTexture::.ctor(System.Single,System.String,CoreGraphics.NVector2i,ModelIO.MDLTextureChannelEncoding,ModelIO.MDLNoiseTextureType)",
 			"SpriteKit.SKWarpGeometryGrid::.ctor(System.IntPtr,System.IntPtr,System.Numerics.Vector2[],System.Numerics.Vector2[])",
 			"UIKit.UIControlEventProxy::.ctor(UIKit.UIControl,System.EventHandler)",
 			"UIKit.UIImageStatusDispatcher::.ctor(UIKit.UIImage/SaveStatus)",

--- a/tests/cecil-tests/SetHandleTest.KnownFailures.cs
+++ b/tests/cecil-tests/SetHandleTest.KnownFailures.cs
@@ -17,7 +17,6 @@ namespace Cecil.Tests {
 			"Foundation.NSUuid::.ctor(System.Byte[])",
 			"GameplayKit.GKPath::.ctor(System.Numerics.Vector2[],System.Single,System.Boolean)",
 			"GameplayKit.GKPath::.ctor(System.Numerics.Vector3[],System.Single,System.Boolean)",
-			"ModelIO.MDLNoiseTexture::.ctor(System.Single,System.String,CoreGraphics.NVector2i,ModelIO.MDLTextureChannelEncoding,ModelIO.MDLNoiseTextureType)",
 			"ObjCRuntime.Runtime::RegisterNSObject(Foundation.NSObject,System.IntPtr)",
 			"ScreenCaptureKit.SCContentFilter::.ctor(ScreenCaptureKit.SCDisplay,ScreenCaptureKit.SCRunningApplication[],ScreenCaptureKit.SCWindow[],ScreenCaptureKit.SCContentFilterOption)",
 			"ScreenCaptureKit.SCContentFilter::.ctor(ScreenCaptureKit.SCDisplay,ScreenCaptureKit.SCWindow[],ScreenCaptureKit.SCContentFilterOption)",


### PR DESCRIPTION
Improve and simplify the manually bound constructors for MDLNoiseTexture by
using the same pattern we use elsewhere for manually bound constructors.