### PR TITLE
[net10.0] [dotnet] Add a way to get help with how apps are launched on mobile.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -2172,19 +2172,46 @@
 		<RelativeMlaunchPath Condition="'$(RelativeMlaunchPath)' == '' And '$(_RelativeMlaunchPath)' != ''">$(_RelativeMlaunchPath)</RelativeMlaunchPath>
 		<RelativeMlaunchPath Condition="'$(RelativeMlaunchPath)' == ''">$(XamarinRelativeSdkRootDirectory)tools\bin\mlaunch</RelativeMlaunchPath>
 		<_RelativeMlaunchPath Condition="'$(_RelativeMlaunchPath)' == ''">$(RelativeMlaunchPath)</_RelativeMlaunchPath>
+
+		<DeviceName Condition="'$(DeviceName)' == ''">$(_DeviceName)</DeviceName>
 	</PropertyGroup>
 
-	<Target Name="ComputeMlaunchInstallArguments" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_DetectAppManifest;_ComputeMlaunchInstallArguments" />
-	<Target Name="_ComputeMlaunchInstallArguments" Condition="'$(_SdkIsSimulator)' == 'false'">
+	<Target
+		Name="ShowRunHelp"
+		DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_DetectAppManifest">
+		<Error Condition="$([MSBuild]::IsOSPlatform('windows'))" Text="It's currently not supported to launch an app from the command line on Windows." />
+		<Error Condition="!Exists('$(_AppBundleManifestPath)')" Text="The app must be built before showing how to launch it." />
+
+		<GetMlaunchArguments
+			AppManifestPath="$(_AppBundleManifestPath)"
+			Help="true"
+			MlaunchPath="$(MlaunchPath)"
+			SdkDevPath="$(_SdkDevPath)"
+			SdkIsSimulator="$(_SdkIsSimulator)"
+			SdkVersion="$(_SdkVersion)"
+			SupportedOSPlatformVersion="$(SupportedOSPlatformVersion)"
+			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
+		>
+		</GetMlaunchArguments>
+
+		<!-- If invoked from 'dotnet run', don't actually run anything -->
+		<PropertyGroup>
+			<RunCommand>true</RunCommand>
+			<RunArguments />
+		</PropertyGroup>
+	</Target>
+	<Target Name="_ShowRunHelpConditioned" Condition="'$(Help)' == 'true'" DependsOnTargets="ShowRunHelp" />
+
+	<Target Name="ComputeMlaunchInstallArguments" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_DetectAppManifest;_ShowRunHelpConditioned;_ComputeMlaunchInstallArguments" />
+	<Target Name="_ComputeMlaunchInstallArguments" Condition="'$(_SdkIsSimulator)' == 'false' And '$(Help)' != 'true'">
 		<!-- Launching from the command line on windows hasn't been implemented: https://github.com/dotnet/macios/issues/16609 -->
 		<Error Condition="$([MSBuild]::IsOSPlatform('windows'))" Text="It's currently not supported to launch an app from the command line on Windows." />
 		<Error Condition="!Exists('$(_AppBundleManifestPath)')" Text="The app must be built before the arguments to launch the app using mlaunch can be computed." />
 
 		<GetMlaunchArguments
 			SessionId="$(BuildSessionId)"
-			AppBundlePath="$(_AppBundlePath)"
 			AppManifestPath="$(_AppBundleManifestPath)"
-			DeviceName="$(_DeviceName)"
+			DeviceName="$(DeviceName)"
 			InstallApp="$(_AppBundlePath)"
 			MlaunchPath="$(MlaunchPath)"
 			SdkDevPath="$(_SdkDevPath)"
@@ -2208,7 +2235,9 @@
 		<Exec SessionId="$(BuildSessionId)" Command="'$(MlaunchPath)' $(MlaunchInstallArguments)" />
 	</Target>
 
-	<Target Name="ComputeMlaunchRunArguments" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_DetectAppManifest" Condition="'$(_PlatformName)' != 'macOS' And '$(_PlatformName)' != 'MacCatalyst'">
+	<Target Name="ComputeMlaunchRunArguments" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_DetectAppManifest;_ShowRunHelpConditioned;_ComputeMlaunchRunArguments" Condition="'$(_PlatformName)' != 'macOS' And '$(_PlatformName)' != 'MacCatalyst'" />
+
+	<Target Name="_ComputeMlaunchRunArguments" Condition="'$(Help)' != 'true'">
 		<!-- Launching from the command line on windows hasn't been implemented: https://github.com/dotnet/macios/issues/16609 -->
 		<Error Condition="$([MSBuild]::IsOSPlatform('windows'))" Text="It's currently not supported to launch an app from the command line on Windows." />
 		<Error Condition="!Exists('$(_AppBundleManifestPath)')" Text="The app must be built before the arguments to launch the app using mlaunch can be computed." />
@@ -2231,10 +2260,9 @@
 		<GetMlaunchArguments
 			SessionId="$(BuildSessionId)"
 			AdditionalArguments="@(MlaunchAdditionalArguments)"
-			AppBundlePath="$(_AppBundlePath)"
 			AppManifestPath="$(_AppBundleManifestPath)"
 			CaptureOutput="$(_MlaunchCaptureOutput)"
-			DeviceName="$(_DeviceName)"
+			DeviceName="$(DeviceName)"
 			EnvironmentVariables="@(MlaunchEnvironmentVariables)"
 			LaunchApp="$(_AppBundlePath)"
 			MlaunchPath="$(MlaunchPath)"
@@ -2256,6 +2284,11 @@
 			WriteOnlyWhenDifferent="true"
 			Condition="'$(MlaunchRunScript)' != ''"
 			 />
+
+		<PropertyGroup>
+			<RunCommand>$(MlaunchPath)</RunCommand>
+			<RunArguments>$(MlaunchRunArguments) -- </RunArguments>
+		</PropertyGroup>
 	</Target>
 
 	<!-- This is only needed for mobile platforms, RunCommand and RunArguments are defined for macOS in Microsoft.macOS.Sdk.targets. -->
@@ -2264,10 +2297,6 @@
 		BeforeTargets="ComputeRunArguments"
 		DependsOnTargets="_InstallMobile;ComputeMlaunchRunArguments"
 		Condition="'$(_PlatformName)' != 'macOS' And '$(_PlatformName)' != 'MacCatalyst'">
-		<PropertyGroup>
-			<RunCommand>$(MlaunchPath)</RunCommand>
-			<RunArguments>$(MlaunchRunArguments) -- </RunArguments>
-		</PropertyGroup>
 	</Target>
 
 	<Target


### PR DESCRIPTION
There are two ways:

> dotnet build /t:ShowRunHelp

or

> dotnet run -p:ShowRunHelp=true

either way results in something like this:

  To run on physical device:
      1. If the project has multiple target frameworks, select the desired target framework. Example: -f net10.0-ios
      2. Pass a RuntimeIdentifier for a device. Example: -p:ios-arm64
      3. Pass the name or identifier of the target device using '-p:DeviceName=<name or identifier of device>'
          There are 3 device(s) connected to this Mac that can be used to run this app:
              Rolf's iPad Pro 3rd Gen (00008027-00187158020A002E)
              Rolf's iPhone 13 (00008110-000568491A92801E)
              Rolf's iPhone 15 (00008130-0008490A3A12001C)
          Example: -p:DeviceName=00008027-00187158020A002E or -p:DeviceName='Rolf\'s iPad Pro 3rd Gen'
      For example:
          dotnet run -f net10.0-ios -r ios-arm64 -p:DeviceName=00008027-00187158020A002E

  To run in a simulator:
      1. If the project has multiple target frameworks, select the desired target framework. Exmaple: -f net10.0-ios
      2. Pass the name or identifier of the target simulator using '-p:DeviceName=<name or identifier of simulator>'
          There are 27 simulators(s) on this Mac that can be used to run this app:
              iPhone 15 Pro (026EF893-4F22-4504-BD82-CBDF3B86C01A)
              iPhone 15 Pro Max (9E089019-5278-4CF2-93F6-AEB2F5061E1E)
              iPhone 15 (79A76C51-F47A-44FA-B7EB-CFA6EEC1F1D7)
              iPhone 15 Plus (E3934E95-D90A-455F-8D60-315BECC8DF1D)
              iPhone SE (3rd generation) (A3D0D0CE-B8EB-406C-82AB-F60763161350)
              iPhone 11 - iOS 17.5 (292B1EB1-6F98-4B66-8149-05976837C9A9)
              iPhone 16 Pro (5FCFB2B7-0666-41B3-83E4-79021E8E99C2)
              iPhone 16 Pro Max (02C48657-7A45-44BC-B45E-86204ACBD0D4)
              iPhone 16 (4D709EA4-AAEA-4F8C-930F-9F0302346116)
              iPhone 16 Plus (F2461C9F-DC53-4006-99D7-3B519C3A9791)
              iPhone 14 (iOS 18.2) - created by XHarness (4FB93AD4-920A-4F7B-A7CD-8729FBE0F272)
              iPhone SE (3rd generation) (D33018A8-BF65-429C-B060-CF562172CDE1)
              iPhone 11 - iOS 18.2 (A91E6E62-554A-4441-A2B8-428E6D67AA7F)
              iPhone 16 Pro (4DC76B0B-96A5-4868-9128-AEFFE8B8BBE5)
              iPhone 16 Pro Max (A822A13B-03A5-4CB0-AD91-2F2072B1FB48)
              iPhone 16e (53A397E9-2A11-4C89-9199-7E97181C7203)
              iPhone 16 (31A707F5-FA6B-4475-AC17-66589A2486D6)
              iPhone 16 Plus (9FD47A7D-5259-4303-A68C-7A40728C1690)
              iPhone SE (3rd generation) (4DF703CC-1FB4-4572-9A93-C8BFC50B8ABF)
              iPhone 11 - iOS 18.3 (41925928-ADF3-4E3C-8342-ECA518DD2696)
              iPhone 16 Pro (AEA667DF-88DA-477F-892B-3C5917CC766A)
              iPhone 16 Pro Max (96BD6EDE-3755-42F7-97A1-D3398ECF687F)
              iPhone 16e (D7C1B5F6-B961-453C-806A-AF426B8AE468)
              iPhone 16 (2A7EE827-1CC0-4E2C-9FB9-A0689AACB357)
              iPhone 16 Plus (785DCF94-AA85-4325-9883-6390440CDAE1)
              iPhone SE (3rd generation) (1C100C34-6FF1-45C0-A4CC-1C6416522326)
              iPhone 11 - iOS 18.4 (BF08B70D-BAB1-47E4-BA3C-2A6FF9EDC5AC)
          Example: -p:DeviceName=026EF893-4F22-4504-BD82-CBDF3B86C01A or -p:DeviceName='iPhone 15 Pro'
      For example:
          dotnet run -f net10.0-ios -p:DeviceName=026EF893-4F22-4504-BD82-CBDF3B86C01A