### PR TITLE
[runtime] Fix skipping nested struct types when processing method type encodings. Fixes #22837.

### DIFF
--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -436,7 +436,8 @@ skip_nested_brace (const char *type)
 	while (*++type) {
 		switch (*type) {
 		case '{':
-			return skip_nested_brace (type);
+			type = skip_nested_brace (type);
+			break;
 		case '}':
 			return type++;
 		default:

--- a/tests/bindings-test/ApiDefinition.cs
+++ b/tests/bindings-test/ApiDefinition.cs
@@ -316,6 +316,9 @@ namespace Bindings.Test {
 
 		[Export ("methodEncodings:obj2:obj3:obj4:obj5:obj6:obj7:")]
 		void GetMethodEncodings (ref NSObject obj1, ref NSObject obj2, ref NSObject obj3, ref NSObject obj4, ref NSObject obj5, ref NSObject obj6, ref NSObject obj7);
+
+		[Export ("setPtrPropertyCGRect:p2:p3:p4:p5:p6:")]
+		void SetPtrPropertyCGRect (nint p1, nint p2, nint p3, nint p4, ref global::CoreGraphics.CGRect p5, nint p6);
 	}
 
 	[Protocol]

--- a/tests/monotouch-test/ObjCRuntime/Messaging.cs
+++ b/tests/monotouch-test/ObjCRuntime/Messaging.cs
@@ -259,6 +259,9 @@ namespace ObjCRuntime {
 
 		[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
 		public extern static void void_objc_msgSend_out_byte_out_sbyte_out_short_out_ushort_out_int_out_uint_out_long_out_ulong (IntPtr receiver, IntPtr selector, out EnumB b, out EnumSB sb, out EnumS s, out EnumUS us, out EnumI i, out EnumUI ui, out EnumL l, out EnumUL ul);
+
+		[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
+		public extern static void void_objc_msgSend_IntPtr_IntPtr_IntPtr_IntPtr_CGRect_IntPtr (IntPtr receiver, IntPtr selector, IntPtr p1, IntPtr p2, IntPtr p3, IntPtr p4, ref CGRect p5, IntPtr p6);
 	}
 
 	public enum EnumB : byte { a, b = 10 };

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -5042,6 +5042,21 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			}
 		}
 
+		[Test]
+		public void MethodEncodings2 ()
+		{
+			using (var met = new MethodEncodingsTests ()) {
+				nint obj1 = 1;
+				nint obj2 = 2;
+				nint obj3 = 3;
+				nint obj4 = 4;
+				CGRect obj5 = new CGRect (1, 2, 3, 4);
+				nint obj6 = 6;
+				Messaging.void_objc_msgSend_IntPtr_IntPtr_IntPtr_IntPtr_CGRect_IntPtr (met.Handle, Selector.GetHandle ("setPtrPropertyCGRect:p2:p3:p4:p5:p6:"), obj1, obj2, obj3, obj4, ref obj5, obj6);
+				Assert.AreEqual (new CGRect (5, 6, 7, 8), obj5, "rv");
+			}
+		}
+
 		class MethodEncodingsTests : NSObject, IObjCProtocolTest {
 			[Export ("methodEncodings:obj2:obj3:obj4:obj5:obj6:obj7:")]
 			public void GetMethodEncodings (ref NSObject obj1, ref NSObject obj2, ref NSObject obj3, ref NSObject obj4, ref NSObject obj5, ref NSObject obj6, ref NSObject obj7)
@@ -5060,6 +5075,19 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				obj5 = new NSObject ();
 				obj6 = new NSObject ();
 				obj7 = new NSObject ();
+			}
+
+			[Export ("setPtrPropertyCGRect:p2:p3:p4:p5:p6:")]
+			void SetPtrPropertyCGRect (nint p1, nint p2, nint p3, nint p4, ref global::CoreGraphics.CGRect p5, nint p6)
+			{
+				Assert.AreEqual ((nint) 1, p1, "1");
+				Assert.AreEqual ((nint) 2, p2, "2");
+				Assert.AreEqual ((nint) 3, p3, "3");
+				Assert.AreEqual ((nint) 4, p4, "4");
+				Assert.AreEqual (new CGRect (1, 2, 3, 4), p5, "5a");
+				Assert.AreEqual ((nint) 6, p6, "6");
+
+				p5 = new CGRect (5, 6, 7, 8);
 			}
 		}
 

--- a/tests/test-libraries/libtest.h
+++ b/tests/test-libraries/libtest.h
@@ -197,6 +197,8 @@ typedef unsigned int (^RegistrarTestBlock) (unsigned int magic);
 		obj6: (byref NSObject **) obj6P
 		obj7: (oneway NSObject **) obj7P
 		;
+
+	-(void) setPtrPropertyCGRect: (void *) p1 p2:(void *)p2 p3:(void *)p3 p4:(void *)p4 p5:(CGRect*)p5 p6:(void *)p6;
 @end
 
 // We need this class so that the ObjCProtocolTest protocol


### PR DESCRIPTION
TODO: better description.

Fixes https://github.com/dotnet/macios/issues/22837.