### PR TITLE
[dotnet] Fix selecting NSUrlSessionHandler when not choosing a specific handler.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -681,7 +681,7 @@
 		<MacDevMessage
 			Error="true"
 			Condition="'$(UseNativeHttpHandler)' == 'true' And '$(_IsNSUrlSessionHandlerFeature)' != 'true' And '$(_IsCFNetworkHandlerFeature)' != 'true'"
-			ResourceName="E7152_InvalidMtouchHttpClientHandler" FormatArguments="'$(MtouchHttpClientHandler)'">
+			ResourceName="E7152_InvalidMtouchHttpClientHandler" FormatArguments="$(MtouchHttpClientHandler)">
 			<!-- Invalid value for 'MtouchHttpClientHandler' ('$(MtouchHttpClientHandler)', must be either 'NSUrlSessionHandler' or 'CFNetworkHandler' (or not set at all). -->
 		</MacDevMessage>
 

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -563,7 +563,7 @@
 			<!-- Set CFNetworkHandler and NSUrlSessionHandler values -->
 			<_IsCFNetworkHandlerFeature Condition="'$(UseNativeHttpHandler)' == 'true' And '$(MtouchHttpClientHandler)' == 'CFNetworkHandler'">true</_IsCFNetworkHandlerFeature>
 			<_IsCFNetworkHandlerFeature Condition="'$(_IsCFNetworkHandlerFeature)' == ''">false</_IsCFNetworkHandlerFeature>
-			<_IsNSUrlSessionHandlerFeature Condition="'$(UseNativeHttpHandler)' == 'true' And '$(MtouchHttpClientHandler)' == 'NSUrlSessionHandler'">true</_IsNSUrlSessionHandlerFeature>
+			<_IsNSUrlSessionHandlerFeature Condition="'$(UseNativeHttpHandler)' == 'true' And ('$(MtouchHttpClientHandler)' == 'NSUrlSessionHandler' Or '$(MtouchHttpClientHandler)' == '')">true</_IsNSUrlSessionHandlerFeature>
 			<_IsNSUrlSessionHandlerFeature Condition="'$(_IsNSUrlSessionHandlerFeature)' == ''">false</_IsNSUrlSessionHandlerFeature>
 
 			<!-- Set default ValidateObjectPointers value -->
@@ -676,6 +676,14 @@
 			<_AdditionalTaskAssemblyDirectory>$(_XamarinSdkRootDirectoryOnMac)tools/dotnet-linker/</_AdditionalTaskAssemblyDirectory>
 			<_AdditionalTaskAssembly>$(_AdditionalTaskAssemblyDirectory)dotnet-linker.dll</_AdditionalTaskAssembly>
 		</PropertyGroup>
+
+		<!-- Validate that one of our native handlers are selected (if using a native handler), otherwise we end up with crashes (infinite recursion) at runtime. -->
+		<MacDevMessage
+			Error="true"
+			Condition="'$(UseNativeHttpHandler)' == 'true' And '$(_IsNSUrlSessionHandlerFeature)' != 'true' And '$(_IsCFNetworkHandlerFeature)' != 'true'"
+			ResourceName="E7152_InvalidMtouchHttpClientHandler" FormatArguments="'$(MtouchHttpClientHandler)'">
+			<!-- Invalid value for 'MtouchHttpClientHandler' ('$(MtouchHttpClientHandler)', must be either 'NSUrlSessionHandler' or 'CFNetworkHandler' (or not set at all). -->
+		</MacDevMessage>
 
 		<ItemGroup>
 			<!-- Configure linker features -->

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1759,4 +1759,8 @@
             This may be either a warning or an error, depending on build configuration.
         </comment>
     </data>
+
+    <data name="E7152_InvalidMtouchHttpClientHandler" xml:space="preserve">
+        <value>Invalid value for 'MtouchHttpClientHandler' ('{0}', must be either 'NSUrlSessionHandler' or 'CFNetworkHandler' (or not set at all).</value>
+    </data>
 </root>

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -3243,6 +3243,7 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.MacCatalyst, "NSUrlSessionHandler")]
 		[TestCase (ApplePlatform.iOS, "CFNetworkHandler")]
 		[TestCase (ApplePlatform.TVOS, "")]
+		[TestCase (ApplePlatform.MacCatalyst, "Invalid")]
 		public void HttpClientHandlerFeatureTrimmedAway (ApplePlatform platform, string handler)
 		{
 			var project = "ApiTestApp";
@@ -3259,6 +3260,12 @@ namespace Xamarin.Tests {
 				properties ["MtouchHttpClientHandler"] = handler;
 			properties ["ExcludeTouchUnitReference"] = "true"; // speed things up a bit
 			properties ["ExcludeNUnitLiteReference"] = "true"; // speed things up a bit
+			if (handler == "Invalid") {
+				var rv2 = DotNet.AssertBuildFailure (project_path, properties);
+				var errors = BinLog.GetBuildLogErrors (rv2.BinLogPath).ToArray ();
+				AssertErrorMessages (errors, $"Invalid value for 'MtouchHttpClientHandler' ('Invalid', must be either 'NSUrlSessionHandler' or 'CFNetworkHandler' (or not set at all).");
+				return;
+			}
 			var rv = DotNet.AssertBuild (project_path, properties);
 			var platformAssembly = Path.Combine (appPath, GetRelativeAssemblyDirectory (platform), $"Microsoft.{platform.AsString ()}.dll");
 			var ad = AssemblyDefinition.ReadAssembly (platformAssembly, new ReaderParameters { ReadingMode = ReadingMode.Deferred });


### PR DESCRIPTION
This fixes an infinite recursion when the runtime asks us to create the
selected native http handler, but we don't have a native http handler because
they've all been linked away, so we ask the runtime to create the http
handler.