### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 14411: Build ID 11628581

### DIFF
--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
@@ -715,6 +715,16 @@
             NativeResource: do not translate (this is the name of an item in the project file).
         </comment>
     </data>
+  <data name="E0191" xml:space="preserve">
+        <value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). The current version of Xcode is {4}. Either install Xcode {3}, or use a different version of {0}. See https://aka.ms/xcode-requirement for more information.</value>
+        <comments>
+            0: Microsoft.[platform]
+            1: platform (iOS, tvOS, macOS or Mac Catalyst)
+            2: version
+            3: version
+            4: version
+        </comments>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>Could not resolve host IPs for WiFi debugger settings.
         </value>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.de.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.de.resx
@@ -715,6 +715,16 @@
             NativeResource: do not translate (this is the name of an item in the project file).
         </comment>
     </data>
+  <data name="E0191" xml:space="preserve">
+        <value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). The current version of Xcode is {4}. Either install Xcode {3}, or use a different version of {0}. See https://aka.ms/xcode-requirement for more information.</value>
+        <comments>
+            0: Microsoft.[platform]
+            1: platform (iOS, tvOS, macOS or Mac Catalyst)
+            2: version
+            3: version
+            4: version
+        </comments>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>Could not resolve host IPs for WiFi debugger settings.
         </value>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.es.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.es.resx
@@ -715,6 +715,16 @@
             NativeResource: do not translate (this is the name of an item in the project file).
         </comment>
     </data>
+  <data name="E0191" xml:space="preserve">
+        <value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). The current version of Xcode is {4}. Either install Xcode {3}, or use a different version of {0}. See https://aka.ms/xcode-requirement for more information.</value>
+        <comments>
+            0: Microsoft.[platform]
+            1: platform (iOS, tvOS, macOS or Mac Catalyst)
+            2: version
+            3: version
+            4: version
+        </comments>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>Could not resolve host IPs for WiFi debugger settings.
         </value>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.fr.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.fr.resx
@@ -715,6 +715,16 @@
             NativeResource: do not translate (this is the name of an item in the project file).
         </comment>
     </data>
+  <data name="E0191" xml:space="preserve">
+        <value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). The current version of Xcode is {4}. Either install Xcode {3}, or use a different version of {0}. See https://aka.ms/xcode-requirement for more information.</value>
+        <comments>
+            0: Microsoft.[platform]
+            1: platform (iOS, tvOS, macOS or Mac Catalyst)
+            2: version
+            3: version
+            4: version
+        </comments>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>Could not resolve host IPs for WiFi debugger settings.
         </value>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.it.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.it.resx
@@ -715,6 +715,16 @@
             NativeResource: do not translate (this is the name of an item in the project file).
         </comment>
     </data>
+  <data name="E0191" xml:space="preserve">
+        <value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). The current version of Xcode is {4}. Either install Xcode {3}, or use a different version of {0}. See https://aka.ms/xcode-requirement for more information.</value>
+        <comments>
+            0: Microsoft.[platform]
+            1: platform (iOS, tvOS, macOS or Mac Catalyst)
+            2: version
+            3: version
+            4: version
+        </comments>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>Could not resolve host IPs for WiFi debugger settings.
         </value>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
@@ -715,6 +715,16 @@
             NativeResource: do not translate (this is the name of an item in the project file).
         </comment>
     </data>
+  <data name="E0191" xml:space="preserve">
+        <value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). The current version of Xcode is {4}. Either install Xcode {3}, or use a different version of {0}. See https://aka.ms/xcode-requirement for more information.</value>
+        <comments>
+            0: Microsoft.[platform]
+            1: platform (iOS, tvOS, macOS or Mac Catalyst)
+            2: version
+            3: version
+            4: version
+        </comments>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>Could not resolve host IPs for WiFi debugger settings.
         </value>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ko.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ko.resx
@@ -715,6 +715,16 @@
             NativeResource: do not translate (this is the name of an item in the project file).
         </comment>
     </data>
+  <data name="E0191" xml:space="preserve">
+        <value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). The current version of Xcode is {4}. Either install Xcode {3}, or use a different version of {0}. See https://aka.ms/xcode-requirement for more information.</value>
+        <comments>
+            0: Microsoft.[platform]
+            1: platform (iOS, tvOS, macOS or Mac Catalyst)
+            2: version
+            3: version
+            4: version
+        </comments>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>Could not resolve host IPs for WiFi debugger settings.
         </value>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
@@ -715,6 +715,16 @@
             NativeResource: do not translate (this is the name of an item in the project file).
         </comment>
     </data>
+  <data name="E0191" xml:space="preserve">
+        <value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). The current version of Xcode is {4}. Either install Xcode {3}, or use a different version of {0}. See https://aka.ms/xcode-requirement for more information.</value>
+        <comments>
+            0: Microsoft.[platform]
+            1: platform (iOS, tvOS, macOS or Mac Catalyst)
+            2: version
+            3: version
+            4: version
+        </comments>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>Could not resolve host IPs for WiFi debugger settings.
         </value>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pt-BR.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pt-BR.resx
@@ -715,6 +715,16 @@
             NativeResource: do not translate (this is the name of an item in the project file).
         </comment>
     </data>
+  <data name="E0191" xml:space="preserve">
+        <value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). The current version of Xcode is {4}. Either install Xcode {3}, or use a different version of {0}. See https://aka.ms/xcode-requirement for more information.</value>
+        <comments>
+            0: Microsoft.[platform]
+            1: platform (iOS, tvOS, macOS or Mac Catalyst)
+            2: version
+            3: version
+            4: version
+        </comments>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>Could not resolve host IPs for WiFi debugger settings.
         </value>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ru.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ru.resx
@@ -715,6 +715,16 @@
             NativeResource: do not translate (this is the name of an item in the project file).
         </comment>
     </data>
+  <data name="E0191" xml:space="preserve">
+        <value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). The current version of Xcode is {4}. Either install Xcode {3}, or use a different version of {0}. See https://aka.ms/xcode-requirement for more information.</value>
+        <comments>
+            0: Microsoft.[platform]
+            1: platform (iOS, tvOS, macOS or Mac Catalyst)
+            2: version
+            3: version
+            4: version
+        </comments>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>Could not resolve host IPs for WiFi debugger settings.
         </value>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
@@ -715,6 +715,16 @@
             NativeResource: do not translate (this is the name of an item in the project file).
         </comment>
     </data>
+  <data name="E0191" xml:space="preserve">
+        <value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). The current version of Xcode is {4}. Either install Xcode {3}, or use a different version of {0}. See https://aka.ms/xcode-requirement for more information.</value>
+        <comments>
+            0: Microsoft.[platform]
+            1: platform (iOS, tvOS, macOS or Mac Catalyst)
+            2: version
+            3: version
+            4: version
+        </comments>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>Could not resolve host IPs for WiFi debugger settings.
         </value>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hans.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hans.resx
@@ -715,6 +715,16 @@
             NativeResource: do not translate (this is the name of an item in the project file).
         </comment>
     </data>
+  <data name="E0191" xml:space="preserve">
+        <value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). The current version of Xcode is {4}. Either install Xcode {3}, or use a different version of {0}. See https://aka.ms/xcode-requirement for more information.</value>
+        <comments>
+            0: Microsoft.[platform]
+            1: platform (iOS, tvOS, macOS or Mac Catalyst)
+            2: version
+            3: version
+            4: version
+        </comments>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>Could not resolve host IPs for WiFi debugger settings.
         </value>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hant.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hant.resx
@@ -715,6 +715,16 @@
             NativeResource: do not translate (this is the name of an item in the project file).
         </comment>
     </data>
+  <data name="E0191" xml:space="preserve">
+        <value>This version of {0} requires the {1} {2} SDK (shipped with Xcode {3}). The current version of Xcode is {4}. Either install Xcode {3}, or use a different version of {0}. See https://aka.ms/xcode-requirement for more information.</value>
+        <comments>
+            0: Microsoft.[platform]
+            1: platform (iOS, tvOS, macOS or Mac Catalyst)
+            2: version
+            3: version
+            4: version
+        </comments>
+    </data>
   <data name="E7001" xml:space="preserve">
         <value>Could not resolve host IPs for WiFi debugger settings.
         </value>


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.