### PR TITLE
[src] Use InitializeHandle instead of calling the Handle setter in several types.

### DIFF
--- a/src/AddressBook/ABGroup.cs
+++ b/src/AddressBook/ABGroup.cs
@@ -123,7 +123,7 @@ namespace AddressBook {
 			if (source is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (source));
 
-			Handle = ABGroupCreateInSource (source.Handle);
+			InitializeHandle (ABGroupCreateInSource (source.Handle));
 			GC.KeepAlive (source);
 		}
 

--- a/src/CoreFoundation/CFMutableString.cs
+++ b/src/CoreFoundation/CFMutableString.cs
@@ -30,6 +30,9 @@ namespace CoreFoundation {
 		[DllImport (Constants.CoreFoundationLibrary)]
 		static extern /* CFMutableStringRef* */ IntPtr CFStringCreateMutable (/* CFAllocatorRef* */ IntPtr alloc, nint maxLength);
 
+		/// <summary>Create a new <see cref="CFMutableString" /> with the specified managed string and maximum length.</summary>
+		/// <param name="string">The managed string to initialize the new <see cref="CFMutableString" /> with.</param>
+		/// <param name="maxLength">The maximum length of the new <see cref="CFMutableString" /> instance.</param>
 		public CFMutableString (string @string = "", nint maxLength = default (nint))
 		{
 			// not really needed - but it's consistant with other .ctor
@@ -38,7 +41,7 @@ namespace CoreFoundation {
 			// NSMallocException Out of memory. We suggest restarting the application. If you have an unsaved document, create a backup copy in Finder, then try to save.
 			if (maxLength < 0)
 				throw new ArgumentException (nameof (maxLength));
-			Handle = CFStringCreateMutable (IntPtr.Zero, maxLength);
+			InitializeHandle (CFStringCreateMutable (IntPtr.Zero, maxLength));
 			if (@string is not null) {
 				using var stringPtr = new TransientString (@string, TransientString.Encoding.Unicode);
 				CFStringAppendCharacters (Handle, stringPtr, @string.Length);
@@ -48,6 +51,9 @@ namespace CoreFoundation {
 		[DllImport (Constants.CoreFoundationLibrary)]
 		static extern /* CFMutableStringRef* */ IntPtr CFStringCreateMutableCopy (/* CFAllocatorRef* */ IntPtr alloc, nint maxLength, /* CFStringRef* */ IntPtr theString);
 
+		/// <summary>Create a new <see cref="CFMutableString" /> with a copy of the specified <see cref="CFString" /> and maximum length.</summary>
+		/// <param name="theString">The managed string to initialize the new <see cref="CFMutableString" /> with.</param>
+		/// <param name="maxLength">The maximum length of the new <see cref="CFMutableString" /> instance.</param>
 		public CFMutableString (CFString theString, nint maxLength = default (nint))
 		{
 			if (theString is null)
@@ -55,7 +61,7 @@ namespace CoreFoundation {
 			// NSMallocException Out of memory. We suggest restarting the application. If you have an unsaved document, create a backup copy in Finder, then try to save.
 			if (maxLength < 0)
 				throw new ArgumentException (nameof (maxLength));
-			Handle = CFStringCreateMutableCopy (IntPtr.Zero, maxLength, theString.GetHandle ());
+			InitializeHandle (CFStringCreateMutableCopy (IntPtr.Zero, maxLength, theString.GetHandle ()));
 			GC.KeepAlive (theString);
 		}
 

--- a/src/CoreFoundation/CFSocket.cs
+++ b/src/CoreFoundation/CFSocket.cs
@@ -463,7 +463,7 @@ namespace CoreFoundation {
 					runLoop.AddSource (source, CFRunLoop.ModeDefault);
 				}
 
-				this.Handle = handle;
+				InitializeHandle (handle);
 			} catch {
 				gch.Free ();
 				throw;

--- a/src/CoreFoundation/CFString.cs
+++ b/src/CoreFoundation/CFString.cs
@@ -190,16 +190,15 @@ namespace CoreFoundation {
 				CFObject.CFRelease (handle);
 		}
 
-		/// <param name="str">To be added.</param>
-		///         <summary>Creates a CFString from a C# string.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Creates a <see cref="CFString" /> from a C# string.</summary>
+		/// <param name="str">The managed string to initialize the new <see cref="CFString" /> with.</param>
 		public CFString (string str)
 		{
 			if (str is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (str));
 
 			using var strPtr = new TransientString (str, TransientString.Encoding.Unicode);
-			Handle = CFStringCreateWithCharacters (IntPtr.Zero, strPtr, str.Length);
+			InitializeHandle (CFStringCreateWithCharacters (IntPtr.Zero, strPtr, str.Length));
 			this.str = str;
 		}
 

--- a/src/CoreFoundation/DispatchBlock.cs
+++ b/src/CoreFoundation/DispatchBlock.cs
@@ -118,7 +118,10 @@ namespace CoreFoundation {
 		///         <remarks>To be added.</remarks>
 		protected internal override void Retain ()
 		{
-			Handle = BlockLiteral._Block_copy (GetCheckedHandle ());
+			// Retaining a block (using _Block_copy) can move it, if it's originally
+			// a stack-allocated block (it will become a heap-allocated block), and
+			// in that case we end up with a different handle (so we're not)
+			InitializeHandle (BlockLiteral._Block_copy (GetCheckedHandle ()));
 		}
 
 		/// <summary>To be added.</summary>

--- a/src/CoreFoundation/OSLog.cs
+++ b/src/CoreFoundation/OSLog.cs
@@ -89,7 +89,7 @@ namespace CoreFoundation {
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (category));
 			using var subsystemPtr = new TransientString (subsystem);
 			using var categoryPtr = new TransientString (category);
-			Handle = os_log_create (subsystemPtr, categoryPtr);
+			InitializeHandle (os_log_create (subsystemPtr, categoryPtr));
 		}
 
 		public void Log (string message)

--- a/src/CoreGraphics/CGPattern.cs
+++ b/src/CoreGraphics/CGPattern.cs
@@ -115,7 +115,7 @@ namespace CoreGraphics {
 			gch = GCHandle.Alloc (drawPattern);
 			unsafe {
 				fixed (CGPatternCallbacks* callbacksptr = &callbacks)
-					Handle = CGPatternCreate (GCHandle.ToIntPtr (gch), bounds, matrix, xStep, yStep, tiling, isColored.AsByte (), callbacksptr);
+					InitializeHandle (CGPatternCreate (GCHandle.ToIntPtr (gch), bounds, matrix, xStep, yStep, tiling, isColored.AsByte (), callbacksptr));
 			}
 		}
 

--- a/src/Foundation/NSUuid.cs
+++ b/src/Foundation/NSUuid.cs
@@ -13,13 +13,12 @@ using ObjCRuntime;
 namespace Foundation {
 	partial class NSUuid {
 
-		/// <param name="bytes">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Create a new <see cref="NSUuid" /> from the specified bytes.</summary>
+		/// <param name="bytes">The array of bytes to initialize the new <see cref="NSUuid" /> with. Must have at least 16 elements.</param>
 		public NSUuid (byte [] bytes) : base (NSObjectFlag.Empty)
 		{
 			if (bytes is null)
-				throw new ArgumentNullException ("bytes");
+				throw new ArgumentNullException (nameof (bytes));
 			if (bytes.Length < 16)
 				throw new ArgumentException ("length must be at least 16 bytes");
 
@@ -28,9 +27,9 @@ namespace Foundation {
 					IntPtr ptr = (IntPtr) p;
 
 					if (IsDirectBinding) {
-						Handle = Messaging.IntPtr_objc_msgSend_IntPtr (this.Handle, Selector.GetHandle ("initWithUUIDBytes:"), ptr);
+						InitializeHandle (Messaging.IntPtr_objc_msgSend_IntPtr (this.Handle, Selector.GetHandle ("initWithUUIDBytes:"), ptr), "initWithUUIDBytes:");
 					} else {
-						Handle = Messaging.IntPtr_objc_msgSendSuper_IntPtr (this.SuperHandle, Selector.GetHandle ("initWithUUIDBytes:"), ptr);
+						InitializeHandle (Messaging.IntPtr_objc_msgSendSuper_IntPtr (this.SuperHandle, Selector.GetHandle ("initWithUUIDBytes:"), ptr), "initWithUUIDBytes:");
 					}
 				}
 			}

--- a/src/ScreenCaptureKit/SCContentFilter.cs
+++ b/src/ScreenCaptureKit/SCContentFilter.cs
@@ -39,10 +39,10 @@ namespace ScreenCaptureKit {
 		{
 			switch (option) {
 			case SCContentFilterOption.Include:
-				Handle = _InitWithDisplayIncludingWindows (display, windows);
+				InitializeHandle (_InitWithDisplayIncludingWindows (display, windows), "initWithDisplay:includingWindows:");
 				break;
 			case SCContentFilterOption.Exclude:
-				Handle = _InitWithDisplayExcludingWindows (display, windows);
+				InitializeHandle (_InitWithDisplayExcludingWindows (display, windows), "initWithDisplay:excludingWindows:");
 				break;
 			default:
 				ObjCRuntime.ThrowHelper.ThrowArgumentOutOfRangeException (nameof (option), $"Unknown option {option}");
@@ -59,10 +59,10 @@ namespace ScreenCaptureKit {
 		{
 			switch (option) {
 			case SCContentFilterOption.Include:
-				Handle = _InitWithDisplayIncludingApplications (display, applications, exceptingWindows);
+				InitializeHandle (_InitWithDisplayIncludingApplications (display, applications, exceptingWindows), "initWithDisplay:includingApplications:exceptingWindows:");
 				break;
 			case SCContentFilterOption.Exclude:
-				Handle = _InitWithDisplayExcludingApplications (display, applications, exceptingWindows);
+				InitializeHandle (_InitWithDisplayExcludingApplications (display, applications, exceptingWindows), "initWithDisplay:excludingApplications:exceptingWindows:");
 				break;
 			default:
 				ObjCRuntime.ThrowHelper.ThrowArgumentOutOfRangeException (nameof (option), $"Unknown option {option}");

--- a/src/Security/SecTrust2.cs
+++ b/src/Security/SecTrust2.cs
@@ -43,7 +43,7 @@ namespace Security {
 			if (trust is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (trust));
 
-			Handle = sec_trust_create (trust.Handle);
+			InitializeHandle (sec_trust_create (trust.Handle));
 			GC.KeepAlive (trust);
 		}
 

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -9304,8 +9304,6 @@ M:CoreFoundation.CFBundle.IsArchitectureLoadable(CoreFoundation.CFBundle.Archite
 M:CoreFoundation.CFBundle.IsExecutableLoadable(CoreFoundation.CFBundle)
 M:CoreFoundation.CFBundle.IsExecutableLoadable(Foundation.NSUrl)
 M:CoreFoundation.CFException.#ctor(System.String,Foundation.NSString,System.IntPtr,System.String,System.String)
-M:CoreFoundation.CFMutableString.#ctor(CoreFoundation.CFString,System.IntPtr)
-M:CoreFoundation.CFMutableString.#ctor(System.String,System.IntPtr)
 M:CoreFoundation.CFNetwork.ExecuteProxyAutoConfigurationScript(System.String,System.Uri,Foundation.NSError@)
 M:CoreFoundation.CFNetwork.ExecuteProxyAutoConfigurationScriptAsync(System.String,System.Uri,System.Threading.CancellationToken)
 M:CoreFoundation.CFNetwork.ExecuteProxyAutoConfigurationUrl(System.Uri,System.Uri,Foundation.NSError@)

--- a/tests/cecil-tests/SetHandleTest.KnownFailures.cs
+++ b/tests/cecil-tests/SetHandleTest.KnownFailures.cs
@@ -4,21 +4,10 @@ using System.Collections.Generic;
 
 namespace Cecil.Tests {
 	public partial class SetHandleTest {
+		// Runtime.RegisterNSObject shouldn't call InitializeHandle, so just mark this as a known failure.
 		static HashSet<string> knownFailuresNobodyCallsHandleSetter = new HashSet<string> {
-			"AddressBook.ABGroup::.ctor(AddressBook.ABRecord)",
-			"CoreFoundation.CFMutableString::.ctor(CoreFoundation.CFString,System.IntPtr)",
-			"CoreFoundation.CFMutableString::.ctor(System.String,System.IntPtr)",
-			"CoreFoundation.CFSocket::Initialize(CoreFoundation.CFRunLoop,CoreFoundation.CFSocket/CreateSocket)",
-			"CoreFoundation.CFString::.ctor(System.String)",
-			"CoreFoundation.DispatchBlock::Retain()",
-			"CoreFoundation.OSLog::.ctor(System.String,System.String)",
-			"CoreGraphics.CGPattern::.ctor(CoreGraphics.CGRect,CoreGraphics.CGAffineTransform,System.Runtime.InteropServices.NFloat,System.Runtime.InteropServices.NFloat,CoreGraphics.CGPatternTiling,System.Boolean,CoreGraphics.CGPattern/DrawPattern)",
-			"Foundation.NSKeyedUnarchiver::.ctor(Foundation.NSData)",
-			"Foundation.NSUuid::.ctor(System.Byte[])",
 			"ObjCRuntime.Runtime::RegisterNSObject(Foundation.NSObject,System.IntPtr)",
-			"ScreenCaptureKit.SCContentFilter::.ctor(ScreenCaptureKit.SCDisplay,ScreenCaptureKit.SCRunningApplication[],ScreenCaptureKit.SCWindow[],ScreenCaptureKit.SCContentFilterOption)",
-			"ScreenCaptureKit.SCContentFilter::.ctor(ScreenCaptureKit.SCDisplay,ScreenCaptureKit.SCWindow[],ScreenCaptureKit.SCContentFilterOption)",
-			"Security.SecTrust2::.ctor(Security.SecTrust)",
+			"Foundation.NSKeyedUnarchiver::.ctor(Foundation.NSData)",
 		};
 	}
 }


### PR DESCRIPTION
Call `InitializeHandle` instead of calling the `Handle` setter in various types.