### PR TITLE
[RGen] Use the 'global::' alias for all types.

### DIFF
--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Microsoft.Macios.Bindings.Analyzer.csproj
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Microsoft.Macios.Bindings.Analyzer.csproj
@@ -33,6 +33,9 @@
     </ItemGroup>
 
     <ItemGroup>
+        <Compile Include="../Microsoft.Macios.Generator/Configuration.cs" >
+            <Link>Generator/Configuration.cs</Link>
+        </Compile>
         <Compile Include="../Microsoft.Macios.Generator/AttributesNames.cs" >
             <Link>Generator/AttributesNames.cs</Link>
         </Compile>
@@ -99,6 +102,9 @@
         </Compile>
         <Compile Include="../Microsoft.Macios.Generator/Extensions/ApplePlatformExtensions.cs" >
             <Link>Generator/Extensions/ApplePlatformExtensions.cs</Link>
+        </Compile>
+        <Compile Include="../Microsoft.Macios.Generator/Extensions/ArgumentSyntaxExtensions.cs" >
+            <Link>Generator/Extensions/ArgumentSyntaxExtensions.cs</Link>
         </Compile>
         <Compile Include="../Microsoft.Macios.Generator/Extensions/CompilationExtensions.cs" >
             <Link>Generator/Extensions/CompilationExtensions.cs</Link>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -55,12 +55,12 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// <summary>
 	/// The special type enum of the type info. This is used to differentiate nint from IntPtr and other.
 	/// </summary>
-	public SpecialType SpecialType { get; } = SpecialType.None;
+	public SpecialType SpecialType { get; init; } = SpecialType.None;
 
 	/// <summary>
 	/// True if the parameter is nullable.
 	/// </summary>
-	public bool IsNullable { get; }
+	public bool IsNullable { get; init; }
 
 	/// <summary>
 	/// True if the parameter type is blittable.
@@ -81,7 +81,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// Returns if the return type is an array type.
 	/// </summary>
 	[MemberNotNullWhen (true, nameof (ArrayElementType))]
-	public bool IsArray { get; }
+	public bool IsArray { get; init; }
 
 	/// <summary>
 	/// Returns if the return type is a reference type.
@@ -270,11 +270,13 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// <returns>An immutable array with the namespace components.</returns>
 	static ImmutableArray<string> GetNamespaceComponents (ITypeSymbol symbol)
 	{
-		var namespaceSymbol = symbol.ContainingNamespace;
+		var namespaceSymbol = symbol.ContainingSymbol;
 		var components = ImmutableArray.CreateBuilder<string> ();
-		while (namespaceSymbol is { IsGlobalNamespace: false }) {
+		while (namespaceSymbol is not null) {
 			components.Insert (0, namespaceSymbol.Name);
-			namespaceSymbol = namespaceSymbol.ContainingNamespace;
+			namespaceSymbol = namespaceSymbol.ContainingSymbol;
+			if (namespaceSymbol is INamespaceSymbol {IsGlobalNamespace: true})
+				break;
 		}
 		return components.ToImmutableArray ();
 	}
@@ -293,7 +295,6 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		IsStruct = symbol.TypeKind == TypeKind.Struct;
 		IsInterface = symbol.TypeKind == TypeKind.Interface;
 		IsDelegate = symbol.TypeKind == TypeKind.Delegate;
-		IsPointer = symbol is IPointerTypeSymbol;
 		IsNativeIntegerType = symbol.IsNativeIntegerType;
 		IsNativeEnum = symbol.HasAttribute (AttributesNames.NativeAttribute);
 		IsProtocol = symbol.HasAttribute (AttributesNames.ProtocolAttribute);
@@ -343,12 +344,23 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 			// get the type argument for nullable, which we know is the data that was boxed and use it to 
 			// overwrite the SpecialType 
 			var typeArgument = namedTypeSymbol.TypeArguments [0];
+			// we need to update the name and namespace with the type argument
+			(Name, Namespace) = GetTypeNameAndNamespace (typeArgument);
+			// we need to decide if is generic based on the inner type
+			if (typeArgument is INamedTypeSymbol innerType) {
+				IsGenericType = innerType.IsGenericType;
+			}
 			SpecialType = typeArgument.SpecialType;
 			MetadataName = SpecialType is SpecialType.None or SpecialType.System_Void
 				? null : typeArgument.MetadataName;
 		} else {
 			MetadataName = SpecialType is SpecialType.None or SpecialType.System_Void
 				? null : symbol.MetadataName;
+		}
+
+		if (symbol is IPointerTypeSymbol pointerTypeSymbol) {
+			IsPointer = true;
+			(Name, Namespace) = GetTypeNameAndNamespace (pointerTypeSymbol.PointedAtType);
 		}
 	}
 
@@ -494,6 +506,27 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		};
 #pragma warning restore format
 		return type;
+	}
+
+	public TypeInfo ToArrayElementType ()
+	{
+		if (!IsArray)
+			return this;
+		// copy all the elements from the current array type and set the array type to false
+		return this with {
+			IsArray = false,
+			SpecialType = ArrayElementType ?? SpecialType.None,
+		};
+	}
+	
+	public TypeInfo ToNonNullable()
+	{
+		if (!IsNullable)
+			return this;
+		// copy all the elements from the current array type and set the array type to false
+		return this with {
+			IsNullable = false,
+		};
 	}
 
 	/// <inheritdoc/>

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.DataModel;
 using Microsoft.Macios.Generator.Extensions;
+using Microsoft.Macios.Generator.Formatters;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Microsoft.Macios.Generator.Emitters;
@@ -17,10 +18,11 @@ namespace Microsoft.Macios.Generator.Emitters;
 /// Syntax factory for the Dlfcn calls.
 /// </summary>
 static partial class BindingSyntaxFactory {
-	readonly static TypeSyntax Dlfcn = GetIdentifierName (
+	internal readonly static TypeSyntax Dlfcn = StringExtensions.GetIdentifierName (
 		@namespace: ["ObjCRuntime"],
 		@class: "Dlfcn");
-	public readonly static TypeSyntax Libraries = GetIdentifierName (
+
+	public readonly static TypeSyntax Libraries = StringExtensions.GetIdentifierName (
 		@namespace: ["ObjCRuntime"],
 		@class: "Libraries");
 
@@ -93,7 +95,7 @@ static partial class BindingSyntaxFactory {
 		return StaticInvocationExpression (Dlfcn, methodName, arguments);
 	}
 
-	static ExpressionSyntax GetGenericConstant (string methodName, string genericName, string libraryName,
+	static ExpressionSyntax GetGenericConstant (string methodName, TypeSyntax genericName, string libraryName,
 		string fieldName)
 	{
 		var arguments = new SyntaxNodeOrToken [] {
@@ -130,7 +132,7 @@ static partial class BindingSyntaxFactory {
 	/// <param name="libraryName">The library from where the field will be loaded.</param>
 	/// <param name="fieldName">The field name.</param>
 	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
-	public static ExpressionSyntax GetStruct (string type, string libraryName, string fieldName)
+	public static ExpressionSyntax GetStruct (TypeSyntax type, string libraryName, string fieldName)
 		=> GetGenericConstant ("GetStruct", type, libraryName, fieldName);
 
 	/// <summary>
@@ -532,7 +534,7 @@ static partial class BindingSyntaxFactory {
 	/// <param name="libraryName">The library from where the field will be loaded.</param>
 	/// <param name="fieldName">The field name.</param>
 	/// <returns>A compilation unit with the desired Dlfcn call.</returns>
-	public static ExpressionSyntax GetNSObjectField (string nsObjectType, string libraryName, string fieldName)
+	public static ExpressionSyntax GetNSObjectField (TypeSyntax nsObjectType, string libraryName, string fieldName)
 	{
 		var getIndirectArguments = new SyntaxNodeOrToken [] {
 			GetLibraryArgument (libraryName), Token (SyntaxKind.CommaToken),
@@ -550,7 +552,7 @@ static partial class BindingSyntaxFactory {
 		return GetNSObject (nsObjectType, [Argument (getIndirectInvocation)], suppressNullableWarning: true);
 	}
 
-	public static ExpressionSyntax GetBlittableField (string blittableType, string libraryName, string fieldName)
+	public static ExpressionSyntax GetBlittableField (TypeSyntax blittableType, string libraryName, string fieldName)
 	{
 		var arguments = new SyntaxNodeOrToken [] {
 			GetLibraryArgument (libraryName), Token (SyntaxKind.CommaToken),
@@ -571,8 +573,7 @@ static partial class BindingSyntaxFactory {
 			SyntaxKind.PointerIndirectionExpression,
 			ParenthesizedExpression (
 				CastExpression (
-					PointerType (
-						IdentifierName (blittableType)),
+					PointerType (blittableType),
 					dlsymInvocation.WithLeadingTrivia (Space)
 				)));
 
@@ -594,11 +595,12 @@ static partial class BindingSyntaxFactory {
 		if (!property.IsField)
 			throw new NotSupportedException ("Cannot retrieve getter for non field property.");
 
+		// needed because you cannot use a in parameter in a lambda
 		var fieldType = property.ReturnType.FullyQualifiedName;
 		var underlyingEnumType = property.ReturnType.EnumUnderlyingType.GetKeyword ();
 
-		Func<string, string, ExpressionSyntax> WrapGenericCall (string genericType,
-			Func<string, string, string, ExpressionSyntax> genericCall)
+		Func<string, string, ExpressionSyntax> WrapGenericCall (TypeSyntax genericType,
+			Func<TypeSyntax, string, string, ExpressionSyntax> genericCall)
 		{
 			return (libraryName, fieldName) => genericCall (genericType, libraryName, fieldName);
 		}
@@ -620,10 +622,10 @@ static partial class BindingSyntaxFactory {
 			return property.ReturnType switch { 
 				{ FullyQualifiedName: "Foundation.NSString" } => (Getter: GetStringConstant, Setter: SetString), 
 				{ FullyQualifiedName: "Foundation.NSArray" } => (
-					Getter: WrapGenericCall (property.ReturnType.FullyQualifiedName, GetNSObjectField),
+					Getter: WrapGenericCall (property.ReturnType.GetIdentifierSyntax (), GetNSObjectField),
 					Setter: SetArray),
 				_ => (
-					Getter: WrapGenericCall (property.ReturnType.FullyQualifiedName, GetNSObjectField),
+					Getter: WrapGenericCall (property.ReturnType.GetIdentifierSyntax (), GetNSObjectField),
 					Setter: SetObject)
 			};
 		}
@@ -633,13 +635,13 @@ static partial class BindingSyntaxFactory {
 			// special types
 			{ FullyQualifiedName: "CoreGraphics.CGSize" } => (Getter: GetCGSize, Setter: SetCGSize),
 			{ FullyQualifiedName: "CoreMedia.CMTag" } => (
-				Getter: WrapGenericCall ("CoreMedia.CMTag", GetStruct),
+				Getter: WrapGenericCall (CMTag, GetStruct),
 				Setter: WrapThrow ()),
 			{ FullyQualifiedName: "nfloat" } => (Getter: GetNFloat, Setter: SetNFloat),
 
 			// Blittable types 
 			{ FullyQualifiedName: "CoreMedia.CMTime" or "AVFoundation.AVCaptureWhiteBalanceGains" }
-				=> (Getter: WrapGenericCall (property.ReturnType.FullyQualifiedName, GetBlittableField),
+				=> (Getter: WrapGenericCall (property.ReturnType.GetIdentifierSyntax (), GetBlittableField),
 					Setter: WrapThrow ()),
 
 			// enum types, decide based on its enum backing field, smart enums have to be done in the binding

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -21,21 +21,54 @@ namespace Microsoft.Macios.Generator.Emitters;
 static partial class BindingSyntaxFactory {
 	readonly static string objc_msgSend = "objc_msgSend";
 	readonly static string objc_msgSendSuper = "objc_msgSendSuper";
-	readonly static TypeSyntax Selector = GetIdentifierName (
+	
+	// ObjC runtime types
+	readonly static TypeSyntax Selector = StringExtensions.GetIdentifierName (
 		@namespace: ["ObjCRuntime"],
 		@class: "Selector");
-	public static readonly TypeSyntax NSValue = GetIdentifierName (
-		@namespace: ["Foundation"],
-		@class: "NSValue");
-	public static readonly TypeSyntax NSNumber = GetIdentifierName (
-		@namespace: ["Foundation"],
-		@class: "NSNumber");
-	public readonly static TypeSyntax NativeHandle = GetIdentifierName (
+	public readonly static TypeSyntax NativeHandle = StringExtensions.GetIdentifierName (
 		@namespace: ["ObjCRuntime"],
 		@class: "NativeHandle");
-	public readonly static TypeSyntax IntPtr = GetIdentifierName (
+	public readonly static TypeSyntax Class = StringExtensions.GetIdentifierName (
+		@namespace: ["ObjCRuntime"],
+		@class: "Class");
+	
+	// Foundation types
+	public static readonly TypeSyntax NSValue = StringExtensions.GetIdentifierName (
+		@namespace: ["Foundation"],
+		@class: "NSValue");
+	public static readonly TypeSyntax NSNumber = StringExtensions.GetIdentifierName (
+		@namespace: ["Foundation"],
+		@class: "NSNumber");
+	public readonly static TypeSyntax NSObject = StringExtensions.GetIdentifierName (
+		@namespace: ["Foundation"],
+		@class: "NSObject");
+	public readonly static TypeSyntax NSObjectFlag = StringExtensions.GetIdentifierName (
+		@namespace: ["Foundation"],
+		@class: "NSObjectFlag");
+	public readonly static TypeSyntax NSString = StringExtensions.GetIdentifierName (
+		@namespace: ["Foundation"],
+		@class: "NSString");
+	public readonly static TypeSyntax NotificationCenter = StringExtensions.GetIdentifierName (
+		@namespace: ["Foundation"],
+		@class: "NotificationCenter");
+	public readonly static TypeSyntax NSNotificationEventArgs = StringExtensions.GetIdentifierName (
+		@namespace: ["Foundation"],
+		@class: "NSNotificationEventArgs");
+	
+	// CoreMedia types
+	public readonly static TypeSyntax CMTag = StringExtensions.GetIdentifierName (
+		@namespace: ["CoreMedia"],
+		@class: "CMTag");
+	
+	
+	// System types
+	public readonly static TypeSyntax IntPtr = StringExtensions.GetIdentifierName (
 		@namespace: ["System"],
 		@class: "IntPtr");
+	public readonly static TypeSyntax EventHandler = StringExtensions.GetIdentifierName (
+		@namespace: ["System"],
+		@class: "EventHandler");
 
 	/// <summary>
 	/// Returns the expression needed to cast a parameter to its native type.

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -12,16 +12,16 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 namespace Microsoft.Macios.Generator.Emitters;
 
 static partial class BindingSyntaxFactory {
-	public static readonly TypeSyntax Runtime = GetIdentifierName (
+	public static readonly TypeSyntax Runtime = StringExtensions.GetIdentifierName (
 		@namespace: ["ObjCRuntime"],
 		@class: "Runtime");
-	public static readonly TypeSyntax NSArray = GetIdentifierName (
+	public static readonly TypeSyntax NSArray = StringExtensions.GetIdentifierName (
 		@namespace: ["Foundation"],
 		@class: "NSArray");
-	public static readonly TypeSyntax CFArray = GetIdentifierName (
+	public static readonly TypeSyntax CFArray = StringExtensions.GetIdentifierName (
 		@namespace: ["CoreFoundation"],
 		@class: "CFArray");
-	public static readonly TypeSyntax CFString = GetIdentifierName (
+	public static readonly TypeSyntax CFString = StringExtensions.GetIdentifierName (
 		@namespace: ["CoreFoundation"],
 		@class: "CFString");
 	public const string ClassPtr = "class_ptr";
@@ -33,7 +33,7 @@ static partial class BindingSyntaxFactory {
 	/// <param name="args">The arguments to pass to the GetNSObject method.</param>
 	/// <param name="suppressNullableWarning">If we should suppress the nullable warning.</param>
 	/// <returns>The expression that calls GetNSObject method.</returns>
-	public static ExpressionSyntax GetNSObject (string nsObjectType, ImmutableArray<ArgumentSyntax> args,
+	public static ExpressionSyntax GetNSObject (TypeSyntax nsObjectType, ImmutableArray<ArgumentSyntax> args,
 		bool suppressNullableWarning = false)
 	{
 		var argsList = ArgumentList (SeparatedList<ArgumentSyntax> (args.ToSyntaxNodeOrTokenArray ()));
@@ -48,7 +48,7 @@ static partial class BindingSyntaxFactory {
 	/// <param name="args">The arguments to pass to the GetNSObject method.</param>
 	/// <param name="suppressNullableWarning">If we should suppress the nullable warning.</param>
 	/// <returns>The expression that calls GetNSObject method.</returns>
-	public static ExpressionSyntax GetINativeObject (string nsObjectType, ImmutableArray<ArgumentSyntax> args,
+	public static ExpressionSyntax GetINativeObject (TypeSyntax nsObjectType, ImmutableArray<ArgumentSyntax> args,
 		bool suppressNullableWarning = false)
 	{
 		var argsList = ArgumentList (SeparatedList<ArgumentSyntax> (args.ToSyntaxNodeOrTokenArray ()));
@@ -63,7 +63,7 @@ static partial class BindingSyntaxFactory {
 	/// <param name="args">The arguments to bass to the ArrayFromHandle method.</param>
 	/// <param name="suppressNullableWarning">If we should suppress the nullable warning.</param>
 	/// <returns>The expression that calls ArrayFromHandle method.</returns>
-	public static ExpressionSyntax GetCFArrayFromHandle (string nsObjectType, ImmutableArray<ArgumentSyntax> args,
+	public static ExpressionSyntax GetCFArrayFromHandle (TypeSyntax nsObjectType, ImmutableArray<ArgumentSyntax> args,
 		bool suppressNullableWarning = false)
 	{
 		var argsList = ArgumentList (SeparatedList<ArgumentSyntax> (args.ToSyntaxNodeOrTokenArray ()));
@@ -78,7 +78,7 @@ static partial class BindingSyntaxFactory {
 	/// <param name="args">The arguments to pass to the ArrayFromHandle method.</param>
 	/// <param name="suppressNullableWarning">If we should suppress the nullable warning.</param>
 	/// <returns>The expression that calls ArrayFromHandle method.</returns>
-	public static ExpressionSyntax GetNSArrayFromHandle (string nsObjectType, ImmutableArray<ArgumentSyntax> args,
+	public static ExpressionSyntax GetNSArrayFromHandle (TypeSyntax nsObjectType, ImmutableArray<ArgumentSyntax> args,
 		bool suppressNullableWarning = false)
 	{
 		var argsList = ArgumentList (SeparatedList<ArgumentSyntax> (args.ToSyntaxNodeOrTokenArray ()));
@@ -401,7 +401,7 @@ static partial class BindingSyntaxFactory {
 	/// <param name="returnType">The generic return type of the call.</param>
 	/// <param name="arguments">An immutable array of arguments.</param>
 	/// <returns>The invocation syntax for the method.</returns>
-	internal static InvocationExpressionSyntax NSArrayFromHandleFunc (string returnType,
+	internal static InvocationExpressionSyntax NSArrayFromHandleFunc (TypeSyntax returnType,
 		ImmutableArray<ArgumentSyntax> arguments)
 	{
 		// generate: (arg1, arg2, arg3)
@@ -409,7 +409,7 @@ static partial class BindingSyntaxFactory {
 			SeparatedList<ArgumentSyntax> (arguments.ToSyntaxNodeOrTokenArray ()));
 		// generate <returnType>
 		var genericsList = TypeArgumentList (
-			SingletonSeparatedList<TypeSyntax> (IdentifierName (returnType)));
+			SingletonSeparatedList (returnType));
 
 		// generate NSArray.ArrayFromHandleFunc<returnType> (arg1, arg2, arg3)
 		return InvocationExpression (

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
@@ -95,7 +95,7 @@ static partial class BindingSyntaxFactory {
 			// parameters that are passed by reference, depend on the type that is referenced
 			{ IsByRef: true, Type.IsReferenceType: false, Type.IsNullable: true} 
 				=> (parameterIdentifier, 
-					PointerType (IdentifierName (parameter.Type.FullyQualifiedName))),
+					PointerType (parameter.Type.GetIdentifierSyntax ())),
 			
 			{ IsByRef: true, Type.SpecialType: SpecialType.System_Boolean} 
 				=> (parameterIdentifier,
@@ -226,7 +226,7 @@ static partial class BindingSyntaxFactory {
 			// parameters that are passed by reference, depend on the type that is referenced
 			{ IsByRef: true, Type.IsReferenceType: false, Type.IsNullable: true} 
 				=> (parameterIdentifier, 
-					PointerType (IdentifierName (parameter.Type.FullyQualifiedName))),
+					PointerType (parameter.Type.ToNonNullable ().GetIdentifierSyntax ())),
 			
 			{ IsByRef: true, Type.SpecialType: SpecialType.System_Boolean} 
 				=> (parameterIdentifier,
@@ -265,7 +265,7 @@ static partial class BindingSyntaxFactory {
 			// delegate parameter, c callback
 			// System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<ParameterType> (ParameterName)
 			{ Type.IsDelegate: true, IsCCallback: true } => 
-				GetDelegateForFunctionPointer (parameter.Type.FullyQualifiedName, [Argument (parameterIdentifier)]),
+				GetDelegateForFunctionPointer (parameter.Type.GetIdentifierSyntax (), [Argument (parameterIdentifier)]),
 			
 			// delegate parameter, block callback
 			// TrampolineNativeInvocationClass.Create (ParameterName)!
@@ -284,13 +284,13 @@ static partial class BindingSyntaxFactory {
 			
 			// CFArray.ArrayFromHandle<{0}> ({1})!
 			{ Type.IsArray: true, Type.ArrayElementTypeIsWrapped: true } 
-				=> GetCFArrayFromHandle (parameter.Type.FullyQualifiedName, [
+				=> GetCFArrayFromHandle (parameter.Type.ToArrayElementType ().GetIdentifierSyntax (), [
 					Argument (parameterIdentifier)
 				], suppressNullableWarning: true), 
 			
 			// NSArray.ArrayFromHandle<{0}> ({1})!
 			{ Type.IsArray: true, Type.ArrayElementIsINativeObject: true } 
-				=> GetNSArrayFromHandle (parameter.Type.FullyQualifiedName, [
+				=> GetNSArrayFromHandle (parameter.Type.ToArrayElementType ().GetIdentifierSyntax (), [
 					Argument (parameterIdentifier)
 				], suppressNullableWarning: true),
 			
@@ -306,12 +306,12 @@ static partial class BindingSyntaxFactory {
 			
 			// Runtime.GetINativeObject<ParameterType> (ParameterName, false)!
 			{ Type.IsProtocol: true } => 
-				GetINativeObject (parameter.Type.FullyQualifiedName, [
+				GetINativeObject (parameter.Type.GetIdentifierSyntax (), [
 						Argument (parameterIdentifier), 
 						BoolArgument (false)
 					], suppressNullableWarning: true),
 			// Runtime.GetINativeObject<ParameterType> (ParameterName, true, Forced.Owns)!
-			{ ForcedType: not null } => GetINativeObject (parameter.Type.FullyQualifiedName, 
+			{ ForcedType: not null } => GetINativeObject (parameter.Type.GetIdentifierSyntax (), 
 				[
 					Argument (parameterIdentifier),
 					BoolArgument (true),
@@ -337,13 +337,13 @@ static partial class BindingSyntaxFactory {
 			
 			// Runtime.GetNSObject<ParameterType> (ParameterName)! 
 			{ Type.IsNSObject: true } =>
-				GetNSObject (parameter.Type.FullyQualifiedName, [
+				GetNSObject (parameter.Type.GetIdentifierSyntax (), [
 					Argument (parameterIdentifier)
 				], suppressNullableWarning: true),
 			
 			// Runtime.GetINativeObject<ParameterType> (ParameterName, false)!
 			{ Type.IsINativeObject: true } =>
-				GetINativeObject (parameter.Type.FullyQualifiedName, [
+				GetINativeObject (parameter.Type.GetIdentifierSyntax (), [
 					Argument (parameterIdentifier), 
 					BoolArgument (false)
 				], suppressNullableWarning: true),
@@ -371,9 +371,7 @@ static partial class BindingSyntaxFactory {
 			// declare a new variable to hold the temp var
 			// ParameterType? tempVariable = null;
 			var declarationNode = LocalDeclarationStatement (
-				VariableDeclaration (
-						NullableType (
-							IdentifierName (parameter.Type.FullyQualifiedName)))
+				VariableDeclaration (parameter.Type.GetIdentifierSyntax ())
 					.WithVariables (
 						SingletonSeparatedList (
 							VariableDeclarator (

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -45,7 +46,7 @@ static partial class BindingSyntaxFactory {
 
 
 	static ExpressionSyntax StaticInvocationGenericExpression (ExpressionSyntax staticClassName, string methodName,
-		string genericName,
+		TypeSyntax genericName,
 		ArgumentListSyntax argumentList, bool suppressNullableWarning = false)
 	{
 		var invocation = InvocationExpression (
@@ -55,7 +56,7 @@ static partial class BindingSyntaxFactory {
 				GenericName (
 						Identifier (methodName))
 					.WithTypeArgumentList (TypeArgumentList (
-						SingletonSeparatedList<TypeSyntax> (IdentifierName (genericName))))
+						SingletonSeparatedList (genericName)))
 					.WithTrailingTrivia (Space)
 			)
 		).WithArgumentList (argumentList);
@@ -95,13 +96,13 @@ static partial class BindingSyntaxFactory {
 	/// <param name="variableType">The variable type.</param>
 	/// <param name="nullable">If the variable type should be made nullable.. </param>
 	/// <returns>The syntax for the field declaration.</returns>
-	internal static MemberDeclarationSyntax StaticVariable (string variableName, string variableType, bool nullable)
+	internal static MemberDeclarationSyntax StaticVariable (string variableName, TypeSyntax variableType, bool nullable)
 	{
 		return FieldDeclaration (
 				VariableDeclaration (
 						nullable
-							? NullableType (IdentifierName (variableType))
-							: IdentifierName (variableType)
+							? NullableType (variableType)
+							: variableType
 					)
 					.WithVariables (
 						SingletonSeparatedList (
@@ -118,12 +119,7 @@ static partial class BindingSyntaxFactory {
 	/// <returns>The variable declaration syntax.</returns>
 	internal static MemberDeclarationSyntax FieldPropertyBackingVariable (in Property property)
 	{
-		var variableType = property.ReturnType.FullyQualifiedName;
-		if (property.ReturnType.SpecialType is SpecialType.System_IntPtr or SpecialType.System_UIntPtr
-			&& property.ReturnType.MetadataName is not null) {
-			variableType = property.ReturnType.MetadataName;
-		}
-
+		var variableType = property.ReturnType.Name.GetIdentifierName (property.ReturnType.Namespace.ToArray ());
 		return StaticVariable (property.BackingField, variableType, property.IsReferenceType);
 	}
 
@@ -183,39 +179,7 @@ static partial class BindingSyntaxFactory {
 			IdentifierName (variableName).WithTrailingTrivia (Space),
 			value.WithLeadingTrivia (Space));
 	}
-
-	/// <summary>
-	/// Returns the expression required for an identifier name. The method will add the namespace and global qualifier
-	/// if needed based on the parameters.
-	/// </summary>
-	/// <param name="namespace">The namespace of the class. This can be null.</param>
-	/// <param name="class">The class name.</param>
-	/// <param name="isGlobal">If the global alias qualifier will be used. This will only be used if the namespace
-	/// was provided.</param>
-	/// <returns>The identifier expression for a given class.</returns>
-	internal static TypeSyntax GetIdentifierName (string []? @namespace, string @class, bool isGlobal = GeneratorConfiguration.UseGlobalNamespace)
-	{
-		// retrieve the name syntax for the namespace
-		if (@namespace is null) {
-			// if we have no namespace, we do not care about it being global
-			return IdentifierName (@class);
-		}
-
-		var fullNamespace = string.Join (".", @namespace);
-		if (isGlobal) {
-			return QualifiedName (
-				AliasQualifiedName (
-					IdentifierName (
-						Token (SyntaxKind.GlobalKeyword)),
-					IdentifierName (fullNamespace)),
-				IdentifierName (@class));
-		}
-
-		return QualifiedName (
-			IdentifierName (fullNamespace),
-			IdentifierName (@class));
-	}
-
+	
 	/// <summary>
 	/// Helper method that will return the Identifier name for a class. 
 	/// </summary>
@@ -230,9 +194,9 @@ static partial class BindingSyntaxFactory {
 	/// <param name="objectType">The target type for get the ref from.</param>
 	/// <param name="arguments">The arguments to pass to the AsRef method.</param>
 	/// <returns>The needed expression to call the AsRef method.</returns>
-	internal static ExpressionSyntax AsRef (string objectType, ImmutableArray<ArgumentSyntax> arguments)
+	internal static ExpressionSyntax AsRef (TypeSyntax objectType, ImmutableArray<ArgumentSyntax> arguments)
 	{
-		var unsafeType = GetIdentifierName (
+		var unsafeType = StringExtensions.GetIdentifierName (
 			@namespace: ["System", "Runtime", "CompilerServices"],
 			@class: "Unsafe");
 		var argsList = ArgumentList (SeparatedList<ArgumentSyntax> (arguments.ToSyntaxNodeOrTokenArray ()));
@@ -246,10 +210,10 @@ static partial class BindingSyntaxFactory {
 	/// <param name="delegateType">The type of the delegate function pointer to cast to.</param>
 	/// <param name="arguments">Arguments for the GetDelegateForFunctionPointer call.</param>
 	/// <returns>The needed expression to call the GetDelegateForFunctionPointer method.</returns>
-	internal static ExpressionSyntax GetDelegateForFunctionPointer (string delegateType,
+	internal static ExpressionSyntax GetDelegateForFunctionPointer (TypeSyntax delegateType,
 		ImmutableArray<ArgumentSyntax> arguments)
 	{
-		var marshalType = GetIdentifierName (
+		var marshalType = StringExtensions.GetIdentifierName (
 			@namespace: ["System", "Runtime", "InteropServices"],
 			@class: "Marshal");
 		// Marshal.GetDelegateForFunctionPointer<T>(IntPtr)

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/EnumEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/EnumEmitter.cs
@@ -4,10 +4,12 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Context;
 using Microsoft.Macios.Generator.DataModel;
+using Microsoft.Macios.Generator.Extensions;
 using Microsoft.Macios.Generator.Formatters;
 using Microsoft.Macios.Generator.IO;
 using ObjCBindings;
@@ -263,16 +265,16 @@ return GetValue (str);
 			classBlock.WriteLine ();
 			// emit the field that holds the error domain
 			classBlock.WriteLine ($"[Field (\"{bindingTypeData.ErrorDomain}\", \"{library}\")]");
-			classBlock.WriteLine (StaticVariable (backingFieldName, "Foundation.NSString", true).ToString ());
+			classBlock.WriteLine (StaticVariable (backingFieldName, NSString, true).ToString ());
 			classBlock.WriteLine ();
 
 			// emit the extension method to return the error domain
 			classBlock.WriteDocumentation (Documentation.SmartEnum.GetDomain (bindingContext.Changes.FullyQualifiedSymbol));
 			classBlock.WriteRaw (
-$@"public static NSString? GetDomain (this {bindingContext.Changes.Name} self)
+$@"public static {NSString}? GetDomain (this {bindingContext.Changes.Name.GetIdentifierName (bindingContext.Changes.Namespace.ToArray ())} self)
 {{
 	if ({backingFieldName} is null)
-		{backingFieldName} = Dlfcn.GetStringConstant ({Libraries}.{libraryName}.Handle, ""{bindingTypeData.ErrorDomain}"");
+		{backingFieldName} = {Dlfcn}.GetStringConstant ({Libraries}.{libraryName}.Handle, ""{bindingTypeData.ErrorDomain}"");
 	return {backingFieldName};
 }}
 ");

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/ArgumentSyntaxExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/ArgumentSyntaxExtensions.cs
@@ -4,7 +4,6 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Microsoft.Macios.Generator.Extensions;

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/StringExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/StringExtensions.cs
@@ -4,7 +4,9 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Xamarin.Utils;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Microsoft.Macios.Generator.Extensions;
 
@@ -58,5 +60,37 @@ static class StringExtensions {
 		if (!inlineSelectors)
 			sb.Append ("XHandle");
 		return sb.ToString ();
+	}
+	
+	/// <summary>
+	/// Returns the expression required for an identifier name. The method will add the namespace and global qualifier
+	/// if needed based on the parameters.
+	/// </summary>
+	/// <param name="namespace">The namespace of the class. This can be null.</param>
+	/// <param name="class">The class name.</param>
+	/// <param name="isGlobal">If the global alias qualifier will be used. This will only be used if the namespace
+	/// was provided.</param>
+	/// <returns>The identifier expression for a given class.</returns>
+	internal static TypeSyntax GetIdentifierName (this string @class, string []? @namespace, bool isGlobal = GeneratorConfiguration.UseGlobalNamespace)
+	{
+		// retrieve the name syntax for the namespace
+		if (@namespace is null || @namespace.Length == 0) {
+			// if we have no namespace, we do not care about it being global
+			return IdentifierName (@class);
+		}
+
+		var fullNamespace = string.Join (".", @namespace);
+		if (isGlobal) {
+			return QualifiedName (
+				AliasQualifiedName (
+					IdentifierName (
+						Token (SyntaxKind.GlobalKeyword)),
+					IdentifierName (fullNamespace)),
+				IdentifierName (@class));
+		}
+
+		return QualifiedName (
+			IdentifierName (fullNamespace),
+			IdentifierName (@class));
 	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/Formatters/TypeInfoFormatter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Formatters/TypeInfoFormatter.cs
@@ -1,8 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Extensions;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
 
@@ -12,27 +15,42 @@ static class TypeInfoFormatter {
 
 	public static TypeSyntax GetIdentifierSyntax (this in TypeInfo typeInfo)
 	{
-		// If we are dealing with a IntPtr or UIntPtr, we want to use the metadata name, otherwise we will
-		// get a nint in the signature. The compiler won't care, this is just done for completeness and to
-		// reduce the surprise factor for a customer debugging the generated code.
-		var name = typeInfo.SpecialType is SpecialType.System_IntPtr or SpecialType.System_UIntPtr
-			? typeInfo.MetadataName! // we know is not null
-			: typeInfo.FullyQualifiedName;
-
+		TypeSyntax classSyntax;
+		// the type info already provides the correct name, but we need to build the actual class for arrays and 
+		// generic types
 		if (typeInfo.IsArray) {
 			// could be a params array or simply an array
-			var arrayType = ArrayType (IdentifierName (name))
+			classSyntax = ArrayType (IdentifierName (typeInfo.Name))
 				.WithRankSpecifiers (SingletonList (
 					ArrayRankSpecifier (
 						SingletonSeparatedList<ExpressionSyntax> (OmittedArraySizeExpression ()))));
-			return typeInfo.IsNullable
-				? NullableType (arrayType)
-				: arrayType;
-		}
+		} else if (typeInfo.IsGenericType) {
+			// build the argument list
+			var parameterBucket = ImmutableArray.CreateBuilder<TypeSyntax> (typeInfo.TypeArguments.Length);
+			foreach (var currentGenericType in typeInfo.TypeArguments) {
+				// build the parameter
+				parameterBucket.Add (IdentifierName (currentGenericType));
+			}
 
-		// dealing with a non-array type
-		return typeInfo.IsNullable
-			? NullableType (IdentifierName (name))
-			: IdentifierName (name);
+			// generates the function parameter list:
+			// example:
+			// <IntPtr, int, int, int>
+			// that is, the block ptr, the parameters and the return type
+			var parametersSyntax = TypeArgumentList (
+				SeparatedList<TypeSyntax> (
+					parameterBucket.ToImmutableArray ().ToSyntaxNodeOrTokenArray ())).NormalizeWhitespace ();
+			classSyntax = GenericName (Identifier (typeInfo.Name))
+				.WithTypeArgumentList (parametersSyntax);
+		} else if (typeInfo.IsPointer) {
+			classSyntax = PointerType (IdentifierName (typeInfo.Name));
+		} else {
+			// dealing with a non-array or generic type
+			classSyntax = IdentifierName (typeInfo.Name);
+		}
+		
+		// build the full type name using the namespace and the class name
+		classSyntax = classSyntax.ToString ().GetIdentifierName (typeInfo.Namespace.ToArray ());
+		// we still need to check if the type is nullable
+		return typeInfo.IsNullable ? NullableType (classSyntax) : classSyntax;
 	}
 }

--- a/src/rgen/Microsoft.Macios.Transformer/Microsoft.Macios.Transformer.csproj
+++ b/src/rgen/Microsoft.Macios.Transformer/Microsoft.Macios.Transformer.csproj
@@ -32,6 +32,9 @@
     </ItemGroup>
 
     <ItemGroup>
+        <Compile Include="../Microsoft.Macios.Generator/Configuration.cs" >
+            <Link>Configuration.cs</Link>
+        </Compile>
         <Compile Include="../Microsoft.Macios.Generator/DictionaryComparer.cs">
             <Link>DictionaryComparer.cs</Link>
         </Compile>
@@ -61,6 +64,9 @@
         </Compile>
         <Compile Include="../Microsoft.Macios.Generator/Extensions/ApplePlatformExtensions.cs">
             <Link>Extensions/ApplePlatformExtensions.cs</Link>
+        </Compile>
+        <Compile Include="../Microsoft.Macios.Generator/Extensions/ArgumentSyntaxExtensions.cs" >
+            <Link>Extensions/ArgumentSyntaxExtensions.cs</Link>
         </Compile>
         <Compile Include="../Microsoft.Macios.Generator/Extensions/BaseTypeDeclarationSyntaxExtensions.cs">
             <Link>Extensions/BaseTypeDeclarationSyntaxExtensions.cs</Link>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/BaseGeneratorTestClass.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/BaseGeneratorTestClass.cs
@@ -30,6 +30,18 @@ public class BaseGeneratorTestClass {
 		{ TargetFramework.DotNet_MacCatalyst, new [] { "__MACCATALYST__" } },
 	};
 
+	/// <summary>
+	/// Returns the name of the class in the global namespace if the generator configuration has set to do so. If
+	/// not, the same string will be returned.
+	/// </summary>
+	/// <param name="className">The class that should have global prepend to it.</param>
+	/// <param name="isGlobal">If global should be used.</param>
+	/// <returns>A modified class name with the global alias if needed.</returns>
+	public static string Global (string className, bool isGlobal = GeneratorConfiguration.UseGlobalNamespace)
+	{
+		return isGlobal ? $"global::{className}" : className;
+	}
+
 	protected Compilation RunGeneratorsAndUpdateCompilation (CSharpGeneratorDriver driver, Compilation compilation, out ImmutableArray<Diagnostic> diagnostics)
 	{
 		driver.RunGeneratorsAndUpdateCompilation (compilation, out var updatedCompilation, out diagnostics);

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/BaseTestDataGenerator.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/BaseTestDataGenerator.cs
@@ -6,10 +6,12 @@ using System.Runtime.CompilerServices;
 namespace Microsoft.Macios.Generator.Tests;
 
 public class BaseTestDataGenerator {
-	public static string ReadFileAsString (string file, [CallerFilePath] string filePath = "")
+	public static string ReadFileAsString (string file, [CallerFilePath] string filePath = "",  bool isGlobal = GeneratorConfiguration.UseGlobalNamespace)
 	{
 		var directoryPath = Path.GetDirectoryName (filePath);
 		var fullPath = Path.Join (directoryPath, "Data", file);
-		return File.ReadAllText (fullPath);
+		return isGlobal
+			? File.ReadAllText (fullPath).Replace ("$GLOBAL$", "global::")
+			: File.ReadAllText (fullPath).Replace ("$GLOBAL$", "");
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/BindingSourceGeneratorGeneratorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/BindingSourceGeneratorGeneratorTests.cs
@@ -45,7 +45,7 @@ namespace TestNamespace;
 public partial class AVAudioPcmBuffer
 {
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	static readonly global::ObjCRuntime.NativeHandle class_ptr = Class.GetHandle (""AVAudioPCMBuffer"");
+	static readonly global::ObjCRuntime.NativeHandle class_ptr = global::ObjCRuntime.Class.GetHandle (""AVAudioPCMBuffer"");
 
 	/// <summary>The Objective-C class handle for this class.</summary>
 	/// <value>The pointer to the Objective-C class.</value>
@@ -103,7 +103,7 @@ public partial class AVAudioPcmBuffer
 	/// </remarks>
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	protected AVAudioPcmBuffer (NSObjectFlag t) : base (t) {}
+	protected AVAudioPcmBuffer (global::Foundation.NSObjectFlag t) : base (t) {}
 
 	/// <summary>A constructor used when creating managed representations of unmanaged objects. Called by the runtime.</summary>
 	/// <param name=""handle"">Pointer (handle) to the unmanaged object.</param>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/ClassGenerationTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/ClassGenerationTests.cs
@@ -41,7 +41,7 @@ public class ClassGenerationTests : BaseGeneratorTestClass {
 			(ApplePlatform.TVOS, "NSUserDefaults", "NSUserDefaults.cs", "ExpectedNSUserDefaults.cs", null, null),
 			(ApplePlatform.MacCatalyst, "NSUserDefaults", "NSUserDefaults.cs", "ExpectedNSUserDefaults.cs", null, null),
 			(ApplePlatform.MacOSX, "NSUserDefaults", "NSUserDefaults.cs", "ExpectedNSUserDefaults.cs", null, null),
-			
+
 			// trampoline tests
 			(ApplePlatform.iOS, "TrampolinePropertyTests", "TrampolinePropertyTests.cs", "ExpectedTrampolinePropertyTests.cs", null, "ExpectedTrampolinePropertyTestsTrampolines.cs"),
 			(ApplePlatform.TVOS, "TrampolinePropertyTests", "TrampolinePropertyTests.cs", "ExpectedTrampolinePropertyTests.cs", null, "ExpectedTrampolinePropertyTestsTrampolines.cs"),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedAVAudioPcmBufferDefaultCtr.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedAVAudioPcmBufferDefaultCtr.cs
@@ -20,7 +20,7 @@ namespace TestNamespace;
 public partial class AVAudioPcmBuffer
 {
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	static readonly global::ObjCRuntime.NativeHandle class_ptr = Class.GetHandle ("AVAudioPCMBuffer");
+	static readonly global::ObjCRuntime.NativeHandle class_ptr = $GLOBAL$ObjCRuntime.Class.GetHandle ("AVAudioPCMBuffer");
 
 	/// <summary>The Objective-C class handle for this class.</summary>
 	/// <value>The pointer to the Objective-C class.</value>
@@ -35,7 +35,7 @@ public partial class AVAudioPcmBuffer
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[DesignatedInitializer]
 	[Export ("init")]
-	public AVAudioPcmBuffer () : base (NSObjectFlag.Empty)
+	public AVAudioPcmBuffer () : base (global::Foundation.NSObjectFlag.Empty)
 	{
 		if (IsDirectBinding)
 			InitializeHandle (global::ObjCRuntime.Messaging.IntPtr_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("init")), "init");
@@ -90,7 +90,7 @@ public partial class AVAudioPcmBuffer
 	/// </remarks>
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	protected AVAudioPcmBuffer (NSObjectFlag t) : base (t) {}
+	protected AVAudioPcmBuffer (global::Foundation.NSObjectFlag t) : base (t) {}
 
 	/// <summary>A constructor used when creating managed representations of unmanaged objects. Called by the runtime.</summary>
 	/// <param name="handle">Pointer (handle) to the unmanaged object.</param>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedAVAudioPcmBufferNoDefaultCtr.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedAVAudioPcmBufferNoDefaultCtr.cs
@@ -20,7 +20,7 @@ namespace TestNamespace;
 public partial class AVAudioPcmBuffer
 {
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	static readonly global::ObjCRuntime.NativeHandle class_ptr = Class.GetHandle ("AVAudioPCMBuffer");
+	static readonly $GLOBAL$ObjCRuntime.NativeHandle class_ptr = $GLOBAL$ObjCRuntime.Class.GetHandle ("AVAudioPCMBuffer");
 
 	/// <summary>The Objective-C class handle for this class.</summary>
 	/// <value>The pointer to the Objective-C class.</value>
@@ -29,7 +29,7 @@ public partial class AVAudioPcmBuffer
 	///     This value contains the pointer to the Objective-C class.
 	///     It is similar to calling the managed <see cref=\"ObjCRuntime.Class.GetHandle(string)\" /> or the native <see href=\"https://developer.apple.com/documentation/objectivec/1418952-objc_getclass\">objc_getClass</see> method with the type name.
 	/// </remarks>
-	public override global::ObjCRuntime.NativeHandle ClassHandle => class_ptr;
+	public override $GLOBAL$ObjCRuntime.NativeHandle ClassHandle => class_ptr;
 
 	/// <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>
 	/// <param name="t">Unused sentinel value, pass NSObjectFlag.Empty.</param>
@@ -78,7 +78,7 @@ public partial class AVAudioPcmBuffer
 	/// </remarks>
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	protected AVAudioPcmBuffer (NSObjectFlag t) : base (t) {}
+	protected AVAudioPcmBuffer ($GLOBAL$Foundation.NSObjectFlag t) : base (t) {}
 
 	/// <summary>A constructor used when creating managed representations of unmanaged objects. Called by the runtime.</summary>
 	/// <param name="handle">Pointer (handle) to the unmanaged object.</param>
@@ -90,6 +90,6 @@ public partial class AVAudioPcmBuffer
 	/// </remarks>
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	protected internal AVAudioPcmBuffer (global::ObjCRuntime.NativeHandle handle) : base (handle) {}
+	protected internal AVAudioPcmBuffer ($GLOBAL$ObjCRuntime.NativeHandle handle) : base (handle) {}
 	// TODO: add binding code here
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedAVAudioPcmBufferNoNativeName.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedAVAudioPcmBufferNoNativeName.cs
@@ -20,7 +20,7 @@ namespace TestNamespace;
 public partial class AVAudioPcmBuffer
 {
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	static readonly global::ObjCRuntime.NativeHandle class_ptr = Class.GetHandle ("AVAudioPcmBuffer");
+	static readonly $GLOBAL$ObjCRuntime.NativeHandle class_ptr = $GLOBAL$ObjCRuntime.Class.GetHandle ("AVAudioPcmBuffer");
 
 	/// <summary>The Objective-C class handle for this class.</summary>
 	/// <value>The pointer to the Objective-C class.</value>
@@ -29,7 +29,7 @@ public partial class AVAudioPcmBuffer
 	///     This value contains the pointer to the Objective-C class.
 	///     It is similar to calling the managed <see cref=\"ObjCRuntime.Class.GetHandle(string)\" /> or the native <see href=\"https://developer.apple.com/documentation/objectivec/1418952-objc_getclass\">objc_getClass</see> method with the type name.
 	/// </remarks>
-	public override global::ObjCRuntime.NativeHandle ClassHandle => class_ptr;
+	public override $GLOBAL$ObjCRuntime.NativeHandle ClassHandle => class_ptr;
 
 	/// <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>
 	/// <param name="t">Unused sentinel value, pass NSObjectFlag.Empty.</param>
@@ -78,7 +78,7 @@ public partial class AVAudioPcmBuffer
 	/// </remarks>
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	protected AVAudioPcmBuffer (NSObjectFlag t) : base (t) {}
+	protected AVAudioPcmBuffer ($GLOBAL$Foundation.NSObjectFlag t) : base (t) {}
 
 	/// <summary>A constructor used when creating managed representations of unmanaged objects. Called by the runtime.</summary>
 	/// <param name="handle">Pointer (handle) to the unmanaged object.</param>
@@ -90,6 +90,6 @@ public partial class AVAudioPcmBuffer
 	/// </remarks>
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	protected internal AVAudioPcmBuffer (global::ObjCRuntime.NativeHandle handle) : base (handle) {}
+	protected internal AVAudioPcmBuffer ($GLOBAL$ObjCRuntime.NativeHandle handle) : base (handle) {}
 	// TODO: add binding code here
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedAppKitPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedAppKitPropertyTests.cs
@@ -24,7 +24,7 @@ public partial class AppKitPropertyTests
 	static readonly global::ObjCRuntime.NativeHandle selCountXHandle = global::ObjCRuntime.Selector.GetHandle ("count");
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	static readonly global::ObjCRuntime.NativeHandle class_ptr = Class.GetHandle ("AppKitPropertyTests");
+	static readonly global::ObjCRuntime.NativeHandle class_ptr = global::ObjCRuntime.Class.GetHandle ("AppKitPropertyTests");
 
 	/// <summary>The Objective-C class handle for this class.</summary>
 	/// <value>The pointer to the Objective-C class.</value>
@@ -39,7 +39,7 @@ public partial class AppKitPropertyTests
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[DesignatedInitializer]
 	[Export ("init")]
-	public AppKitPropertyTests () : base (NSObjectFlag.Empty)
+	public AppKitPropertyTests () : base (global::Foundation.NSObjectFlag.Empty)
 	{
 		if (IsDirectBinding)
 			InitializeHandle (global::ObjCRuntime.Messaging.IntPtr_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("init")), "init");
@@ -94,7 +94,7 @@ public partial class AppKitPropertyTests
 	/// </remarks>
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	protected AppKitPropertyTests (NSObjectFlag t) : base (t) {}
+	protected AppKitPropertyTests (global::Foundation.NSObjectFlag t) : base (t) {}
 
 	/// <summary>A constructor used when creating managed representations of unmanaged objects. Called by the runtime.</summary>
 	/// <param name="handle">Pointer (handle) to the unmanaged object.</param>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedCIImage.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedCIImage.cs
@@ -20,7 +20,7 @@ namespace TestNamespace;
 public partial class CIImage
 {
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	static readonly global::ObjCRuntime.NativeHandle class_ptr = Class.GetHandle ("CIImage");
+	static readonly $GLOBAL$ObjCRuntime.NativeHandle class_ptr = $GLOBAL$ObjCRuntime.Class.GetHandle ("CIImage");
 
 	/// <summary>The Objective-C class handle for this class.</summary>
 	/// <value>The pointer to the Objective-C class.</value>
@@ -29,18 +29,18 @@ public partial class CIImage
 	///     This value contains the pointer to the Objective-C class.
 	///     It is similar to calling the managed <see cref=\"ObjCRuntime.Class.GetHandle(string)\" /> or the native <see href=\"https://developer.apple.com/documentation/objectivec/1418952-objc_getclass\">objc_getClass</see> method with the type name.
 	/// </remarks>
-	public override global::ObjCRuntime.NativeHandle ClassHandle => class_ptr;
+	public override $GLOBAL$ObjCRuntime.NativeHandle ClassHandle => class_ptr;
 
 	/// <summary>Creates a new <see cref="CIImage" /> with default values.</summary>
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[DesignatedInitializer]
 	[Export ("init")]
-	public CIImage () : base (NSObjectFlag.Empty)
+	public CIImage () : base ($GLOBAL$Foundation.NSObjectFlag.Empty)
 	{
 		if (IsDirectBinding)
-			InitializeHandle (global::ObjCRuntime.Messaging.IntPtr_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("init")), "init");
+			InitializeHandle ($GLOBAL$ObjCRuntime.Messaging.IntPtr_objc_msgSend (this.Handle, $GLOBAL$ObjCRuntime.Selector.GetHandle ("init")), "init");
 		else
-			InitializeHandle (global::ObjCRuntime.Messaging.IntPtr_objc_msgSendSuper (this.SuperHandle, global::ObjCRuntime.Selector.GetHandle ("init")), "init");
+			InitializeHandle ($GLOBAL$ObjCRuntime.Messaging.IntPtr_objc_msgSendSuper (this.SuperHandle, $GLOBAL$ObjCRuntime.Selector.GetHandle ("init")), "init");
 	}
 
 	/// <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>
@@ -90,7 +90,7 @@ public partial class CIImage
 	/// </remarks>
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	protected CIImage (NSObjectFlag t) : base (t) {}
+	protected CIImage ($GLOBAL$Foundation.NSObjectFlag t) : base (t) {}
 
 	/// <summary>A constructor used when creating managed representations of unmanaged objects. Called by the runtime.</summary>
 	/// <param name="handle">Pointer (handle) to the unmanaged object.</param>
@@ -102,9 +102,9 @@ public partial class CIImage
 	/// </remarks>
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	protected internal CIImage (global::ObjCRuntime.NativeHandle handle) : base (handle) {}
+	protected internal CIImage ($GLOBAL$ObjCRuntime.NativeHandle handle) : base (handle) {}
 
-	static Foundation.NSString? _DidProcessEditingNotification;
+	static $GLOBAL$Foundation.NSString? _DidProcessEditingNotification;
 
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios11.0")]
@@ -112,7 +112,7 @@ public partial class CIImage
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[Advice ("Use 'CIImage.Notifications.DidProcessEditingNotification' helper method instead.")]
-	public static partial Foundation.NSString DidProcessEditingNotification
+	public static partial $GLOBAL$Foundation.NSString DidProcessEditingNotification
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios11.0")]
@@ -121,7 +121,7 @@ public partial class CIImage
 		get
 		{
 			if (_DidProcessEditingNotification is null)
-				_DidProcessEditingNotification = global::ObjCRuntime.Dlfcn.GetStringConstant (global::ObjCRuntime.Libraries.TestNamespace.Handle, "kCIFormatLA8")!;
+				_DidProcessEditingNotification = $GLOBAL$ObjCRuntime.Dlfcn.GetStringConstant ($GLOBAL$ObjCRuntime.Libraries.TestNamespace.Handle, "kCIFormatLA8")!;
 			return _DidProcessEditingNotification;
 		}
 	}
@@ -140,7 +140,7 @@ public partial class CIImage
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			return global::ObjCRuntime.Dlfcn.GetInt32 (global::ObjCRuntime.Libraries.TestNamespace.Handle, "kCIFormatABGR8");
+			return $GLOBAL$ObjCRuntime.Dlfcn.GetInt32 ($GLOBAL$ObjCRuntime.Libraries.TestNamespace.Handle, "kCIFormatABGR8");
 		}
 	}
 
@@ -158,7 +158,7 @@ public partial class CIImage
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			return global::ObjCRuntime.Dlfcn.GetInt32 (global::ObjCRuntime.Libraries.TestNamespace.Handle, "kCIFormatLA8");
+			return $GLOBAL$ObjCRuntime.Dlfcn.GetInt32 ($GLOBAL$ObjCRuntime.Libraries.TestNamespace.Handle, "kCIFormatLA8");
 		}
 
 		[SupportedOSPlatform ("macos14.0")]
@@ -167,7 +167,7 @@ public partial class CIImage
 		[SupportedOSPlatform ("maccatalyst17.0")]
 		set
 		{
-			global::ObjCRuntime.Dlfcn.SetInt32 (global::ObjCRuntime.Libraries.TestNamespace.Handle, "kCIFormatLA8", value);
+			$GLOBAL$ObjCRuntime.Dlfcn.SetInt32 ($GLOBAL$ObjCRuntime.Libraries.TestNamespace.Handle, "kCIFormatLA8", value);
 		}
 	}
 
@@ -185,21 +185,21 @@ public partial class CIImage
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			return global::ObjCRuntime.Dlfcn.GetInt32 (global::ObjCRuntime.Libraries.TestNamespace.Handle, "FormatRGBA16Int");
+			return $GLOBAL$ObjCRuntime.Dlfcn.GetInt32 ($GLOBAL$ObjCRuntime.Libraries.TestNamespace.Handle, "FormatRGBA16Int");
 		}
 	}
 
 	public static partial class Notifications
 	{
 
-		public static NSObject ObserveDidProcessEditing (EventHandler<Foundation.NSNotificationEventArgs> handler)
+		public static $GLOBAL$Foundation.NSObject ObserveDidProcessEditing ($GLOBAL$System.EventHandler<$GLOBAL$Foundation.NSNotificationEventArgs> handler)
 		{
-			return NSNotificationCenter.DefaultCenter.AddObserver (DidProcessEditingNotification, notification => handler (null, new Foundation.NSNotificationEventArgs (notification)));
+			return $GLOBAL$Foundation.NotificationCenter.DefaultCenter.AddObserver (DidProcessEditingNotification, notification => handler (null, new $GLOBAL$Foundation.NSNotificationEventArgs (notification)));
 		}
 
-		public static NSObject ObserveDidProcessEditing (NSObject objectToObserve, EventHandler<Foundation.NSNotificationEventArgs> handler)
+		public static NSObject ObserveDidProcessEditing ($GLOBAL$Foundation.NSObject objectToObserve, $GLOBAL$System.EventHandler<$GLOBAL$Foundation.NSNotificationEventArgs> handler)
 		{
-			return NSNotificationCenter.DefaultCenter.AddObserver (DidProcessEditingNotification, notification => handler (null, new Foundation.NSNotificationEventArgs (notification)), objectToObserve);
+			return $GLOBAL$Foundation.NotificationCenter.DefaultCenter.AddObserver (DidProcessEditingNotification, notification => handler (null, new $GLOBAL$Foundation.NSNotificationEventArgs (notification)), objectToObserve);
 		}
 
 	}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedNSUserDefaults.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedNSUserDefaults.cs
@@ -20,7 +20,7 @@ namespace Foundation;
 public partial class NSUserDefaults
 {
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	static readonly global::ObjCRuntime.NativeHandle class_ptr = Class.GetHandle ("NSUserDefaults");
+	static readonly global::ObjCRuntime.NativeHandle class_ptr = global::ObjCRuntime.Class.GetHandle ("NSUserDefaults");
 
 	/// <summary>The Objective-C class handle for this class.</summary>
 	/// <value>The pointer to the Objective-C class.</value>
@@ -35,7 +35,7 @@ public partial class NSUserDefaults
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[DesignatedInitializer]
 	[Export ("init")]
-	public NSUserDefaults () : base (NSObjectFlag.Empty)
+	public NSUserDefaults () : base (global::Foundation.NSObjectFlag.Empty)
 	{
 		if (IsDirectBinding)
 			InitializeHandle (global::ObjCRuntime.Messaging.IntPtr_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("init")), "init");
@@ -90,7 +90,7 @@ public partial class NSUserDefaults
 	/// </remarks>
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	protected NSUserDefaults (NSObjectFlag t) : base (t) {}
+	protected NSUserDefaults (global::Foundation.NSObjectFlag t) : base (t) {}
 
 	/// <summary>A constructor used when creating managed representations of unmanaged objects. Called by the runtime.</summary>
 	/// <param name="handle">Pointer (handle) to the unmanaged object.</param>
@@ -104,11 +104,11 @@ public partial class NSUserDefaults
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
 	protected internal NSUserDefaults (global::ObjCRuntime.NativeHandle handle) : base (handle) {}
 
-	static Foundation.NSString? _CompletedInitialSyncNotification;
+	static global::Foundation.NSString? _CompletedInitialSyncNotification;
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[Advice ("Use 'NSUserDefaults.Notifications.CompletedInitialSyncNotification' helper method instead.")]
-	public static partial Foundation.NSString CompletedInitialSyncNotification
+	public static partial global::Foundation.NSString CompletedInitialSyncNotification
 	{
 		get
 		{
@@ -118,11 +118,11 @@ public partial class NSUserDefaults
 		}
 	}
 
-	static Foundation.NSString? _DidChangeAccountsNotification;
+	static global::Foundation.NSString? _DidChangeAccountsNotification;
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[Advice ("Use 'NSUserDefaults.Notifications.DidChangeAccountsNotification' helper method instead.")]
-	public static partial Foundation.NSString DidChangeAccountsNotification
+	public static partial global::Foundation.NSString DidChangeAccountsNotification
 	{
 		get
 		{
@@ -132,11 +132,11 @@ public partial class NSUserDefaults
 		}
 	}
 
-	static Foundation.NSString? _NoCloudAccountNotification;
+	static global::Foundation.NSString? _NoCloudAccountNotification;
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[Advice ("Use 'NSUserDefaults.Notifications.NoCloudAccountNotification' helper method instead.")]
-	public static partial Foundation.NSString NoCloudAccountNotification
+	public static partial global::Foundation.NSString NoCloudAccountNotification
 	{
 		get
 		{
@@ -146,11 +146,11 @@ public partial class NSUserDefaults
 		}
 	}
 
-	static Foundation.NSString? _SizeLimitExceededNotification;
+	static global::Foundation.NSString? _SizeLimitExceededNotification;
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[Advice ("Use 'NSUserDefaults.Notifications.SizeLimitExceededNotification' helper method instead.")]
-	public static partial Foundation.NSString SizeLimitExceededNotification
+	public static partial global::Foundation.NSString SizeLimitExceededNotification
 	{
 		get
 		{
@@ -163,44 +163,44 @@ public partial class NSUserDefaults
 	public static partial class Notifications
 	{
 
-		public static NSObject ObserveCompletedInitialSync (EventHandler<Foundation.MyNotificationArgs> handler)
+		public static global::Foundation.NSObject ObserveCompletedInitialSync (global::System.EventHandler<Foundation.MyNotificationArgs> handler)
 		{
 			return SharedWorkspace.NotificationCenter.AddObserver (CompletedInitialSyncNotification, notification => handler (null, new Foundation.MyNotificationArgs (notification)));
 		}
 
-		public static NSObject ObserveCompletedInitialSync (NSObject objectToObserve, EventHandler<Foundation.MyNotificationArgs> handler)
+		public static NSObject ObserveCompletedInitialSync (global::Foundation.NSObject objectToObserve, global::System.EventHandler<Foundation.MyNotificationArgs> handler)
 		{
 			return SharedWorkspace.NotificationCenter.AddObserver (CompletedInitialSyncNotification, notification => handler (null, new Foundation.MyNotificationArgs (notification)), objectToObserve);
 		}
 
-		public static NSObject ObserveDidChangeAccounts (EventHandler<Foundation.MyNotificationArgs> handler)
+		public static global::Foundation.NSObject ObserveDidChangeAccounts (global::System.EventHandler<Foundation.MyNotificationArgs> handler)
 		{
-			return NSNotificationCenter.DefaultCenter.AddObserver (DidChangeAccountsNotification, notification => handler (null, new Foundation.MyNotificationArgs (notification)));
+			return global::Foundation.NotificationCenter.DefaultCenter.AddObserver (DidChangeAccountsNotification, notification => handler (null, new Foundation.MyNotificationArgs (notification)));
 		}
 
-		public static NSObject ObserveDidChangeAccounts (NSObject objectToObserve, EventHandler<Foundation.MyNotificationArgs> handler)
+		public static NSObject ObserveDidChangeAccounts (global::Foundation.NSObject objectToObserve, global::System.EventHandler<Foundation.MyNotificationArgs> handler)
 		{
-			return NSNotificationCenter.DefaultCenter.AddObserver (DidChangeAccountsNotification, notification => handler (null, new Foundation.MyNotificationArgs (notification)), objectToObserve);
+			return global::Foundation.NotificationCenter.DefaultCenter.AddObserver (DidChangeAccountsNotification, notification => handler (null, new Foundation.MyNotificationArgs (notification)), objectToObserve);
 		}
 
-		public static NSObject ObserveNoCloudAccount (EventHandler<Foundation.NSNotificationEventArgs> handler)
+		public static global::Foundation.NSObject ObserveNoCloudAccount (global::System.EventHandler<global::Foundation.NSNotificationEventArgs> handler)
 		{
-			return SharedWorkspace.NotificationCenter.AddObserver (NoCloudAccountNotification, notification => handler (null, new Foundation.NSNotificationEventArgs (notification)));
+			return SharedWorkspace.NotificationCenter.AddObserver (NoCloudAccountNotification, notification => handler (null, new global::Foundation.NSNotificationEventArgs (notification)));
 		}
 
-		public static NSObject ObserveNoCloudAccount (NSObject objectToObserve, EventHandler<Foundation.NSNotificationEventArgs> handler)
+		public static NSObject ObserveNoCloudAccount (global::Foundation.NSObject objectToObserve, global::System.EventHandler<global::Foundation.NSNotificationEventArgs> handler)
 		{
-			return SharedWorkspace.NotificationCenter.AddObserver (NoCloudAccountNotification, notification => handler (null, new Foundation.NSNotificationEventArgs (notification)), objectToObserve);
+			return SharedWorkspace.NotificationCenter.AddObserver (NoCloudAccountNotification, notification => handler (null, new global::Foundation.NSNotificationEventArgs (notification)), objectToObserve);
 		}
 
-		public static NSObject ObserveSizeLimitExceeded (EventHandler<Foundation.NSNotificationEventArgs> handler)
+		public static global::Foundation.NSObject ObserveSizeLimitExceeded (global::System.EventHandler<global::Foundation.NSNotificationEventArgs> handler)
 		{
-			return NSNotificationCenter.DefaultCenter.AddObserver (SizeLimitExceededNotification, notification => handler (null, new Foundation.NSNotificationEventArgs (notification)));
+			return global::Foundation.NotificationCenter.DefaultCenter.AddObserver (SizeLimitExceededNotification, notification => handler (null, new global::Foundation.NSNotificationEventArgs (notification)));
 		}
 
-		public static NSObject ObserveSizeLimitExceeded (NSObject objectToObserve, EventHandler<Foundation.NSNotificationEventArgs> handler)
+		public static NSObject ObserveSizeLimitExceeded (global::Foundation.NSObject objectToObserve, global::System.EventHandler<global::Foundation.NSNotificationEventArgs> handler)
 		{
-			return NSNotificationCenter.DefaultCenter.AddObserver (SizeLimitExceededNotification, notification => handler (null, new Foundation.NSNotificationEventArgs (notification)), objectToObserve);
+			return global::Foundation.NotificationCenter.DefaultCenter.AddObserver (SizeLimitExceededNotification, notification => handler (null, new global::Foundation.NSNotificationEventArgs (notification)), objectToObserve);
 		}
 
 	}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedThreadSafeAppKitPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedThreadSafeAppKitPropertyTests.cs
@@ -24,7 +24,7 @@ public partial class ThreadSafeAppKitPropertyTests
 	static readonly global::ObjCRuntime.NativeHandle selCountXHandle = global::ObjCRuntime.Selector.GetHandle ("count");
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	static readonly global::ObjCRuntime.NativeHandle class_ptr = Class.GetHandle ("ThreadSafeAppKitPropertyTests");
+	static readonly global::ObjCRuntime.NativeHandle class_ptr = global::ObjCRuntime.Class.GetHandle ("ThreadSafeAppKitPropertyTests");
 
 	/// <summary>The Objective-C class handle for this class.</summary>
 	/// <value>The pointer to the Objective-C class.</value>
@@ -39,7 +39,7 @@ public partial class ThreadSafeAppKitPropertyTests
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[DesignatedInitializer]
 	[Export ("init")]
-	public ThreadSafeAppKitPropertyTests () : base (NSObjectFlag.Empty)
+	public ThreadSafeAppKitPropertyTests () : base (global::Foundation.NSObjectFlag.Empty)
 	{
 		if (IsDirectBinding)
 			InitializeHandle (global::ObjCRuntime.Messaging.IntPtr_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("init")), "init");
@@ -94,7 +94,7 @@ public partial class ThreadSafeAppKitPropertyTests
 	/// </remarks>
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	protected ThreadSafeAppKitPropertyTests (NSObjectFlag t) : base (t) {}
+	protected ThreadSafeAppKitPropertyTests (global::Foundation.NSObjectFlag t) : base (t) {}
 
 	/// <summary>A constructor used when creating managed representations of unmanaged objects. Called by the runtime.</summary>
 	/// <param name="handle">Pointer (handle) to the unmanaged object.</param>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedThreadSafeUIKitPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedThreadSafeUIKitPropertyTests.cs
@@ -24,7 +24,7 @@ public partial class ThreadSafeUIKitPropertyTests
 	static readonly global::ObjCRuntime.NativeHandle selCountXHandle = global::ObjCRuntime.Selector.GetHandle ("count");
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	static readonly global::ObjCRuntime.NativeHandle class_ptr = Class.GetHandle ("ThreadSafeUIKitPropertyTests");
+	static readonly global::ObjCRuntime.NativeHandle class_ptr = global::ObjCRuntime.Class.GetHandle ("ThreadSafeUIKitPropertyTests");
 
 	/// <summary>The Objective-C class handle for this class.</summary>
 	/// <value>The pointer to the Objective-C class.</value>
@@ -39,7 +39,7 @@ public partial class ThreadSafeUIKitPropertyTests
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[DesignatedInitializer]
 	[Export ("init")]
-	public ThreadSafeUIKitPropertyTests () : base (NSObjectFlag.Empty)
+	public ThreadSafeUIKitPropertyTests () : base (global::Foundation.NSObjectFlag.Empty)
 	{
 		if (IsDirectBinding)
 			InitializeHandle (global::ObjCRuntime.Messaging.IntPtr_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("init")), "init");
@@ -94,7 +94,7 @@ public partial class ThreadSafeUIKitPropertyTests
 	/// </remarks>
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	protected ThreadSafeUIKitPropertyTests (NSObjectFlag t) : base (t) {}
+	protected ThreadSafeUIKitPropertyTests (global::Foundation.NSObjectFlag t) : base (t) {}
 
 	/// <summary>A constructor used when creating managed representations of unmanaged objects. Called by the runtime.</summary>
 	/// <param name="handle">Pointer (handle) to the unmanaged object.</param>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedTrampolinePropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedTrampolinePropertyTests.cs
@@ -29,7 +29,7 @@ public partial class TrampolinePropertyTests
 	static readonly global::ObjCRuntime.NativeHandle selSetCompletionHandler_XHandle = global::ObjCRuntime.Selector.GetHandle ("setCompletionHandler:");
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	static readonly global::ObjCRuntime.NativeHandle class_ptr = Class.GetHandle ("TrampolinePropertyTests");
+	static readonly global::ObjCRuntime.NativeHandle class_ptr = global::ObjCRuntime.Class.GetHandle ("TrampolinePropertyTests");
 
 	/// <summary>The Objective-C class handle for this class.</summary>
 	/// <value>The pointer to the Objective-C class.</value>
@@ -44,7 +44,7 @@ public partial class TrampolinePropertyTests
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[DesignatedInitializer]
 	[Export ("init")]
-	public TrampolinePropertyTests () : base (NSObjectFlag.Empty)
+	public TrampolinePropertyTests () : base (global::Foundation.NSObjectFlag.Empty)
 	{
 		if (IsDirectBinding)
 			InitializeHandle (global::ObjCRuntime.Messaging.IntPtr_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("init")), "init");
@@ -99,7 +99,7 @@ public partial class TrampolinePropertyTests
 	/// </remarks>
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	protected TrampolinePropertyTests (NSObjectFlag t) : base (t) {}
+	protected TrampolinePropertyTests (global::Foundation.NSObjectFlag t) : base (t) {}
 
 	/// <summary>A constructor used when creating managed representations of unmanaged objects. Called by the runtime.</summary>
 	/// <param name="handle">Pointer (handle) to the unmanaged object.</param>
@@ -114,11 +114,11 @@ public partial class TrampolinePropertyTests
 	protected internal TrampolinePropertyTests (global::ObjCRuntime.NativeHandle handle) : base (handle) {}
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial System.Action CompletionHandler
+	public partial global::System.Action CompletionHandler
 	{
 		get
 		{
-			System.Action ret;
+			global::System.Action ret;
 			if (IsDirectBinding) {
 				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completionHandler"));
 			} else {

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedUIKitPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedUIKitPropertyTests.cs
@@ -24,7 +24,7 @@ public partial class UIKitPropertyTests
 	static readonly global::ObjCRuntime.NativeHandle selCountXHandle = global::ObjCRuntime.Selector.GetHandle ("count");
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	static readonly global::ObjCRuntime.NativeHandle class_ptr = Class.GetHandle ("UIKitPropertyTests");
+	static readonly global::ObjCRuntime.NativeHandle class_ptr = global::ObjCRuntime.Class.GetHandle ("UIKitPropertyTests");
 
 	/// <summary>The Objective-C class handle for this class.</summary>
 	/// <value>The pointer to the Objective-C class.</value>
@@ -39,7 +39,7 @@ public partial class UIKitPropertyTests
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[DesignatedInitializer]
 	[Export ("init")]
-	public UIKitPropertyTests () : base (NSObjectFlag.Empty)
+	public UIKitPropertyTests () : base (global::Foundation.NSObjectFlag.Empty)
 	{
 		if (IsDirectBinding)
 			InitializeHandle (global::ObjCRuntime.Messaging.IntPtr_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("init")), "init");
@@ -94,7 +94,7 @@ public partial class UIKitPropertyTests
 	/// </remarks>
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	protected UIKitPropertyTests (NSObjectFlag t) : base (t) {}
+	protected UIKitPropertyTests (global::Foundation.NSObjectFlag t) : base (t) {}
 
 	/// <summary>A constructor used when creating managed representations of unmanaged objects. Called by the runtime.</summary>
 	/// <param name="handle">Pointer (handle) to the unmanaged object.</param>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
@@ -122,7 +122,7 @@ public partial class PropertyTests
 	static readonly global::ObjCRuntime.NativeHandle selSetCenter_XHandle = global::ObjCRuntime.Selector.GetHandle ("setCenter:");
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	static readonly global::ObjCRuntime.NativeHandle class_ptr = Class.GetHandle ("PropertyTests");
+	static readonly global::ObjCRuntime.NativeHandle class_ptr = global::ObjCRuntime.Class.GetHandle ("PropertyTests");
 
 	/// <summary>The Objective-C class handle for this class.</summary>
 	/// <value>The pointer to the Objective-C class.</value>
@@ -137,7 +137,7 @@ public partial class PropertyTests
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[DesignatedInitializer]
 	[Export ("init")]
-	public PropertyTests () : base (NSObjectFlag.Empty)
+	public PropertyTests () : base (global::Foundation.NSObjectFlag.Empty)
 	{
 		if (IsDirectBinding)
 			InitializeHandle (global::ObjCRuntime.Messaging.IntPtr_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("init")), "init");
@@ -192,7 +192,7 @@ public partial class PropertyTests
 	/// </remarks>
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	protected PropertyTests (NSObjectFlag t) : base (t) {}
+	protected PropertyTests (global::Foundation.NSObjectFlag t) : base (t) {}
 
 	/// <summary>A constructor used when creating managed representations of unmanaged objects. Called by the runtime.</summary>
 	/// <param name="handle">Pointer (handle) to the unmanaged object.</param>
@@ -211,7 +211,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public static partial Foundation.NSCharacterSet Alphanumerics
+	public static partial global::Foundation.NSCharacterSet Alphanumerics
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -219,11 +219,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			Foundation.NSCharacterSet ret;
+			global::Foundation.NSCharacterSet ret;
 			if (IsDirectBinding) {
-				ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSCharacterSet> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("alphanumericCharacterSet")))!;
+				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSCharacterSet> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("alphanumericCharacterSet")))!;
 			} else {
-				ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSCharacterSet> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("alphanumericCharacterSet")))!;
+				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSCharacterSet> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("alphanumericCharacterSet")))!;
 			}
 			GC.KeepAlive (this);
 			return ret;
@@ -235,7 +235,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial Foundation.NSAttributedString AttributedStringByInflectingString
+	public virtual partial global::Foundation.NSAttributedString AttributedStringByInflectingString
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -243,11 +243,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			Foundation.NSAttributedString ret;
+			global::Foundation.NSAttributedString ret;
 			if (IsDirectBinding) {
-				ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSAttributedString> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("attributedStringByInflectingString")))!;
+				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSAttributedString> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("attributedStringByInflectingString")))!;
 			} else {
-				ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSAttributedString> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("attributedStringByInflectingString")))!;
+				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSAttributedString> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("attributedStringByInflectingString")))!;
 			}
 			GC.KeepAlive (this);
 			return ret;
@@ -292,7 +292,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial CoreGraphics.CGPoint Center
+	public virtual partial global::CoreGraphics.CGPoint Center
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -300,7 +300,7 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			CoreGraphics.CGPoint ret;
+			global::CoreGraphics.CGPoint ret;
 			if (IsDirectBinding) {
 				ret = NSValue.ToCGPoint (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")));
 			} else {
@@ -439,7 +439,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial nfloat LineSpacing
+	public virtual partial global::CompareGeneratedCode.CompareGeneratedCode.netmodule..nfloat LineSpacing
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -447,7 +447,7 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			nfloat ret;
+			global::CompareGeneratedCode.CompareGeneratedCode.netmodule..nfloat ret;
 			if (IsDirectBinding) {
 				ret = global::ObjCRuntime.Messaging.nfloat_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("lineSpacing"));
 			} else {
@@ -472,7 +472,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	internal virtual partial Foundation.NSLocale Locale
+	internal virtual partial global::Foundation.NSLocale Locale
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -480,11 +480,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			Foundation.NSLocale ret;
+			global::Foundation.NSLocale ret;
 			if (IsDirectBinding) {
-				ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSLocale> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("locale")))!;
+				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSLocale> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("locale")))!;
 			} else {
-				ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSLocale> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("locale")))!;
+				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSLocale> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("locale")))!;
 			}
 			GC.KeepAlive (this);
 			return ret;
@@ -505,7 +505,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial CoreGraphics.CGPoint[] Location
+	public virtual partial global::CoreGraphics.CGPoint[] Location
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -513,11 +513,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			CoreGraphics.CGPoint[] ret;
+			global::CoreGraphics.CGPoint[] ret;
 			if (IsDirectBinding) {
-				ret = global::Foundation.NSArray.ArrayFromHandleFunc<CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")), NSValue.ToCGPoint, false);
+				ret = global::Foundation.NSArray.ArrayFromHandleFunc<global::CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")), NSValue.ToCGPoint, false);
 			} else {
-				ret = global::Foundation.NSArray.ArrayFromHandleFunc<CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")), NSValue.ToCGPoint, false);
+				ret = global::Foundation.NSArray.ArrayFromHandleFunc<global::CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")), NSValue.ToCGPoint, false);
 			}
 			GC.KeepAlive (this);
 			return ret;
@@ -637,7 +637,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial AVFoundation.AVCaptureReactionType ReactionType
+	public virtual partial global::AVFoundation.AVCaptureReactionType ReactionType
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -645,7 +645,7 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			AVFoundation.AVCaptureReactionType ret;
+			global::AVFoundation.AVCaptureReactionType ret;
 			if (IsDirectBinding) {
 				ret = global::AVFoundation.AVCaptureReactionTypeExtensions.GetValue (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("canDraw")));
 			} else {
@@ -670,7 +670,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial Foundation.NSMetadataItem[] Results
+	public virtual partial global::Foundation.NSMetadataItem[] Results
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -678,11 +678,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			Foundation.NSMetadataItem[] ret;
+			global::Foundation.NSMetadataItem[] ret;
 			if (IsDirectBinding) {
-				ret = global::CoreFoundation.CFArray.ArrayFromHandle<Foundation.NSMetadataItem> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("results")))!;
+				ret = global::CoreFoundation.CFArray.ArrayFromHandle<global::Foundation.NSMetadataItem> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("results")))!;
 			} else {
-				ret = global::CoreFoundation.CFArray.ArrayFromHandle<Foundation.NSMetadataItem> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("results")))!;
+				ret = global::CoreFoundation.CFArray.ArrayFromHandle<global::Foundation.NSMetadataItem> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("results")))!;
 			}
 			GC.KeepAlive (this);
 			return ret;
@@ -694,7 +694,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial CoreGraphics.CGSize Size
+	public virtual partial global::CoreGraphics.CGSize Size
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -702,7 +702,7 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			CoreGraphics.CGSize ret;
+			global::CoreGraphics.CGSize ret;
 			if (IsDirectBinding) {
 				ret = global::ObjCRuntime.Messaging.CGSize_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("size"));
 			} else {
@@ -718,7 +718,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial nuint[] Sizes
+	public virtual partial UIntPtr[] Sizes
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -726,7 +726,7 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			nuint[] ret;
+			UIntPtr[] ret;
 			if (IsDirectBinding) {
 				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("sizes"));
 			} else {
@@ -742,7 +742,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial Foundation.NSObject? WeakDelegate
+	public virtual partial global::Foundation.NSObject? WeakDelegate
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -750,11 +750,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			Foundation.NSObject? ret;
+			global::Foundation.NSObject? ret;
 			if (IsDirectBinding) {
-				ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSObject> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("delegate")));
+				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSObject> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("delegate")));
 			} else {
-				ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSObject> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("delegate")));
+				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSObject> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("delegate")));
 			}
 			GC.KeepAlive (this);
 			return ret;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
@@ -122,7 +122,7 @@ public partial class PropertyTests
 	static readonly global::ObjCRuntime.NativeHandle selSetCenter_XHandle = global::ObjCRuntime.Selector.GetHandle ("setCenter:");
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	static readonly global::ObjCRuntime.NativeHandle class_ptr = Class.GetHandle ("PropertyTests");
+	static readonly global::ObjCRuntime.NativeHandle class_ptr = global::ObjCRuntime.Class.GetHandle ("PropertyTests");
 
 	/// <summary>The Objective-C class handle for this class.</summary>
 	/// <value>The pointer to the Objective-C class.</value>
@@ -137,7 +137,7 @@ public partial class PropertyTests
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[DesignatedInitializer]
 	[Export ("init")]
-	public PropertyTests () : base (NSObjectFlag.Empty)
+	public PropertyTests () : base (global::Foundation.NSObjectFlag.Empty)
 	{
 		if (IsDirectBinding)
 			InitializeHandle (global::ObjCRuntime.Messaging.IntPtr_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("init")), "init");
@@ -192,7 +192,7 @@ public partial class PropertyTests
 	/// </remarks>
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	protected PropertyTests (NSObjectFlag t) : base (t) {}
+	protected PropertyTests (global::Foundation.NSObjectFlag t) : base (t) {}
 
 	/// <summary>A constructor used when creating managed representations of unmanaged objects. Called by the runtime.</summary>
 	/// <param name="handle">Pointer (handle) to the unmanaged object.</param>
@@ -211,7 +211,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public static partial Foundation.NSCharacterSet Alphanumerics
+	public static partial global::Foundation.NSCharacterSet Alphanumerics
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -219,11 +219,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			Foundation.NSCharacterSet ret;
+			global::Foundation.NSCharacterSet ret;
 			if (IsDirectBinding) {
-				ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSCharacterSet> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("alphanumericCharacterSet")))!;
+				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSCharacterSet> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("alphanumericCharacterSet")))!;
 			} else {
-				ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSCharacterSet> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("alphanumericCharacterSet")))!;
+				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSCharacterSet> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("alphanumericCharacterSet")))!;
 			}
 			GC.KeepAlive (this);
 			return ret;
@@ -235,7 +235,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial Foundation.NSAttributedString AttributedStringByInflectingString
+	public virtual partial global::Foundation.NSAttributedString AttributedStringByInflectingString
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -243,11 +243,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			Foundation.NSAttributedString ret;
+			global::Foundation.NSAttributedString ret;
 			if (IsDirectBinding) {
-				ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSAttributedString> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("attributedStringByInflectingString")))!;
+				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSAttributedString> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("attributedStringByInflectingString")))!;
 			} else {
-				ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSAttributedString> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("attributedStringByInflectingString")))!;
+				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSAttributedString> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("attributedStringByInflectingString")))!;
 			}
 			GC.KeepAlive (this);
 			return ret;
@@ -292,7 +292,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial CoreGraphics.CGPoint Center
+	public virtual partial global::CoreGraphics.CGPoint Center
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -300,7 +300,7 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			CoreGraphics.CGPoint ret;
+			global::CoreGraphics.CGPoint ret;
 			if (IsDirectBinding) {
 				ret = NSValue.ToCGPoint (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")));
 			} else {
@@ -439,7 +439,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial nfloat LineSpacing
+	public virtual partial global::CompareGeneratedCode.CompareGeneratedCode.netmodule..nfloat LineSpacing
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -447,7 +447,7 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			nfloat ret;
+			global::CompareGeneratedCode.CompareGeneratedCode.netmodule..nfloat ret;
 			if (IsDirectBinding) {
 				ret = global::ObjCRuntime.Messaging.nfloat_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("lineSpacing"));
 			} else {
@@ -472,7 +472,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	internal virtual partial Foundation.NSLocale Locale
+	internal virtual partial global::Foundation.NSLocale Locale
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -480,11 +480,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			Foundation.NSLocale ret;
+			global::Foundation.NSLocale ret;
 			if (IsDirectBinding) {
-				ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSLocale> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("locale")))!;
+				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSLocale> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("locale")))!;
 			} else {
-				ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSLocale> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("locale")))!;
+				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSLocale> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("locale")))!;
 			}
 			GC.KeepAlive (this);
 			return ret;
@@ -505,7 +505,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial CoreGraphics.CGPoint[] Location
+	public virtual partial global::CoreGraphics.CGPoint[] Location
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -513,11 +513,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			CoreGraphics.CGPoint[] ret;
+			global::CoreGraphics.CGPoint[] ret;
 			if (IsDirectBinding) {
-				ret = global::Foundation.NSArray.ArrayFromHandleFunc<CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")), NSValue.ToCGPoint, false);
+				ret = global::Foundation.NSArray.ArrayFromHandleFunc<global::CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")), NSValue.ToCGPoint, false);
 			} else {
-				ret = global::Foundation.NSArray.ArrayFromHandleFunc<CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")), NSValue.ToCGPoint, false);
+				ret = global::Foundation.NSArray.ArrayFromHandleFunc<global::CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")), NSValue.ToCGPoint, false);
 			}
 			GC.KeepAlive (this);
 			return ret;
@@ -637,7 +637,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial AVFoundation.AVCaptureReactionType ReactionType
+	public virtual partial global::AVFoundation.AVCaptureReactionType ReactionType
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -645,7 +645,7 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			AVFoundation.AVCaptureReactionType ret;
+			global::AVFoundation.AVCaptureReactionType ret;
 			if (IsDirectBinding) {
 				ret = global::AVFoundation.AVCaptureReactionTypeExtensions.GetValue (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("canDraw")));
 			} else {
@@ -670,7 +670,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial Foundation.NSMetadataItem[] Results
+	public virtual partial global::Foundation.NSMetadataItem[] Results
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -678,11 +678,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			Foundation.NSMetadataItem[] ret;
+			global::Foundation.NSMetadataItem[] ret;
 			if (IsDirectBinding) {
-				ret = global::CoreFoundation.CFArray.ArrayFromHandle<Foundation.NSMetadataItem> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("results")))!;
+				ret = global::CoreFoundation.CFArray.ArrayFromHandle<global::Foundation.NSMetadataItem> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("results")))!;
 			} else {
-				ret = global::CoreFoundation.CFArray.ArrayFromHandle<Foundation.NSMetadataItem> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("results")))!;
+				ret = global::CoreFoundation.CFArray.ArrayFromHandle<global::Foundation.NSMetadataItem> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("results")))!;
 			}
 			GC.KeepAlive (this);
 			return ret;
@@ -694,7 +694,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial CoreGraphics.CGSize Size
+	public virtual partial global::CoreGraphics.CGSize Size
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -702,7 +702,7 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			CoreGraphics.CGSize ret;
+			global::CoreGraphics.CGSize ret;
 			if (IsDirectBinding) {
 				ret = global::ObjCRuntime.Messaging.CGSize_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("size"));
 			} else {
@@ -718,7 +718,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial nuint[] Sizes
+	public virtual partial UIntPtr[] Sizes
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -726,7 +726,7 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			nuint[] ret;
+			UIntPtr[] ret;
 			if (IsDirectBinding) {
 				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("sizes"));
 			} else {
@@ -742,7 +742,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial Foundation.NSObject? WeakDelegate
+	public virtual partial global::Foundation.NSObject? WeakDelegate
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -750,11 +750,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			Foundation.NSObject? ret;
+			global::Foundation.NSObject? ret;
 			if (IsDirectBinding) {
-				ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSObject> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("delegate")));
+				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSObject> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("delegate")));
 			} else {
-				ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSObject> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("delegate")));
+				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSObject> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("delegate")));
 			}
 			GC.KeepAlive (this);
 			return ret;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
@@ -122,7 +122,7 @@ public partial class PropertyTests
 	static readonly global::ObjCRuntime.NativeHandle selSetCenter_XHandle = global::ObjCRuntime.Selector.GetHandle ("setCenter:");
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	static readonly global::ObjCRuntime.NativeHandle class_ptr = Class.GetHandle ("PropertyTests");
+	static readonly global::ObjCRuntime.NativeHandle class_ptr = global::ObjCRuntime.Class.GetHandle ("PropertyTests");
 
 	/// <summary>The Objective-C class handle for this class.</summary>
 	/// <value>The pointer to the Objective-C class.</value>
@@ -137,7 +137,7 @@ public partial class PropertyTests
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[DesignatedInitializer]
 	[Export ("init")]
-	public PropertyTests () : base (NSObjectFlag.Empty)
+	public PropertyTests () : base (global::Foundation.NSObjectFlag.Empty)
 	{
 		if (IsDirectBinding)
 			InitializeHandle (global::ObjCRuntime.Messaging.IntPtr_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("init")), "init");
@@ -192,7 +192,7 @@ public partial class PropertyTests
 	/// </remarks>
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	protected PropertyTests (NSObjectFlag t) : base (t) {}
+	protected PropertyTests (global::Foundation.NSObjectFlag t) : base (t) {}
 
 	/// <summary>A constructor used when creating managed representations of unmanaged objects. Called by the runtime.</summary>
 	/// <param name="handle">Pointer (handle) to the unmanaged object.</param>
@@ -211,7 +211,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public static partial Foundation.NSCharacterSet Alphanumerics
+	public static partial global::Foundation.NSCharacterSet Alphanumerics
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -219,11 +219,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			Foundation.NSCharacterSet ret;
+			global::Foundation.NSCharacterSet ret;
 			if (IsDirectBinding) {
-				ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSCharacterSet> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("alphanumericCharacterSet")))!;
+				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSCharacterSet> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("alphanumericCharacterSet")))!;
 			} else {
-				ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSCharacterSet> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("alphanumericCharacterSet")))!;
+				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSCharacterSet> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("alphanumericCharacterSet")))!;
 			}
 			GC.KeepAlive (this);
 			return ret;
@@ -235,7 +235,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial Foundation.NSAttributedString AttributedStringByInflectingString
+	public virtual partial global::Foundation.NSAttributedString AttributedStringByInflectingString
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -243,11 +243,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			Foundation.NSAttributedString ret;
+			global::Foundation.NSAttributedString ret;
 			if (IsDirectBinding) {
-				ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSAttributedString> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("attributedStringByInflectingString")))!;
+				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSAttributedString> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("attributedStringByInflectingString")))!;
 			} else {
-				ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSAttributedString> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("attributedStringByInflectingString")))!;
+				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSAttributedString> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("attributedStringByInflectingString")))!;
 			}
 			GC.KeepAlive (this);
 			return ret;
@@ -292,7 +292,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial CoreGraphics.CGPoint Center
+	public virtual partial global::CoreGraphics.CGPoint Center
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -300,7 +300,7 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			CoreGraphics.CGPoint ret;
+			global::CoreGraphics.CGPoint ret;
 			if (IsDirectBinding) {
 				ret = NSValue.ToCGPoint (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")));
 			} else {
@@ -439,7 +439,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial nfloat LineSpacing
+	public virtual partial global::CompareGeneratedCode.CompareGeneratedCode.netmodule..nfloat LineSpacing
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -447,7 +447,7 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			nfloat ret;
+			global::CompareGeneratedCode.CompareGeneratedCode.netmodule..nfloat ret;
 			if (IsDirectBinding) {
 				ret = global::ObjCRuntime.Messaging.nfloat_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("lineSpacing"));
 			} else {
@@ -472,7 +472,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	internal virtual partial Foundation.NSLocale Locale
+	internal virtual partial global::Foundation.NSLocale Locale
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -480,11 +480,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			Foundation.NSLocale ret;
+			global::Foundation.NSLocale ret;
 			if (IsDirectBinding) {
-				ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSLocale> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("locale")))!;
+				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSLocale> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("locale")))!;
 			} else {
-				ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSLocale> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("locale")))!;
+				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSLocale> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("locale")))!;
 			}
 			GC.KeepAlive (this);
 			return ret;
@@ -505,7 +505,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial CoreGraphics.CGPoint[] Location
+	public virtual partial global::CoreGraphics.CGPoint[] Location
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -513,11 +513,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			CoreGraphics.CGPoint[] ret;
+			global::CoreGraphics.CGPoint[] ret;
 			if (IsDirectBinding) {
-				ret = global::Foundation.NSArray.ArrayFromHandleFunc<CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")), NSValue.ToCGPoint, false);
+				ret = global::Foundation.NSArray.ArrayFromHandleFunc<global::CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")), NSValue.ToCGPoint, false);
 			} else {
-				ret = global::Foundation.NSArray.ArrayFromHandleFunc<CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")), NSValue.ToCGPoint, false);
+				ret = global::Foundation.NSArray.ArrayFromHandleFunc<global::CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")), NSValue.ToCGPoint, false);
 			}
 			GC.KeepAlive (this);
 			return ret;
@@ -637,7 +637,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial AVFoundation.AVCaptureReactionType ReactionType
+	public virtual partial global::AVFoundation.AVCaptureReactionType ReactionType
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -645,7 +645,7 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			AVFoundation.AVCaptureReactionType ret;
+			global::AVFoundation.AVCaptureReactionType ret;
 			if (IsDirectBinding) {
 				ret = global::AVFoundation.AVCaptureReactionTypeExtensions.GetValue (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("canDraw")));
 			} else {
@@ -670,7 +670,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial Foundation.NSMetadataItem[] Results
+	public virtual partial global::Foundation.NSMetadataItem[] Results
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -678,11 +678,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			Foundation.NSMetadataItem[] ret;
+			global::Foundation.NSMetadataItem[] ret;
 			if (IsDirectBinding) {
-				ret = global::CoreFoundation.CFArray.ArrayFromHandle<Foundation.NSMetadataItem> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("results")))!;
+				ret = global::CoreFoundation.CFArray.ArrayFromHandle<global::Foundation.NSMetadataItem> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("results")))!;
 			} else {
-				ret = global::CoreFoundation.CFArray.ArrayFromHandle<Foundation.NSMetadataItem> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("results")))!;
+				ret = global::CoreFoundation.CFArray.ArrayFromHandle<global::Foundation.NSMetadataItem> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("results")))!;
 			}
 			GC.KeepAlive (this);
 			return ret;
@@ -694,7 +694,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial CoreGraphics.CGSize Size
+	public virtual partial global::CoreGraphics.CGSize Size
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -702,7 +702,7 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			CoreGraphics.CGSize ret;
+			global::CoreGraphics.CGSize ret;
 			if (IsDirectBinding) {
 				ret = global::ObjCRuntime.Messaging.CGSize_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("size"));
 			} else {
@@ -718,7 +718,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial nuint[] Sizes
+	public virtual partial UIntPtr[] Sizes
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -726,7 +726,7 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			nuint[] ret;
+			UIntPtr[] ret;
 			if (IsDirectBinding) {
 				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("sizes"));
 			} else {
@@ -742,7 +742,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial Foundation.NSObject? WeakDelegate
+	public virtual partial global::Foundation.NSObject? WeakDelegate
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -750,11 +750,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			Foundation.NSObject? ret;
+			global::Foundation.NSObject? ret;
 			if (IsDirectBinding) {
-				ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSObject> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("delegate")));
+				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSObject> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("delegate")));
 			} else {
-				ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSObject> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("delegate")));
+				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSObject> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("delegate")));
 			}
 			GC.KeepAlive (this);
 			return ret;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/TypeInfoTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/TypeInfoTests.cs
@@ -481,7 +481,7 @@ namespace NS {
 		// ensure that the first parameter is a pointer
 		Assert.True (changes.Value.Parameters [0].Type.IsGenericType);
 		Assert.Single (changes.Value.Parameters [0].Type.TypeArguments);
-		Assert.Equal ("NS.ExampleClass", changes.Value.Parameters [0].Type.TypeArguments [0]);
+		Assert.Equal (Global ("NS.ExampleClass"), changes.Value.Parameters [0].Type.TypeArguments [0]);
 		Assert.Equal ("List", changes.Value.Parameters [0].Type.Name);
 		Assert.Equal ("System.Collections.Generic.List<NS.ExampleClass>", changes.Value.Parameters [0].Type.FullyQualifiedName);
 		Assert.Equal ("System.Collections.Generic", string.Join ('.', changes.Value.Parameters [0].Type.Namespace));

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryFieldAccessorsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryFieldAccessorsTests.cs
@@ -498,7 +498,7 @@ namespace CoreGraphics {
 ";
 
 			yield return [cmtagFieldProperty,
-				"global::ObjCRuntime.Dlfcn.GetStruct<CoreMedia.CMTag> (global::ObjCRuntime.Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\")"];
+				$"global::ObjCRuntime.Dlfcn.GetStruct<{Global ("CoreMedia.CMTag")}> (global::ObjCRuntime.Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\")"];
 
 			const string nsArrayFieldProperty = @"
 using System;
@@ -519,7 +519,7 @@ namespace CoreGraphics {
 ";
 
 			yield return [nsArrayFieldProperty,
-				"global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSArray> (global::ObjCRuntime.Dlfcn.GetIndirect (global::ObjCRuntime.Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\"))!"];
+				$"global::ObjCRuntime.Runtime.GetNSObject<{Global ("Foundation.NSArray")}> (global::ObjCRuntime.Dlfcn.GetIndirect (global::ObjCRuntime.Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\"))!"];
 
 			const string nsNumberFieldProperty = @"
 using System;
@@ -540,7 +540,7 @@ namespace CoreGraphics {
 ";
 
 			yield return [nsNumberFieldProperty,
-				"global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSNumber> (global::ObjCRuntime.Dlfcn.GetIndirect (global::ObjCRuntime.Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\"))!"];
+				$"global::ObjCRuntime.Runtime.GetNSObject<{Global ("Foundation.NSNumber")}> (global::ObjCRuntime.Dlfcn.GetIndirect (global::ObjCRuntime.Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\"))!"];
 
 			const string sbyteEnumFieldProperty = @"
 using System;
@@ -786,7 +786,7 @@ namespace CoreGraphics {
 
 			yield return [
 				cmTimeFieldProperty,
-				"*((CoreMedia.CMTime*) global::ObjCRuntime.Dlfcn.dlsym (global::ObjCRuntime.Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\"))"
+				$"*(({Global ("CoreMedia.CMTime")}*) global::ObjCRuntime.Dlfcn.dlsym (global::ObjCRuntime.Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\"))"
 			];
 
 			const string whiteFieldProperty = @"
@@ -810,7 +810,7 @@ namespace CoreGraphics {
 
 			yield return [
 				whiteFieldProperty,
-				"*((AVFoundation.AVCaptureWhiteBalanceGains*) global::ObjCRuntime.Dlfcn.dlsym (global::ObjCRuntime.Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\"))"
+				$"*(({Global ("AVFoundation.AVCaptureWhiteBalanceGains")}*) global::ObjCRuntime.Dlfcn.dlsym (global::ObjCRuntime.Libraries.CoreGraphics.Handle, \"kCGColorSpaceGenericGray\"))"
 			];
 		}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryFieldBackingVariableTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryFieldBackingVariableTests.cs
@@ -38,7 +38,7 @@ namespace CoreGraphics {
 
 			yield return [
 				nsStringFieldProperty,
-				"static Foundation.NSString? _GenericGray;"
+				$"static {Global ("Foundation.NSString")}? _GenericGray;"
 			];
 
 			const string byteFieldProperty = @"
@@ -485,6 +485,7 @@ namespace CoreGraphics {
 using System;
 using Foundation;
 using ObjCBindings;
+using nfloat = System.Runtime.InteropServices.NFloat;
 
 namespace CoreGraphics {
 
@@ -500,7 +501,7 @@ namespace CoreGraphics {
 
 			yield return [
 				nfloatFieldProperty,
-				"static nfloat? _GenericGray;"
+				$"static {Global ("System.Runtime.InteropServices.NFloat")} _GenericGray;"
 			];
 
 			const string cgsizeFieldProperty = @"
@@ -523,7 +524,7 @@ namespace CoreGraphics {
 
 			yield return [
 				cgsizeFieldProperty,
-				"static CoreGraphics.CGSize _GenericGray;"
+				$"static {Global ("CoreGraphics.CGSize")} _GenericGray;"
 			];
 
 			const string cmtagFieldProperty = @"
@@ -546,7 +547,7 @@ namespace CoreGraphics {
 
 			yield return [
 				cmtagFieldProperty,
-				"static CoreMedia.CMTag _GenericGray;"
+				$"static {Global ("CoreMedia.CMTag")} _GenericGray;"
 			];
 
 			const string nsArrayFieldProperty = @"
@@ -569,7 +570,7 @@ namespace CoreGraphics {
 
 			yield return [
 				nsArrayFieldProperty,
-				"static Foundation.NSArray? _GenericGray;"
+				$"static {Global ("Foundation.NSArray")}? _GenericGray;"
 			];
 
 			const string nsNumberFieldProperty = @"
@@ -592,7 +593,7 @@ namespace CoreGraphics {
 
 			yield return [
 				nsNumberFieldProperty,
-				"static Foundation.NSNumber? _GenericGray;"
+				$"static {Global ("Foundation.NSNumber")}? _GenericGray;"
 			];
 
 			const string enumFieldProperty = @"
@@ -620,7 +621,7 @@ namespace CoreGraphics {
 
 			yield return [
 				enumFieldProperty,
-				"static CoreGraphics.CGColorSpaceGenericGray _GenericGray;"
+				$"static {Global ("CoreGraphics.CGColorSpaceGenericGray")} _GenericGray;"
 			];
 		}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryPropertyTests.cs
@@ -10,6 +10,7 @@ using ObjCRuntime;
 using Xunit;
 using static Microsoft.Macios.Generator.Emitters.BindingSyntaxFactory;
 using static Microsoft.Macios.Generator.Tests.TestDataFactory;
+using static  Microsoft.Macios.Generator.Tests.BaseGeneratorTestClass;
 
 namespace Microsoft.Macios.Generator.Tests.Emitters;
 
@@ -215,8 +216,8 @@ public class BindingSyntaxFactoryPropertyTests {
 
 			yield return [
 				property,
-				"ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSObject> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))!",
-				"ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSObject> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))!"
+				$"ret = global::ObjCRuntime.Runtime.GetNSObject<{Global ("Foundation.NSObject")}> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))!",
+				$"ret = global::ObjCRuntime.Runtime.GetNSObject<{Global ("Foundation.NSObject")}> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))!"
 			];
 
 			property = new Property (
@@ -240,8 +241,8 @@ public class BindingSyntaxFactoryPropertyTests {
 
 			yield return [
 				property,
-				"ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSObject> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))",
-				"ret = global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSObject> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))"
+				$"ret = global::ObjCRuntime.Runtime.GetNSObject<{Global ("Foundation.NSObject")}> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))",
+				$"ret = global::ObjCRuntime.Runtime.GetNSObject<{Global ("Foundation.NSObject")}> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))"
 			];
 
 			property = new Property (
@@ -265,8 +266,8 @@ public class BindingSyntaxFactoryPropertyTests {
 
 			yield return [
 				property,
-				"ret = global::CoreFoundation.CFArray.ArrayFromHandle<Foundation.NSObject> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))!",
-				"ret = global::CoreFoundation.CFArray.ArrayFromHandle<Foundation.NSObject> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))!"
+				$"ret = global::CoreFoundation.CFArray.ArrayFromHandle<{Global ("Foundation.NSObject")}> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))!",
+				$"ret = global::CoreFoundation.CFArray.ArrayFromHandle<{Global ("Foundation.NSObject")}> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))!"
 			];
 
 			property = new Property (
@@ -473,8 +474,8 @@ public class BindingSyntaxFactoryPropertyTests {
 
 			yield return [
 				property,
-				"ret = global::Foundation.NSArray.ArrayFromHandleFunc<CoreAnimation.CATransform3D> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")), NSValue.ToCATransform3D, false)",
-				"ret = global::Foundation.NSArray.ArrayFromHandleFunc<CoreAnimation.CATransform3D> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")), NSValue.ToCATransform3D, false)",
+				$"ret = global::Foundation.NSArray.ArrayFromHandleFunc<{Global ("CoreAnimation.CATransform3D")}> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")), NSValue.ToCATransform3D, false)",
+				$"ret = global::Foundation.NSArray.ArrayFromHandleFunc<{Global ("CoreAnimation.CATransform3D")}> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")), NSValue.ToCATransform3D, false)",
 			];
 
 			property = new Property (
@@ -499,8 +500,8 @@ public class BindingSyntaxFactoryPropertyTests {
 
 			yield return [
 				property,
-				"ret = global::Foundation.NSArray.ArrayFromHandleFunc<CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")), NSValue.ToCGPoint, false)",
-				"ret = global::Foundation.NSArray.ArrayFromHandleFunc<CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")), NSValue.ToCGPoint, false)",
+				$"ret = global::Foundation.NSArray.ArrayFromHandleFunc<{Global ("CoreGraphics.CGPoint")}> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")), NSValue.ToCGPoint, false)",
+				$"ret = global::Foundation.NSArray.ArrayFromHandleFunc<{Global ("CoreGraphics.CGPoint")}> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")), NSValue.ToCGPoint, false)",
 			];
 		}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -7,10 +7,12 @@ using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Extensions;
 using Xunit;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using static Microsoft.Macios.Generator.Emitters.BindingSyntaxFactory;
 using static Microsoft.Macios.Generator.Tests.TestDataFactory;
+using static Microsoft.Macios.Generator.Tests.BaseGeneratorTestClass;
 using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
 
 namespace Microsoft.Macios.Generator.Tests.Emitters;
@@ -349,14 +351,14 @@ public class BindingSyntaxFactoryRuntimeTests {
 		public IEnumerator<object []> GetEnumerator ()
 		{
 			yield return [
-				"int",
+				"int".GetIdentifierName ([]),
 				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1"))),
 				"global::Foundation.NSArray.ArrayFromHandleFunc<int> (arg1)"
 			];
 
 			yield return [
-				"string",
+				"string".GetIdentifierName ([]),
 				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1")),
 					Argument (IdentifierName ("arg2")),
@@ -370,7 +372,7 @@ public class BindingSyntaxFactoryRuntimeTests {
 
 	[Theory]
 	[ClassData (typeof (TestDataNSArrayFromHandleFunc))]
-	void NSArrayFromHandleFuncTests (string returnType, ImmutableArray<ArgumentSyntax> arguments, string expectedDeclaration)
+	void NSArrayFromHandleFuncTests (TypeSyntax returnType, ImmutableArray<ArgumentSyntax> arguments, string expectedDeclaration)
 	{
 		var declaration = NSArrayFromHandleFunc (returnType, arguments);
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
@@ -569,41 +571,41 @@ public class BindingSyntaxFactoryRuntimeTests {
 		public IEnumerator<object []> GetEnumerator ()
 		{
 			yield return [
-				"NSString",
+				"NSString".GetIdentifierName (["Foundation"]),
 				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1"))),
 				false,
-				"global::ObjCRuntime.Runtime.GetNSObject<NSString> (arg1)"
+				$"global::ObjCRuntime.Runtime.GetNSObject<{Global ("Foundation.NSString")}> (arg1)"
 			];
 
 			yield return [
-				"NSString",
+				"NSString".GetIdentifierName (["Foundation"]),
 				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1"))),
 				true,
-				"global::ObjCRuntime.Runtime.GetNSObject<NSString> (arg1)!"
+				$"global::ObjCRuntime.Runtime.GetNSObject<{Global ("Foundation.NSString")}> (arg1)!"
 			];
 
 			yield return [
-				"NSNumber",
+				"NSNumber".GetIdentifierName (["Foundation"]),
 				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1")),
 					Argument (IdentifierName ("arg2")),
 					Argument (IdentifierName ("arg3"))
 				),
 				false,
-				"global::ObjCRuntime.Runtime.GetNSObject<NSNumber> (arg1, arg2, arg3)"
+				$"global::ObjCRuntime.Runtime.GetNSObject<{Global ("Foundation.NSNumber")}> (arg1, arg2, arg3)"
 			];
 
 			yield return [
-				"NSNumber",
+				"NSNumber".GetIdentifierName (["Foundation"]),
 				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1")),
 					Argument (IdentifierName ("arg2")),
 					Argument (IdentifierName ("arg3"))
 				),
 				true,
-				"global::ObjCRuntime.Runtime.GetNSObject<NSNumber> (arg1, arg2, arg3)!"
+				$"global::ObjCRuntime.Runtime.GetNSObject<{Global ("Foundation.NSNumber")}> (arg1, arg2, arg3)!"
 			];
 		}
 
@@ -612,7 +614,7 @@ public class BindingSyntaxFactoryRuntimeTests {
 
 	[Theory]
 	[ClassData (typeof (TestDataGetNSObject))]
-	void GetNSObjectTests (string nsObjecttype, ImmutableArray<ArgumentSyntax> arguments, bool suppressNullable, string expectedDeclaration)
+	void GetNSObjectTests (TypeSyntax nsObjecttype, ImmutableArray<ArgumentSyntax> arguments, bool suppressNullable, string expectedDeclaration)
 	{
 		var declaration = GetNSObject (nsObjecttype, arguments, suppressNullable);
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
@@ -622,41 +624,41 @@ public class BindingSyntaxFactoryRuntimeTests {
 		public IEnumerator<object []> GetEnumerator ()
 		{
 			yield return [
-				"NSString",
+				"NSString".GetIdentifierName (["Foundation"]),
 				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1"))),
 				false,
-				"global::ObjCRuntime.Runtime.GetINativeObject<NSString> (arg1)"
+				$"global::ObjCRuntime.Runtime.GetINativeObject<{Global ("Foundation.NSString")}> (arg1)"
 			];
 
 			yield return [
-				"NSString",
+				"NSString".GetIdentifierName (["Foundation"]),
 				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1"))),
 				true,
-				"global::ObjCRuntime.Runtime.GetINativeObject<NSString> (arg1)!"
+				$"global::ObjCRuntime.Runtime.GetINativeObject<{Global ("Foundation.NSString")}> (arg1)!"
 			];
 
 			yield return [
-				"NSNumber",
+				"NSNumber".GetIdentifierName (["Foundation"]),
 				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1")),
 					Argument (IdentifierName ("arg2")),
 					Argument (IdentifierName ("arg3"))
 				),
 				false,
-				"global::ObjCRuntime.Runtime.GetINativeObject<NSNumber> (arg1, arg2, arg3)"
+				$"global::ObjCRuntime.Runtime.GetINativeObject<{Global ("Foundation.NSNumber")}> (arg1, arg2, arg3)"
 			];
 
 			yield return [
-				"NSNumber",
+				"NSNumber".GetIdentifierName (["Foundation"]),
 				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1")),
 					Argument (IdentifierName ("arg2")),
 					Argument (IdentifierName ("arg3"))
 				),
 				true,
-				"global::ObjCRuntime.Runtime.GetINativeObject<NSNumber> (arg1, arg2, arg3)!"
+				$"global::ObjCRuntime.Runtime.GetINativeObject<{Global ("Foundation.NSNumber")}> (arg1, arg2, arg3)!"
 			];
 		}
 
@@ -665,7 +667,7 @@ public class BindingSyntaxFactoryRuntimeTests {
 
 	[Theory]
 	[ClassData (typeof (TestGetINativeObject))]
-	void GetINativeObjectTests (string iNativeObject, ImmutableArray<ArgumentSyntax> arguments, bool suppressNullable, string expectedDeclaration)
+	void GetINativeObjectTests (TypeSyntax iNativeObject, ImmutableArray<ArgumentSyntax> arguments, bool suppressNullable, string expectedDeclaration)
 	{
 		var declaration = GetINativeObject (iNativeObject, arguments, suppressNullable);
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
@@ -770,20 +772,20 @@ public class BindingSyntaxFactoryRuntimeTests {
 		public IEnumerator<object []> GetEnumerator ()
 		{
 			yield return [
-				"NSObject",
+				"NSObject".GetIdentifierName (["Foundation"]),
 				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1"))),
-				"global::CoreFoundation.CFArray.ArrayFromHandle<NSObject> (arg1)",
+				$"global::CoreFoundation.CFArray.ArrayFromHandle<{Global ("Foundation.NSObject")}> (arg1)",
 			];
 
 			yield return [
-				"NSString",
+				"NSString".GetIdentifierName (["Foundation"]),
 				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1")),
 					Argument (IdentifierName ("arg2")),
 					Argument (IdentifierName ("arg3"))
 				),
-				"global::CoreFoundation.CFArray.ArrayFromHandle<NSString> (arg1, arg2, arg3)",
+				$"global::CoreFoundation.CFArray.ArrayFromHandle<{Global ("Foundation.NSString")}> (arg1, arg2, arg3)",
 			];
 		}
 
@@ -792,7 +794,7 @@ public class BindingSyntaxFactoryRuntimeTests {
 
 	[Theory]
 	[ClassData (typeof (TestDataGetCFArrayFromHandle))]
-	void GetCFArrayFromHandleTests (string objectType, ImmutableArray<ArgumentSyntax> arguments, string expectedDeclaration)
+	void GetCFArrayFromHandleTests (TypeSyntax objectType, ImmutableArray<ArgumentSyntax> arguments, string expectedDeclaration)
 	{
 		var declaration = GetCFArrayFromHandle (objectType, arguments);
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
@@ -802,20 +804,20 @@ public class BindingSyntaxFactoryRuntimeTests {
 		public IEnumerator<object []> GetEnumerator ()
 		{
 			yield return [
-				"NSObject",
+				"NSObject".GetIdentifierName (["Foundation"]),
 				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1"))),
-				"global::Foundation.NSArray.ArrayFromHandle<NSObject> (arg1)",
+				$"global::Foundation.NSArray.ArrayFromHandle<{Global ("Foundation.NSObject")}> (arg1)",
 			];
 
 			yield return [
-				"NSString",
+				"NSString".GetIdentifierName (["Foundation"]),
 				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1")),
 					Argument (IdentifierName ("arg2")),
 					Argument (IdentifierName ("arg3"))
 				),
-				"global::Foundation.NSArray.ArrayFromHandle<NSString> (arg1, arg2, arg3)",
+				$"global::Foundation.NSArray.ArrayFromHandle<{Global ("Foundation.NSString")}> (arg1, arg2, arg3)",
 			];
 		}
 
@@ -824,7 +826,7 @@ public class BindingSyntaxFactoryRuntimeTests {
 
 	[Theory]
 	[ClassData (typeof (TestDataGetNSArrayFromHandle))]
-	void GetNSArrayFromHandleTests (string objectType, ImmutableArray<ArgumentSyntax> arguments, string expectedDeclaration)
+	void GetNSArrayFromHandleTests (TypeSyntax objectType, ImmutableArray<ArgumentSyntax> arguments, string expectedDeclaration)
 	{
 		var declaration = GetNSArrayFromHandle (objectType, arguments);
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
@@ -896,7 +898,7 @@ public class BindingSyntaxFactoryRuntimeTests {
 	[ClassData (typeof (TestDataGetIdentifierNameTests))]
 	void GetIdentifierNameTests (string []? @namespace, string @class, bool isGlobal, string expectedDeclaration)
 	{
-		var declaration = GetIdentifierName (@namespace, @class, isGlobal);
+		var declaration = @class.GetIdentifierName (@namespace, isGlobal);
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
 	}
 
@@ -904,20 +906,20 @@ public class BindingSyntaxFactoryRuntimeTests {
 		public IEnumerator<object []> GetEnumerator ()
 		{
 			yield return [
-				"NSObject",
+				"NSObject".GetIdentifierName (["Foundation"]),
 				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1"))
 				),
-				"global::System.Runtime.CompilerServices.Unsafe.AsRef<NSObject> (arg1)"
+				$"global::System.Runtime.CompilerServices.Unsafe.AsRef<{Global ("Foundation.NSObject")}> (arg1)"
 			];
 
 			yield return [
-				"NSString",
+				"NSString".GetIdentifierName (["Foundation"]),
 				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1")),
 					Argument (IdentifierName ("arg2")),
 					Argument (IdentifierName ("arg3"))),
-				"global::System.Runtime.CompilerServices.Unsafe.AsRef<NSString> (arg1, arg2, arg3)"
+				$"global::System.Runtime.CompilerServices.Unsafe.AsRef<{Global ("Foundation.NSString")}> (arg1, arg2, arg3)"
 			];
 		}
 
@@ -926,7 +928,7 @@ public class BindingSyntaxFactoryRuntimeTests {
 
 	[Theory]
 	[ClassData (typeof (TestDataAsRefTests))]
-	void AsRefTests (string objectType, ImmutableArray<ArgumentSyntax> arguments, string expectedDeclaration)
+	void AsRefTests (TypeSyntax objectType, ImmutableArray<ArgumentSyntax> arguments, string expectedDeclaration)
 	{
 		var declaration = AsRef (objectType, arguments);
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
@@ -936,20 +938,20 @@ public class BindingSyntaxFactoryRuntimeTests {
 		public IEnumerator<object []> GetEnumerator ()
 		{
 			yield return [
-				"MyDelegateType",
+				"MyDelegateType".GetIdentifierName (["NS"]),
 				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1"))
 				),
-				"global::System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<MyDelegateType> (arg1)"
+				$"global::System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<{Global ("NS.MyDelegateType")}> (arg1)"
 			];
 
 			yield return [
-				"Action<string>",
+				"Action<string>".GetIdentifierName (["System"]),
 				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1")),
 					Argument (IdentifierName ("arg2")),
 					Argument (IdentifierName ("arg3"))),
-				"global::System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<Action<string>> (arg1, arg2, arg3)"
+				$"global::System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<{Global ("System.Action<string>")}> (arg1, arg2, arg3)"
 			];
 		}
 
@@ -958,7 +960,7 @@ public class BindingSyntaxFactoryRuntimeTests {
 
 	[Theory]
 	[ClassData (typeof (TestDataGetDelegateForFunctionPointer))]
-	void GetDelegateForFunctionPointerTests (string objectType, ImmutableArray<ArgumentSyntax> arguments, string expectedDeclaration)
+	void GetDelegateForFunctionPointerTests (TypeSyntax objectType, ImmutableArray<ArgumentSyntax> arguments, string expectedDeclaration)
 	{
 		var declaration = GetDelegateForFunctionPointer (objectType, arguments);
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -328,7 +328,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				ccallbackParameter,
-				"global::System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<System.Action> (callbackParameter)"
+				$"global::System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<{Global ("System.Action")}> (callbackParameter)"
 			];
 
 			var blockParameter = @"
@@ -410,7 +410,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				nsObjectArray,
-				"global::CoreFoundation.CFArray.ArrayFromHandle<Foundation.NSObject> (nsObjectArray)!",
+				$"global::CoreFoundation.CFArray.ArrayFromHandle<{Global ("Foundation.NSObject")}> (nsObjectArray)!",
 			];
 
 			var iNativeObjectArray = @"
@@ -430,7 +430,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				iNativeObjectArray,
-				"global::Foundation.NSArray.ArrayFromHandle<CoreMedia.CMTimebase> (inativeArray)!",
+				$"global::Foundation.NSArray.ArrayFromHandle<{Global ("CoreMedia.CMTimebase")}> (inativeArray)!",
 			];
 
 			var stringArray = @"
@@ -487,7 +487,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				protocolParameter,
-				"global::ObjCRuntime.Runtime.GetINativeObject<Foundation.INSUrlConnectionDataDelegate> (protocolParameter, false)!",
+				$"global::ObjCRuntime.Runtime.GetINativeObject<{Global ("Foundation.INSUrlConnectionDataDelegate")}> (protocolParameter, false)!",
 			];
 
 			var forcedParameterOwnsFalse = @"
@@ -506,7 +506,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				forcedParameterOwnsFalse,
-				"global::ObjCRuntime.Runtime.GetINativeObject<Foundation.INSUrlConnectionDataDelegate> (forcedParameter, true, false)!",
+				$"global::ObjCRuntime.Runtime.GetINativeObject<{Global ("Foundation.INSUrlConnectionDataDelegate")}> (forcedParameter, true, false)!",
 			];
 
 			var forcedParameterOwnsTrue = @"
@@ -525,7 +525,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				forcedParameterOwnsTrue,
-				"global::ObjCRuntime.Runtime.GetINativeObject<Foundation.INSUrlConnectionDataDelegate> (forcedParameter, true, true)!",
+				$"global::ObjCRuntime.Runtime.GetINativeObject<{Global ("Foundation.INSUrlConnectionDataDelegate")}> (forcedParameter, true, true)!",
 			];
 
 			var nsObjectParameter = @"
@@ -544,7 +544,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				nsObjectParameter,
-				"global::ObjCRuntime.Runtime.GetNSObject<Foundation.NSObject> (nsObjectParameter)!",
+				$"global::ObjCRuntime.Runtime.GetNSObject<{Global ("Foundation.NSObject")}> (nsObjectParameter)!",
 			];
 
 			var iNativeParameter = @"
@@ -564,7 +564,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				iNativeParameter,
-				"global::ObjCRuntime.Runtime.GetINativeObject<CoreMedia.CMTimebase> (inativeParameter, false)!",
+				$"global::ObjCRuntime.Runtime.GetINativeObject<{Global ("CoreMedia.CMTimebase")}> (inativeParameter, false)!",
 			];
 
 			var cmSampleBuffer = @"
@@ -1941,7 +1941,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				ccallbackParameter,
-				"del (global::System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<System.Action> (callbackParameter));",
+				$"del (global::System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<{Global ("System.Action")}> (callbackParameter));",
 			];
 
 			var severalParametersConversion = @"
@@ -1959,7 +1959,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				severalParametersConversion,
-				"del (global::System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<System.Action> (callbackParameter), NIDsomeTrampolineName.Create (callbackParameter)!);",
+				$"del (global::System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<{Global ("System.Action")}> (callbackParameter), NIDsomeTrampolineName.Create (callbackParameter)!);",
 			];
 
 			var severalParametersConversionReturn = @"
@@ -1977,7 +1977,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				severalParametersConversionReturn,
-				"var ret = del (global::System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<System.Action> (callbackParameter), NIDsomeTrampolineName.Create (callbackParameter)!);",
+				$"var ret = del (global::System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<{Global ("System.Action")}> (callbackParameter), NIDsomeTrampolineName.Create (callbackParameter)!);",
 			];
 
 		}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Formatters/ConstructorFormatterTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Formatters/ConstructorFormatterTests.cs
@@ -98,7 +98,7 @@ public partial class MyClass {
 	public MyClass(MyStruct myParam);
 }
 ";
-			yield return [customParamConstructor, "public MyClass (NS.MyStruct myParam)"];
+			yield return [customParamConstructor, $"public MyClass ({Global ("NS.MyStruct")} myParam)"];
 
 			const string nullableCustomParamConstructor = @"
 using System;
@@ -115,7 +115,7 @@ public partial class MyClass {
 	public MyClass(MyStruct? myParam);
 }
 ";
-			yield return [nullableCustomParamConstructor, "public MyClass (NS.MyStruct? myParam)"];
+			yield return [nullableCustomParamConstructor, $"public MyClass ({Global ("NS.MyStruct")}? myParam)"];
 
 			const string refCustomParamConstructor = @"
 using System;
@@ -132,7 +132,7 @@ public partial class MyClass {
 	public MyClass(ref MyStruct myParam);
 }
 ";
-			yield return [refCustomParamConstructor, "public MyClass (ref NS.MyStruct myParam)"];
+			yield return [refCustomParamConstructor, $"public MyClass (ref {Global ("NS.MyStruct")} myParam)"];
 
 			const string inCustomParamConstructor = @"
 using System;
@@ -149,7 +149,7 @@ public partial class MyClass {
 	public MyClass(in MyStruct myParam);
 }
 ";
-			yield return [inCustomParamConstructor, "public MyClass (in NS.MyStruct myParam)"];
+			yield return [inCustomParamConstructor, $"public MyClass (in {Global ("NS.MyStruct")} myParam)"];
 
 			const string refReadonlyCustomParamConstructor = @"
 using System;
@@ -166,7 +166,7 @@ public partial class MyClass {
 	public MyClass(ref readonly MyStruct myParam);
 }
 ";
-			yield return [refReadonlyCustomParamConstructor, "public MyClass (ref readonly NS.MyStruct myParam)"];
+			yield return [refReadonlyCustomParamConstructor, $"public MyClass (ref readonly {Global ("NS.MyStruct")} myParam)"];
 
 			const string arrayParamConbstructor = @"
 using System;
@@ -184,7 +184,7 @@ public partial class MyClass {
 }
 ";
 
-			yield return [arrayParamConbstructor, "public MyClass (NS.MyStruct[] myParam)"];
+			yield return [arrayParamConbstructor, $"public MyClass ({Global ("NS.MyStruct")}[] myParam)"];
 
 			const string nullableArrayParamConstructor = @"
 using System;
@@ -202,7 +202,7 @@ public partial class MyClass {
 }
 ";
 
-			yield return [nullableArrayParamConstructor, "public MyClass (NS.MyStruct[]? myParam)"];
+			yield return [nullableArrayParamConstructor, $"public MyClass ({Global ("NS.MyStruct")}[]? myParam)"];
 
 			const string genericParamConstructor = @"
 using System;
@@ -216,7 +216,7 @@ public partial class MyClass {
 }
 ";
 
-			yield return [genericParamConstructor, "public MyClass (System.Collections.Generic.List<string> myParam)"];
+			yield return [genericParamConstructor, $"public MyClass ({Global ("System.Collections.Generic.List")}<string> myParam)"];
 
 			const string genericCustomParamConstructor = @"
 using System;
@@ -235,7 +235,7 @@ public partial class MyClass {
 }
 ";
 
-			yield return [genericCustomParamConstructor, "public MyClass (System.Collections.Generic.List<NS.MyStruct> myParam)"];
+			yield return [genericCustomParamConstructor, $"public MyClass ({Global ("System.Collections.Generic.List")}<{Global ("NS.MyStruct")}> myParam)"];
 
 			const string nullableGenericParamConstructor = @"
 using System;
@@ -249,7 +249,7 @@ public partial class MyClass {
 }
 ";
 
-			yield return [nullableGenericParamConstructor, "public MyClass (System.Collections.Generic.List<string>? myParam)"];
+			yield return [nullableGenericParamConstructor, $"public MyClass ({Global ("System.Collections.Generic.List")}<string>? myParam)"];
 
 			const string nullableGenericCustomParamConstructor = @"
 using System;
@@ -268,7 +268,7 @@ public partial class MyClass {
 }
 ";
 
-			yield return [nullableGenericCustomParamConstructor, "public MyClass (System.Collections.Generic.List<NS.MyStruct>? myParam)"];
+			yield return [nullableGenericCustomParamConstructor, $"public MyClass ({Global ("System.Collections.Generic.List")}<{Global ("NS.MyStruct")}>? myParam)"];
 
 			const string nullableNullableGenericParamConstructor = @"
 using System;
@@ -282,7 +282,7 @@ public partial class MyClass {
 }
 ";
 
-			yield return [nullableNullableGenericParamConstructor, "public MyClass (System.Collections.Generic.List<string?>? myParam)"];
+			yield return [nullableNullableGenericParamConstructor, $"public MyClass ({Global ("System.Collections.Generic.List")}<string?>? myParam)"];
 
 			const string nullableNullableGenericCustomParamConstructor = @"
 using System;
@@ -301,7 +301,7 @@ public partial class MyClass {
 }
 ";
 
-			yield return [nullableNullableGenericCustomParamConstructor, "public MyClass (System.Collections.Generic.List<NS.MyStruct?>? myParam)"];
+			yield return [nullableNullableGenericCustomParamConstructor, $"public MyClass ({Global ("System.Collections.Generic.List")}<{Global ("NS.MyStruct")}?>? myParam)"];
 
 
 			const string genericDictParamConstructor = @"
@@ -316,7 +316,7 @@ public partial class MyClass {
 }
 ";
 
-			yield return [genericDictParamConstructor, "public MyClass (System.Collections.Generic.Dictionary<string, string> myParam)"];
+			yield return [genericDictParamConstructor, $"public MyClass ({Global ("System.Collections.Generic.Dictionary")}<string, string> myParam)"];
 
 			const string paramsConstructor = @"
 using System;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Formatters/MethodFormatterTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Formatters/MethodFormatterTests.cs
@@ -98,7 +98,7 @@ public partial class MyClass {
 	public partial MyStruct TestMethod(string? myParam);
 }
 ";
-			yield return [customReturnMethod, "public partial NS.MyStruct TestMethod (string? myParam)"];
+			yield return [customReturnMethod, $"public partial {Global ("NS.MyStruct")} TestMethod (string? myParam)"];
 
 			const string nullableCustomReturnMethod = @"
 using System;
@@ -115,7 +115,7 @@ public partial class MyClass {
 	public partial MyStruct? TestMethod(string? myParam);
 }
 ";
-			yield return [nullableCustomReturnMethod, "public partial NS.MyStruct? TestMethod (string? myParam)"];
+			yield return [nullableCustomReturnMethod, $"public partial {Global ("NS.MyStruct")}? TestMethod (string? myParam)"];
 
 			const string customParamMethod = @"
 using System;
@@ -132,7 +132,7 @@ public partial class MyClass {
 	public partial void TestMethod(MyStruct myParam);
 }
 ";
-			yield return [customParamMethod, "public partial void TestMethod (NS.MyStruct myParam)"];
+			yield return [customParamMethod, $"public partial void TestMethod ({Global ("NS.MyStruct")} myParam)"];
 
 			const string nullableCustomParamMethod = @"
 using System;
@@ -149,7 +149,7 @@ public partial class MyClass {
 	public partial void TestMethod(MyStruct? myParam);
 }
 ";
-			yield return [nullableCustomParamMethod, "public partial void TestMethod (NS.MyStruct? myParam)"];
+			yield return [nullableCustomParamMethod, $"public partial void TestMethod ({Global ("NS.MyStruct")}? myParam)"];
 
 			const string refCustomParamMethod = @"
 using System;
@@ -166,7 +166,7 @@ public partial class MyClass {
 	public partial void TestMethod(ref MyStruct myParam);
 }
 ";
-			yield return [refCustomParamMethod, "public partial void TestMethod (ref NS.MyStruct myParam)"];
+			yield return [refCustomParamMethod, $"public partial void TestMethod (ref {Global ("NS.MyStruct")} myParam)"];
 
 			const string outCustomParamMethod = @"
 using System;
@@ -183,7 +183,7 @@ public partial class MyClass {
 	public partial void TestMethod(out MyStruct myParam);
 }
 ";
-			yield return [outCustomParamMethod, "public partial void TestMethod (out NS.MyStruct myParam)"];
+			yield return [outCustomParamMethod, $"public partial void TestMethod (out {Global ("NS.MyStruct")} myParam)"];
 
 			const string inCustomParamMethod = @"
 using System;
@@ -200,7 +200,7 @@ public partial class MyClass {
 	public partial void TestMethod(in MyStruct myParam);
 }
 ";
-			yield return [inCustomParamMethod, "public partial void TestMethod (in NS.MyStruct myParam)"];
+			yield return [inCustomParamMethod, $"public partial void TestMethod (in {Global ("NS.MyStruct")} myParam)"];
 
 			const string refReadonlyCustomParamMethod = @"
 using System;
@@ -217,7 +217,7 @@ public partial class MyClass {
 	public partial void TestMethod(ref readonly MyStruct myParam);
 }
 ";
-			yield return [refReadonlyCustomParamMethod, "public partial void TestMethod (ref readonly NS.MyStruct myParam)"];
+			yield return [refReadonlyCustomParamMethod, $"public partial void TestMethod (ref readonly {Global ("NS.MyStruct")} myParam)"];
 
 			const string arrayParamMethod = @"
 using System;
@@ -235,7 +235,7 @@ public partial class MyClass {
 }
 ";
 
-			yield return [arrayParamMethod, "public partial void TestMethod (NS.MyStruct[] myParam)"];
+			yield return [arrayParamMethod, $"public partial void TestMethod ({Global ("NS.MyStruct")}[] myParam)"];
 
 			const string nullableArrayParamMethod = @"
 using System;
@@ -253,7 +253,7 @@ public partial class MyClass {
 }
 ";
 
-			yield return [nullableArrayParamMethod, "public partial void TestMethod (NS.MyStruct[]? myParam)"];
+			yield return [nullableArrayParamMethod, $"public partial void TestMethod ({Global ("NS.MyStruct")}[]? myParam)"];
 
 			const string genericParamMethod = @"
 using System;
@@ -267,7 +267,7 @@ public partial class MyClass {
 }
 ";
 
-			yield return [genericParamMethod, "public partial void TestMethod (System.Collections.Generic.List<string> myParam)"];
+			yield return [genericParamMethod, $"public partial void TestMethod ({Global ("System.Collections.Generic.List")}<string> myParam)"];
 
 			const string genericCustomParamMethod = @"
 using System;
@@ -286,7 +286,7 @@ public partial class MyClass {
 }
 ";
 
-			yield return [genericCustomParamMethod, "public partial void TestMethod (System.Collections.Generic.List<NS.MyStruct> myParam)"];
+			yield return [genericCustomParamMethod, $"public partial void TestMethod ({Global ("System.Collections.Generic.List")}<{Global ("NS.MyStruct")}> myParam)"];
 
 			const string nullableGenericParamMethod = @"
 using System;
@@ -300,7 +300,7 @@ public partial class MyClass {
 }
 ";
 
-			yield return [nullableGenericParamMethod, "public partial void TestMethod (System.Collections.Generic.List<string>? myParam)"];
+			yield return [nullableGenericParamMethod, $"public partial void TestMethod ({Global ("System.Collections.Generic.List")}<string>? myParam)"];
 
 			const string nullableGenericCustomParamMethod = @"
 using System;
@@ -319,7 +319,7 @@ public partial class MyClass {
 }
 ";
 
-			yield return [nullableGenericCustomParamMethod, "public partial void TestMethod (System.Collections.Generic.List<NS.MyStruct>? myParam)"];
+			yield return [nullableGenericCustomParamMethod, $"public partial void TestMethod ({Global ("System.Collections.Generic.List")}<{Global ("NS.MyStruct")}>? myParam)"];
 
 			const string nullableNullableGenericParamMethod = @"
 using System;
@@ -333,7 +333,7 @@ public partial class MyClass {
 }
 ";
 
-			yield return [nullableNullableGenericParamMethod, "public partial void TestMethod (System.Collections.Generic.List<string?>? myParam)"];
+			yield return [nullableNullableGenericParamMethod, $"public partial void TestMethod ({Global ("System.Collections.Generic.List")}<string?>? myParam)"];
 
 			const string nullableNullableGenericCustomParamMethod = @"
 using System;
@@ -352,7 +352,7 @@ public partial class MyClass {
 }
 ";
 
-			yield return [nullableNullableGenericCustomParamMethod, "public partial void TestMethod (System.Collections.Generic.List<NS.MyStruct?>? myParam)"];
+			yield return [nullableNullableGenericCustomParamMethod, $"public partial void TestMethod ({Global ("System.Collections.Generic.List")}<{Global ("NS.MyStruct")}?>? myParam)"];
 
 			const string genericDictParamMethod = @"
 using System;
@@ -366,7 +366,7 @@ public partial class MyClass {
 }
 ";
 
-			yield return [genericDictParamMethod, "public partial void TestMethod (System.Collections.Generic.Dictionary<string, string> myParam)"];
+			yield return [genericDictParamMethod, $"public partial void TestMethod ({Global ("System.Collections.Generic.Dictionary")}<string, string> myParam)"];
 
 			const string genericReturnMethod = @"
 using System;
@@ -380,7 +380,7 @@ public partial class MyClass {
 }
 ";
 
-			yield return [genericReturnMethod, "public partial System.Collections.Generic.List<string> TestMethod ()"];
+			yield return [genericReturnMethod, $"public partial {Global ("System.Collections.Generic.List")}<string> TestMethod ()"];
 
 			const string genericCustomReturnMethod = @"
 using System;
@@ -399,7 +399,7 @@ public partial class MyClass {
 }
 ";
 
-			yield return [genericCustomReturnMethod, "public partial System.Collections.Generic.List<NS.MyStruct> TestMethod ()"];
+			yield return [genericCustomReturnMethod, $"public partial {Global ("System.Collections.Generic.List")}<{Global ("NS.MyStruct")}> TestMethod ()"];
 
 			const string nullableGenericReturnMethod = @"
 using System;
@@ -413,7 +413,7 @@ public partial class MyClass {
 }
 ";
 
-			yield return [nullableGenericReturnMethod, "public partial System.Collections.Generic.List<string>? TestMethod ()"];
+			yield return [nullableGenericReturnMethod, $"public partial {Global ("System.Collections.Generic.List")}<string>? TestMethod ()"];
 
 			const string nullableNullableGenericReturnMethod = @"
 using System;
@@ -427,7 +427,7 @@ public partial class MyClass {
 }
 ";
 
-			yield return [nullableNullableGenericReturnMethod, "public partial System.Collections.Generic.List<string?>? TestMethod ()"];
+			yield return [nullableNullableGenericReturnMethod, $"public partial {Global ("System.Collections.Generic.List")}<string?>? TestMethod ()"];
 
 			const string paramsMethod = @"
 using System;
@@ -453,7 +453,7 @@ namespace NS {
 	}
 }
 ";
-			yield return [actionNoParam, "public partial void TestMethod (System.Action cb)"];
+			yield return [actionNoParam, $"public partial void TestMethod ({Global ("System.Action")} cb)"];
 
 			const string actionSingleParam = @"
 using System;
@@ -464,7 +464,7 @@ namespace NS {
 	}
 }
 ";
-			yield return [actionSingleParam, "public partial void TestMethod (System.Action<string> cb)"];
+			yield return [actionSingleParam, $"public partial void TestMethod ({Global ("System.Action")}<string> cb)"];
 
 			const string actionSingleNullableParam = @"
 using System;
@@ -475,7 +475,7 @@ namespace NS {
 	}
 }
 ";
-			yield return [actionSingleNullableParam, "public partial void TestMethod (System.Action<string?> cb)"];
+			yield return [actionSingleNullableParam, $"public partial void TestMethod ({Global ("System.Action")}<string?> cb)"];
 
 			const string actionMultiParam = @"
 using System;
@@ -486,7 +486,7 @@ namespace NS {
 	}
 }
 ";
-			yield return [actionMultiParam, "public partial void TestMethod (System.Action<string, string> cb)"];
+			yield return [actionMultiParam, $"public partial void TestMethod ({Global ("System.Action")}<string, string> cb)"];
 
 			const string funcSingleParam = @"
 using System;
@@ -497,7 +497,7 @@ namespace NS {
 	}
 }
 ";
-			yield return [funcSingleParam, "public partial void TestMethod (System.Func<string, string> cb)"];
+			yield return [funcSingleParam, $"public partial void TestMethod ({Global ("System.Func")}<string, string> cb)"];
 
 			const string customDelegate = @"
 using System;
@@ -510,7 +510,7 @@ namespace NS {
 	}
 }
 ";
-			yield return [customDelegate, "public partial void TestMethod (NS.MyClass.Callback cb)"];
+			yield return [customDelegate, $"public partial void TestMethod ({Global ("NS.MyClass.Callback")} cb)"];
 
 			const string intReturnMethod = @"
 using System;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Formatters/PropertyFormatterTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Formatters/PropertyFormatterTests.cs
@@ -76,7 +76,7 @@ public partial class MyClass {
 	public partial MyStruct? Property { get; set; }
 }
 ";
-			yield return [nullableStructProperty, "public partial NS.MyStruct? Property"];
+			yield return [nullableStructProperty, $"public partial {Global ("NS.MyStruct")}? Property"];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/SmartEnum/Data/ExpectedGKError.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/SmartEnum/Data/ExpectedGKError.cs
@@ -14,17 +14,17 @@ public static partial class GKErrorExtensions
 {
 
 	[Field ("GKErrorDomain", "GameKit")]
-	static Foundation.NSString? _domain;
+	static $GLOBAL$Foundation.NSString? _domain;
 
 	/// <summary>Returns the error domain associated with the GameKit.GKError value</summary>
 	/// <param name="self">The enumeration value</param>
 	/// <remarks>
 	///   <para>See the <see cref="global::Foundation.NSError" /> for information on how to use the error domains when reporting errors.</para>
 	/// </remarks>
-	public static NSString? GetDomain (this GKError self)
+	public static $GLOBAL$Foundation.NSString? GetDomain (this $GLOBAL$GameKit.GKError self)
 	{
 		if (_domain is null)
-			_domain = Dlfcn.GetStringConstant (global::ObjCRuntime.Libraries.GameKit.Handle, "GKErrorDomain");
+			_domain = $GLOBAL$ObjCRuntime.Dlfcn.GetStringConstant ($GLOBAL$ObjCRuntime.Libraries.GameKit.Handle, "GKErrorDomain");
 		return _domain;
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/SmartEnum/Data/ExpectedGKErrorCustomLibrary.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/SmartEnum/Data/ExpectedGKErrorCustomLibrary.cs
@@ -14,17 +14,17 @@ public static partial class GKCustomErrorExtensions
 {
 
 	[Field ("GKErrorDomain", "/path/to/customlibrary.framework")]
-	static Foundation.NSString? _domain;
+	static $GLOBAL$Foundation.NSString? _domain;
 
 	/// <summary>Returns the error domain associated with the GameKit.GKCustomError value</summary>
 	/// <param name="self">The enumeration value</param>
 	/// <remarks>
 	///   <para>See the <see cref="global::Foundation.NSError" /> for information on how to use the error domains when reporting errors.</para>
 	/// </remarks>
-	public static NSString? GetDomain (this GKCustomError self)
+	public static $GLOBAL$Foundation.NSString? GetDomain (this $GLOBAL$GameKit.GKCustomError self)
 	{
 		if (_domain is null)
-			_domain = Dlfcn.GetStringConstant (global::ObjCRuntime.Libraries.customlibrary.Handle, "GKErrorDomain");
+			_domain = $GLOBAL$ObjCRuntime.Dlfcn.GetStringConstant ($GLOBAL$ObjCRuntime.Libraries.customlibrary.Handle, "GKErrorDomain");
 		return _domain;
 	}
 }


### PR DESCRIPTION
Upate the code generation of rgen to use the 'global::' allias based in the generator configuration. The tests classes have been updated to ensure that if we switch off the use of the alias, the tests do not need to be udpdated.