### PR TITLE
[msbuild] Don't execute the ParseDeviceSpecificBuildInformation task on Mac Catalyst.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1232,7 +1232,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			will apply to Xamarin.Mac as well.
 		-->
 		<ParseDeviceSpecificBuildInformation
-			Condition="'$(DeviceSpecificBuild)' == 'true' And '$(TargetiOSDevice)' != '' And '$(_CanDeployToDeviceOrSimulator)' == 'true' And '$(_PlatformName)' != 'macOS'"
+			Condition="'$(DeviceSpecificBuild)' == 'true' And '$(TargetiOSDevice)' != '' And '$(_CanDeployToDeviceOrSimulator)' == 'true' And '$(_PlatformName)' != 'macOS' And '$(_PlatformName)' != 'MacCatalyst'"
 			Architectures="$(TargetArchitectures)"
 			IntermediateOutputPath="$(IntermediateOutputPath)"
 			OutputPath="$(OutputPath)"

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1232,7 +1232,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			will apply to Xamarin.Mac as well.
 		-->
 		<ParseDeviceSpecificBuildInformation
-			Condition="'$(DeviceSpecificBuild)' == 'true' And '$(TargetiOSDevice)' != '' And '$(_CanDeployToDeviceOrSimulator)' == 'true' And '$(_PlatformName)' != 'macOS' And '$(_PlatformName)' != 'MacCatalyst'"
+			Condition="'$(DeviceSpecificBuild)' == 'true' And '$(TargetiOSDevice)' != '' And '$(_CanDeployToDeviceOrSimulator)' == 'true' And '$(_PlatformName)' != 'macOS'"
 			Architectures="$(TargetArchitectures)"
 			IntermediateOutputPath="$(IntermediateOutputPath)"
 			OutputPath="$(OutputPath)"

--- a/tests/dotnet/UnitTests/MauiTest.cs
+++ b/tests/dotnet/UnitTests/MauiTest.cs
@@ -12,6 +12,11 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64")]
 		public void BuildMauiApp (ApplePlatform platform, string runtimeIdentifiers)
 		{
+			BuildMauiAppImpl (platform, runtimeIdentifiers);
+		}
+
+		void BuildMauiAppImpl (ApplePlatform platform, string runtimeIdentifiers, Diagnostics<string, string?> properties = null)
+		{
 			var project = "MyMauiApp";
 			Configuration.IgnoreIfIgnoredPlatform (platform);
 
@@ -20,7 +25,7 @@ namespace Xamarin.Tests {
 
 			DotNet.InstallWorkload ("maui-tizen");
 
-			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties = GetDefaultProperties (runtimeIdentifiers, extraProperties: properties);
 			var rv = DotNet.AssertBuild (project_path, properties);
 			AssertThatLinkerExecuted (rv);
 			var infoPlistPath = GetInfoPListPath (platform, appPath);
@@ -38,6 +43,14 @@ namespace Xamarin.Tests {
 			Assert.AreEqual ("copy", trimModeValue, "TrimMode");
 			Assert.AreEqual ("None", linkModeValue, "LinkMode");
 			Assert.AreEqual ("None", mtouchLinkValue, "MtouchLink");
+		}
+
+		[TestCase (ApplePlatform.iOS, "ios-arm64")]
+		[Category ("RemoteWindows")]
+		public void BuildMauiAppOnRemoteWindows (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			Configuration.IgnoreIfNotOnWindows ();
+			BuildMauiApp (platform, runtimeIdentifiers, AddRemoteProperties ());
 		}
 	}
 }


### PR DESCRIPTION
The 'ParseDeviceSpecificBuildInformation' task is only applicable to mobile
targets (iOS and tvOS), so skip running it on Mac Catalyst (like we're already
doing for macOS).

This fixes a build error if happens to run on Mac Catalyst:

> The "ParseDeviceSpecificBuildInformation" task failed unexpectedly. System.InvalidOperationException: Invalid platform: MacCatalyst

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2484312.