### PR TITLE
[RGen] Fix bug where we converted a bool to a byte when we needed the opposite.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -135,6 +135,24 @@ static partial class BindingSyntaxFactory {
 			whenTrue: castOne.WithLeadingTrivia (Space),
 			whenFalse: castZero);
 	}
+	
+	/// <summary>
+	/// Returns the expression needed to cast a byte to a bool to be used in a call. 
+	/// </summary>
+	/// <param name="variableName">The variable to cast.</param>
+	/// <param name="typeInfo">The type information of the variable.</param>
+	/// <returns>A binary expression that casts a byte to a bool.</returns>
+	internal static BinaryExpressionSyntax CastToBool (string variableName, in TypeInfo typeInfo)
+	{
+		// with this exact space count
+		// byte != 0;
+		return BinaryExpression (
+			SyntaxKind.NotEqualsExpression,
+			IdentifierName (variableName),
+			LiteralExpression (
+				SyntaxKind.NumericLiteralExpression,
+				Literal (0))).NormalizeWhitespace (); 
+	}
 
 	/// <summary>
 	/// Return the expression needed to cast an invocation that returns a byte to a bool.

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -135,7 +135,7 @@ static partial class BindingSyntaxFactory {
 			whenTrue: castOne.WithLeadingTrivia (Space),
 			whenFalse: castZero);
 	}
-	
+
 	/// <summary>
 	/// Returns the expression needed to cast a byte to a bool to be used in a call. 
 	/// </summary>
@@ -151,7 +151,7 @@ static partial class BindingSyntaxFactory {
 			IdentifierName (variableName),
 			LiteralExpression (
 				SyntaxKind.NumericLiteralExpression,
-				Literal (0))).NormalizeWhitespace (); 
+				Literal (0))).NormalizeWhitespace ();
 	}
 
 	/// <summary>

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
@@ -278,7 +278,7 @@ static partial class BindingSyntaxFactory {
 			
 			// boolean, convert it to byte
 			{ Type.SpecialType: SpecialType.System_Boolean } 
-				=> CastToByte (parameter.Name, parameter.Type)!,
+				=> CastToBool (parameter.Name, parameter.Type)!,
 			
 			// array types
 			

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -391,7 +391,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				boolParameter,
-				"boolParameter ? (byte) 1 : (byte) 0",
+				"boolParameter != 0",
 			];
 
 			var nsObjectArray = @"


### PR DESCRIPTION
The argument conversions is from low level to high level, therefore we need to look for a bool parameter and convert the byte to a bool. Not the otherway around.