### PR TITLE
[RGen] Handle nested classes correctly.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -270,18 +270,17 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	static string GetName (ITypeSymbol symbol)
 	{
 		// before we return the name, make sure that we do not have parent types, if we do, append those to the name
-		var sb = new StringBuilder();
+		var sb = new StringBuilder ();
 		var parentSymbol = symbol.ContainingType;
 
-		while (parentSymbol is not null)
-		{
+		while (parentSymbol is not null) {
 			// add in reverse order, since we are going from the child to the parent
-			sb.Insert(0, parentSymbol.Name + ".");
+			sb.Insert (0, parentSymbol.Name + ".");
 			parentSymbol = parentSymbol.ContainingType;
 		}
 
-		sb.Append(symbol.Name);
-		return sb.ToString();
+		sb.Append (symbol.Name);
+		return sb.ToString ();
 	}
 
 	/// <summary>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -255,12 +256,32 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	static (string Name, ImmutableArray<string> Namespace) GetTypeNameAndNamespace (ITypeSymbol symbol)
 	{
 		if (symbol.SpecialType == SpecialType.None)
-			return (symbol.Name, GetNamespaceComponents (symbol));
+			return (GetName (symbol), GetNamespaceComponents (symbol));
 
 		var token = symbol.SpecialType.GetKeyword ();
 		var name = string.IsNullOrEmpty (token) ? symbol.Name : token;
 		// if we are dealing with int, uint etc.. we will ignore the namespace since it is not needed
 		return (name, []);
+	}
+
+	/// <summary>
+	/// Returns the name of the type symbol including any containing types BUT not namespaces.
+	/// </summary>
+	static string GetName (ITypeSymbol symbol)
+	{
+		// before we return the name, make sure that we do not have parent types, if we do, append those to the name
+		var sb = new StringBuilder();
+		var parentSymbol = symbol.ContainingType;
+
+		while (parentSymbol is not null)
+		{
+			// add in reverse order, since we are going from the child to the parent
+			sb.Insert(0, parentSymbol.Name + ".");
+			parentSymbol = parentSymbol.ContainingType;
+		}
+
+		sb.Append(symbol.Name);
+		return sb.ToString();
 	}
 
 	/// <summary>
@@ -270,11 +291,11 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// <returns>An immutable array with the namespace components.</returns>
 	static ImmutableArray<string> GetNamespaceComponents (ITypeSymbol symbol)
 	{
-		var namespaceSymbol = symbol.ContainingSymbol;
+		var namespaceSymbol = symbol.ContainingNamespace;
 		var components = ImmutableArray.CreateBuilder<string> ();
 		while (namespaceSymbol is not null) {
 			components.Insert (0, namespaceSymbol.Name);
-			namespaceSymbol = namespaceSymbol.ContainingSymbol;
+			namespaceSymbol = namespaceSymbol.ContainingNamespace;
 			if (namespaceSymbol is INamespaceSymbol { IsGlobalNamespace: true })
 				break;
 		}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -273,6 +273,9 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		var sb = new StringBuilder ();
 		var parentSymbol = symbol.ContainingType;
 
+		if (parentSymbol is null)
+			return symbol.Name;
+
 		while (parentSymbol is not null) {
 			// add in reverse order, since we are going from the child to the parent
 			sb.Insert (0, parentSymbol.Name + ".");

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/TypeInfoTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/TypeInfoTests.cs
@@ -645,4 +645,49 @@ namespace Example {
 		Assert.Equal ("Example.NS.ExampleClass", changes.Value.Parameters [0].Type.FullyQualifiedName);
 		Assert.Equal ("Example.NS", string.Join ('.', changes.Value.Parameters [0].Type.Namespace));
 	}
+	
+	[Theory]
+	[AllSupportedPlatforms]
+	void TypeInfoNestedCase (ApplePlatform platform)
+	{
+		var inputText = @"
+using System;
+using System.Collections.Generic;
+using ObjCRuntime;
+using System.Collections.Generic;
+
+namespace Example {
+	namespace NS {
+
+		public class MyClass {
+
+			public class ExampleClass {
+				public int Number => 0;
+			}
+
+			public int ProcessPointer (ExampleClass pointer)
+			{
+				return pointer.Number;
+			}
+		}
+	}
+}
+";
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
+		Assert.Single (syntaxTrees);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ().OfType<MethodDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		Assert.True (Method.TryCreate (declaration, semanticModel, out var changes));
+		Assert.NotNull (changes);
+		// ensure that the method has a single parameter
+		Assert.Single (changes.Value.Parameters);
+		// ensure that the first parameter is a pointer
+		Assert.False (changes.Value.Parameters [0].Type.IsGenericType);
+		Assert.Equal ("MyClass.ExampleClass", changes.Value.Parameters [0].Type.Name);
+		Assert.Equal ("Example.NS.MyClass.ExampleClass", changes.Value.Parameters [0].Type.FullyQualifiedName);
+		Assert.Equal ("Example.NS", string.Join ('.', changes.Value.Parameters [0].Type.Namespace));
+	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/TypeInfoTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/TypeInfoTests.cs
@@ -645,7 +645,7 @@ namespace Example {
 		Assert.Equal ("Example.NS.ExampleClass", changes.Value.Parameters [0].Type.FullyQualifiedName);
 		Assert.Equal ("Example.NS", string.Join ('.', changes.Value.Parameters [0].Type.Namespace));
 	}
-	
+
 	[Theory]
 	[AllSupportedPlatforms]
 	void TypeInfoNestedCase (ApplePlatform platform)


### PR DESCRIPTION
Ensure that the name of a nested class is "Parent.Class" and its namespace is that of the parent.

The previous algorithm was mixing the parent name class and the namespace which would be problematic when we want to import the namespace from a TypeInfo.