### PR TITLE
[RGen] Fix missing 'global::' when using New.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.Extensions;
+using Microsoft.Macios.Generator.Formatters;
 using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
@@ -493,18 +494,11 @@ static partial class BindingSyntaxFactory {
 	/// <param name="arguments">The argument list for the object creation expression.</param>
 	/// <param name="global">If the global qualifier should be used.</param>
 	/// <returns>An object creation expression.</returns>
-	internal static ObjectCreationExpressionSyntax New (in TypeInfo type, ImmutableArray<ArgumentSyntax> arguments,
-		bool global = false)
+	internal static ObjectCreationExpressionSyntax New (in TypeInfo type, ImmutableArray<ArgumentSyntax> arguments)
 	{
 		var argumentList = ArgumentList (
 			SeparatedList<ArgumentSyntax> (arguments.ToSyntaxNodeOrTokenArray ()));
-		NameSyntax identifier = global
-			? AliasQualifiedName (
-				IdentifierName (Token (SyntaxKind.GlobalKeyword)),
-				IdentifierName (type.FullyQualifiedName))
-			: IdentifierName (type.FullyQualifiedName);
-
-		return ObjectCreationExpression (identifier.WithLeadingTrivia (Space).WithTrailingTrivia (Space))
+		return ObjectCreationExpression (type.GetIdentifierSyntax ().WithLeadingTrivia (Space).WithTrailingTrivia (Space))
 			.WithArgumentList (argumentList);
 	}
 

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
@@ -324,7 +324,7 @@ static partial class BindingSyntaxFactory {
 			// {0} == IntPtr.Zero ? null! : new global::CoreMedia.CMSampleBuffer ({0}, false)
 			{ Type.FullyQualifiedName: "CoreMedia.CMSampleBuffer" } =>
 				IntPtrZeroCheck (parameter.Name, 
-					expressionSyntax: New (parameter.Type, [Argument (parameterIdentifier), BoolArgument (false)], true), 
+					expressionSyntax: New (parameter.Type, [Argument (parameterIdentifier), BoolArgument (false)]), 
 					suppressNullableWarning: true),
 			
 			// AudioToolbox.AudioBuffers

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -479,15 +479,7 @@ public class BindingSyntaxFactoryRuntimeTests {
 			yield return [
 				ReturnTypeForNSObject ("AudioToolbox.AudioBuffers"),
 				ImmutableArray<ArgumentSyntax>.Empty,
-				false,
-				"new AudioToolbox.AudioBuffers ()"
-			];
-
-			yield return [
-				ReturnTypeForNSObject ("AudioToolbox.AudioBuffers"),
-				ImmutableArray<ArgumentSyntax>.Empty,
-				true,
-				"new global::AudioToolbox.AudioBuffers ()"
+				$"new {Global ("AudioToolbox.AudioBuffers")} ()"
 			];
 
 			// single param
@@ -496,39 +488,17 @@ public class BindingSyntaxFactoryRuntimeTests {
 				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1"))
 				),
-				false,
-				"new AudioToolbox.AudioBuffers (arg1)"
-			];
-
-			yield return [
-				ReturnTypeForNSObject ("AudioToolbox.AudioBuffers"),
-				ImmutableArray.Create (
-					Argument (IdentifierName ("arg1"))
-				),
-				true,
-				"new global::AudioToolbox.AudioBuffers (arg1)"
+				$"new {Global ("AudioToolbox.AudioBuffers")} (arg1)"
 			];
 
 			// several params
-
 			yield return [
 				ReturnTypeForNSObject ("AudioToolbox.AudioBuffers"),
 				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1")),
 					Argument (IdentifierName ("arg2"))
 				),
-				false,
-				"new AudioToolbox.AudioBuffers (arg1, arg2)"
-			];
-
-			yield return [
-				ReturnTypeForNSObject ("AudioToolbox.AudioBuffers"),
-				ImmutableArray.Create (
-					Argument (IdentifierName ("arg1")),
-					Argument (IdentifierName ("arg2"))
-				),
-				true,
-				"new global::AudioToolbox.AudioBuffers (arg1, arg2)"
+				$"new {Global ("AudioToolbox.AudioBuffers")} (arg1, arg2)"
 			];
 
 			// out params
@@ -540,20 +510,7 @@ public class BindingSyntaxFactoryRuntimeTests {
 						.WithRefOrOutKeyword (Token (SyntaxKind.OutKeyword))
 						.NormalizeWhitespace ()
 				),
-				false,
-				"new AudioToolbox.AudioBuffers (arg1, out arg2)"
-			];
-
-			yield return [
-				ReturnTypeForNSObject ("AudioToolbox.AudioBuffers"),
-				ImmutableArray.Create (
-					Argument (IdentifierName ("arg1")),
-					Argument (IdentifierName ("arg2"))
-						.WithRefOrOutKeyword (Token (SyntaxKind.OutKeyword))
-						.NormalizeWhitespace ()
-				),
-				true,
-				"new global::AudioToolbox.AudioBuffers (arg1, out arg2)"
+				$"new {Global ("AudioToolbox.AudioBuffers")} (arg1, out arg2)"
 			];
 		}
 
@@ -562,9 +519,9 @@ public class BindingSyntaxFactoryRuntimeTests {
 
 	[Theory]
 	[ClassData (typeof (TestDataNew))]
-	void NewTests (TypeInfo typeInfo, ImmutableArray<ArgumentSyntax> arguments, bool global, string expectedDeclaration)
+	void NewTests (TypeInfo typeInfo, ImmutableArray<ArgumentSyntax> arguments, string expectedDeclaration)
 	{
-		var declaration = New (typeInfo, arguments, global);
+		var declaration = New (typeInfo, arguments);
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -604,7 +604,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				audioBuffer,
-				"new AudioToolbox.AudioBuffers (audioBuffer)",
+				$"new {Global ("AudioToolbox.AudioBuffers")} (audioBuffer)",
 			];
 
 			var outNullableInt = @"


### PR DESCRIPTION
Rather than take its own parameter, is better to relay in the method that returns the identifier of a type which is used all over the code generator and ensures that we will be consistent.

Tests have been updated to reflect the change.