### PR TITLE
[release/10.0.1xx-preview5] [msbuild] Don't execute the ParseDeviceSpecificBuildInformation task on Mac Catalyst.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1289,7 +1289,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			will apply to Xamarin.Mac as well.
 		-->
 		<ParseDeviceSpecificBuildInformation
-			Condition="'$(DeviceSpecificBuild)' == 'true' And '$(TargetiOSDevice)' != '' And '$(_CanDeployToDeviceOrSimulator)' == 'true' And '$(_PlatformName)' != 'macOS' And '$(_PlatformName)' != 'MacCatalyst'"
+			Condition="'$(DeviceSpecificBuild)' == 'true' And '$(TargetiOSDevice)' != '' And '$(_CanDeployToDeviceOrSimulator)' == 'true' And '$(_PlatformName)' != 'macOS'"
 			Architectures="$(TargetArchitectures)"
 			IntermediateOutputPath="$(IntermediateOutputPath)"
 			OutputPath="$(OutputPath)"

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1289,7 +1289,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			will apply to Xamarin.Mac as well.
 		-->
 		<ParseDeviceSpecificBuildInformation
-			Condition="'$(DeviceSpecificBuild)' == 'true' And '$(TargetiOSDevice)' != '' And '$(_CanDeployToDeviceOrSimulator)' == 'true' And '$(_PlatformName)' != 'macOS'"
+			Condition="'$(DeviceSpecificBuild)' == 'true' And '$(TargetiOSDevice)' != '' And '$(_CanDeployToDeviceOrSimulator)' == 'true' And '$(_PlatformName)' != 'macOS' And '$(_PlatformName)' != 'MacCatalyst'"
 			Architectures="$(TargetArchitectures)"
 			IntermediateOutputPath="$(IntermediateOutputPath)"
 			OutputPath="$(OutputPath)"

--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Xml;
 
 using Xamarin.Utils;
 
@@ -221,15 +222,19 @@ namespace Xamarin.Tests {
 						}
 					}
 					if (generatedProps is not null) {
+						var settings = new XmlWriterSettings ();
 						var sb = new StringBuilder ();
-						sb.AppendLine ("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
-						sb.AppendLine ("<Project>");
-						sb.AppendLine ("\t<PropertyGroup>");
+						var xml = XmlWriter.Create (sb, settings);
+						xml.WriteStartElement ("Project");
+						xml.WriteStartElement ("PropertyGroup");
 						foreach (var prop in generatedProps) {
-							sb.AppendLine ($"\t\t<{prop.Key}>{prop.Value}</{prop.Key}>");
+							xml.WriteStartElement (prop.Key);
+							xml.WriteString (prop.Value);
+							xml.WriteEndElement ();
 						}
-						sb.AppendLine ("\t</PropertyGroup>");
-						sb.AppendLine ("</Project>");
+						xml.WriteEndElement ();
+						xml.WriteEndElement ();
+						xml.Flush ();
 
 						var generatedProjectFile = Path.Combine (Cache.CreateTemporaryDirectory (), "GeneratedProjectFile.props");
 						File.WriteAllText (generatedProjectFile, sb.ToString ());

--- a/tests/dotnet/UnitTests/MauiTest.cs
+++ b/tests/dotnet/UnitTests/MauiTest.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Tests {
 			BuildMauiAppImpl (platform, runtimeIdentifiers);
 		}
 
-		void BuildMauiAppImpl (ApplePlatform platform, string runtimeIdentifiers, Diagnostics<string, string?> properties = null)
+		void BuildMauiAppImpl (ApplePlatform platform, string runtimeIdentifiers, Dictionary<string, string>? properties = null)
 		{
 			var project = "MyMauiApp";
 			Configuration.IgnoreIfIgnoredPlatform (platform);
@@ -50,7 +50,7 @@ namespace Xamarin.Tests {
 		public void BuildMauiAppOnRemoteWindows (ApplePlatform platform, string runtimeIdentifiers)
 		{
 			Configuration.IgnoreIfNotOnWindows ();
-			BuildMauiApp (platform, runtimeIdentifiers, AddRemoteProperties ());
+			BuildMauiAppImpl (platform, runtimeIdentifiers, AddRemoteProperties ());
 		}
 	}
 }

--- a/tests/dotnet/UnitTests/MauiTest.cs
+++ b/tests/dotnet/UnitTests/MauiTest.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Tests {
 			BuildMauiAppImpl (platform, runtimeIdentifiers);
 		}
 
-		void BuildMauiAppImpl (ApplePlatform platform, string runtimeIdentifiers, Dictionary<string, string>? properties = null)
+		void BuildMauiAppImpl (ApplePlatform platform, string runtimeIdentifiers, bool deviceSpecificBuild = false)
 		{
 			var project = "MyMauiApp";
 			Configuration.IgnoreIfIgnoredPlatform (platform);
@@ -25,7 +25,29 @@ namespace Xamarin.Tests {
 
 			DotNet.InstallWorkload ("maui-tizen");
 
-			properties = GetDefaultProperties (runtimeIdentifiers, extraProperties: properties);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			if (deviceSpecificBuild) {
+				properties ["file:TargetiOSDevice"] =
+					"""
+					<?xml version="1.0" encoding="UTF-8"?>
+					<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+					<plist version="1.0">
+					<dict>
+						<key>device</key>
+						<dict>
+							<key>architecture</key>
+							<string>ARM64</string>
+							<key>os</key>
+							<string>ios</string>
+							<key>model</key>
+							<string>iphone</string>
+							<key>os-version</key>
+							<string>18.0</string>
+						</dict>
+					</dict>
+					</plist>
+					""";
+			}
 			var rv = DotNet.AssertBuild (project_path, properties);
 			AssertThatLinkerExecuted (rv);
 			var infoPlistPath = GetInfoPListPath (platform, appPath);
@@ -45,12 +67,12 @@ namespace Xamarin.Tests {
 			Assert.AreEqual ("None", mtouchLinkValue, "MtouchLink");
 		}
 
-		[TestCase (ApplePlatform.iOS, "ios-arm64")]
-		[Category ("RemoteWindows")]
-		public void BuildMauiAppOnRemoteWindows (ApplePlatform platform, string runtimeIdentifiers)
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64")]
+		// [Category ("RemoteWindows")]
+		public void BuildMauiAppWithDeviceSpecificBuilds (ApplePlatform platform, string runtimeIdentifiers)
 		{
-			Configuration.IgnoreIfNotOnWindows ();
-			BuildMauiAppImpl (platform, runtimeIdentifiers, AddRemoteProperties ());
+			// Configuration.IgnoreIfNotOnWindows ();
+			BuildMauiAppImpl (platform, runtimeIdentifiers, deviceSpecificBuild: true);
 		}
 	}
 }

--- a/tests/dotnet/UnitTests/MauiTest.cs
+++ b/tests/dotnet/UnitTests/MauiTest.cs
@@ -12,6 +12,11 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64")]
 		public void BuildMauiApp (ApplePlatform platform, string runtimeIdentifiers)
 		{
+			BuildMauiAppImpl (platform, runtimeIdentifiers);
+		}
+
+		void BuildMauiAppImpl (ApplePlatform platform, string runtimeIdentifiers, Diagnostics<string, string?> properties = null)
+		{
 			var project = "MyMauiApp";
 			Configuration.IgnoreIfIgnoredPlatform (platform);
 
@@ -20,7 +25,7 @@ namespace Xamarin.Tests {
 
 			DotNet.InstallWorkload ("maui-tizen");
 
-			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties = GetDefaultProperties (runtimeIdentifiers, extraProperties: properties);
 			var rv = DotNet.AssertBuild (project_path, properties);
 			AssertThatLinkerExecuted (rv);
 			var infoPlistPath = GetInfoPListPath (platform, appPath);
@@ -38,6 +43,14 @@ namespace Xamarin.Tests {
 			Assert.AreEqual ("copy", trimModeValue, "TrimMode");
 			Assert.AreEqual ("None", linkModeValue, "LinkMode");
 			Assert.AreEqual ("None", mtouchLinkValue, "MtouchLink");
+		}
+
+		[TestCase (ApplePlatform.iOS, "ios-arm64")]
+		[Category ("RemoteWindows")]
+		public void BuildMauiAppOnRemoteWindows (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			Configuration.IgnoreIfNotOnWindows ();
+			BuildMauiApp (platform, runtimeIdentifiers, AddRemoteProperties ());
 		}
 	}
 }


### PR DESCRIPTION
The 'ParseDeviceSpecificBuildInformation' task is only applicable to mobile
targets (iOS and tvOS), so skip running it on Mac Catalyst (like we're already
doing for macOS).

This fixes a build error if happens to run on Mac Catalyst:

> The \"ParseDeviceSpecificBuildInformation\" task failed unexpectedly. System.InvalidOperationException: Invalid platform: MacCatalyst

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2484312.

Backport of #22887.