### PR TITLE
[RGen] Update the emitters to generate the trampoline static class.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.KnownTypes.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.KnownTypes.cs
@@ -68,6 +68,13 @@ static partial class BindingSyntaxFactory {
 		@namespace: ["ObjCRuntime"],
 		@class: "Runtime");
 
+	/// <summary>
+	/// TypeSyntax for ObjCRuntime.BlockLiteral.
+	/// </summary>
+	public static readonly TypeSyntax BlockLiteral = StringExtensions.GetIdentifierName (
+		@namespace: ["ObjCRuntime"],
+		@class: "BlockLiteral");
+
 	// Foundation types
 
 	/// <summary>

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/Documentation.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/Documentation.cs
@@ -135,5 +135,8 @@ public static class Documentation {
 ///         Developers should not invoke this method directly, instead they should call <see cref=""ObjCRuntime.Runtime.GetNSObject(System.IntPtr)"" /> as it will prevent two instances of a managed object pointing to the same native object.
 ///     </para>
 /// </remarks>";
+
+		public static string TrampolineStaticClass (string name) =>
+"/// <summary>This class bridges native block invocations that call into C#</summary>";
 	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/TrampolineEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/TrampolineEmitter.cs
@@ -3,21 +3,164 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.Macios.Generator.Context;
-using Microsoft.Macios.Generator.DataModel;
+using Microsoft.Macios.Generator.Formatters;
 using Microsoft.Macios.Generator.IO;
 using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
+using static Microsoft.Macios.Generator.Emitters.BindingSyntaxFactory;
 
 namespace Microsoft.Macios.Generator.Emitters;
 
 class TrampolineEmitter (
 	RootContext context,
 	TabbedStringBuilder builder) {
+	/// <summary>
+	/// The nomenclator is used to generate the name of the static class that will contain the trampoline, needs to
+	/// be an instance class since we want to keep track of the already generated names.
+	/// </summary>
+	Nomenclator nomenclator = new ();
 
 	public string SymbolNamespace => "ObjCRuntime";
 	public string SymbolName => "Trampolines";
 
+	/// <summary>
+	/// Generate the static helper class for the trampoline uses to bridge the native block invocation.
+	/// </summary>
+	/// <param name="typeInfo">The type info of the trampoline to generate.</param>
+	/// <param name="trampolineName">The trampoline name.</param>
+	/// <param name="classBuilder">The tabbed string builder to use.</param>
+	/// <returns>Ture if the code was generated, fals otherwise.</returns>
+	public bool TryEmitStaticClass (in TypeInfo typeInfo, string trampolineName, TabbedWriter<StringWriter> classBuilder)
+	{
+		// create a new static class using the name from the nomenclator
+		var argumentSyntax = GetTrampolineInvokeArguments (trampolineName, typeInfo.Delegate!);
+		var delegateIdentifier = typeInfo.GetIdentifierSyntax ();
+		var className = Nomenclator.GetTrampolineClassName (trampolineName, Nomenclator.TrampolineClassType.StaticBridgeClass);
+		var invokeMethodName = Nomenclator.GetTrampolineInvokeMethodName ();
+		var trampolineVariableName = Nomenclator.GetTrampolineDelegatePointerVariableName ();
+		var delegateVariableName = Nomenclator.GetTrampolineDelegateVariableName ();
+
+		classBuilder.WriteDocumentation (Documentation.Class.TrampolineStaticClass (className));
+		using (var classBlock = classBuilder.CreateBlock ($"static internal class {className}", true)) {
+			// Invoke method
+			classBlock.WriteLine ("[Preserve (Conditional = true)]");
+			classBlock.WriteLine ("[UnmanagedCallersOnly]");
+			classBlock.WriteLine ($"[UserDelegateType (typeof ({delegateIdentifier}))]");
+			using (var invokeMethod = classBlock.CreateBlock (GetTrampolineInvokeSignature (typeInfo).ToString (), true)) {
+				// initialized the parameters, this might be needed for the parameters that are out or ref
+				foreach (var argument in argumentSyntax) {
+					invokeMethod.Write (argument.Initializers);
+				}
+				
+				// get the delegate from the block literal to execute with the trampoline
+				invokeMethod.WriteLine ($"var {delegateVariableName} = {BlockLiteral}.GetTarget<{delegateIdentifier}> ({Nomenclator.GetTrampolineBlockParameterName (typeInfo.Delegate!.Parameters)});");
+				
+				// if the deletate is null, we return default, otherwise we call the delegate
+				using (var ifBlock = invokeMethod.CreateBlock ($"if ({delegateVariableName} is not null)", true)) {
+					
+					// build any needed pre conversion operations before calling the delegate
+					foreach (var argument in argumentSyntax) {
+						ifBlock.Write (argument.PreDelegateCallConversion);
+					}
+					
+					ifBlock.WriteLine ($"{CallTrampolineDelegate (typeInfo.Delegate!, argumentSyntax)}");
+					
+					// build any needed post conversion operations after calling the delegate
+					foreach (var argument in argumentSyntax) {
+						ifBlock.Write (argument.PostDelegateCallConversion);
+					}
+					
+					// perform any needed
+					if (typeInfo.Delegate.ReturnType.SpecialType != SpecialType.System_Void) 
+						ifBlock.WriteLine($"return {GetTrampolineInvokeReturnType (typeInfo, Nomenclator.GetReturnVariableName ())};");
+				}
+				if (typeInfo.Delegate.ReturnType.SpecialType != SpecialType.System_Void) 
+					invokeMethod.WriteLine ("return default;");
+			}
+
+			// CreateNullableBlock
+			classBlock.WriteLine (); // empty line for readability
+			using (var createNullableBlock = classBlock.CreateBlock (
+					   $"internal static unsafe {BlockLiteral} CreateNullableBlock ({delegateIdentifier}? callback)", true)) {
+				createNullableBlock.WriteRaw (
+$@"if (callback is null)
+	return default ({BlockLiteral});
+return CreateBlock (callback);
+"
+				);
+			}
+
+			// CreateBlock
+			classBlock.WriteLine (); // empty line for readability
+			classBlock.WriteLine ("[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]");
+			using (var createBlock = classBlock.CreateBlock (
+					   $"internal static unsafe {BlockLiteral} CreateBlock ({delegateIdentifier} callback)", true)) {
+				createBlock.WriteLine (GetTrampolineDelegatePointer (typeInfo).ToFullString ());
+				createBlock.WriteLine (
+					$"return new {BlockLiteral} ({trampolineVariableName}, callback, typeof ({className}), nameof ({invokeMethodName}));");
+			}
+		}
+		return true;
+	}
+
+	/// <summary>
+	/// Emits the delegate declaration for the trampoline.
+	/// </summary>
+	/// <param name="typeInfo">The type of the trampoline to generate.</param>
+	/// <param name="classBuilder">The current tabbed string builder to use.</param>
+	/// <param name="addedDelegates">A hash set with the delegates already added.</param>
+	/// <param name="delegateName">The delegate name.</param>
+	/// <returns>True if the code was generated, false otherwise.</returns>
+	public bool TryEmitInternalDelegate (in TypeInfo typeInfo, TabbedWriter<StringWriter> classBuilder, HashSet<string> addedDelegates,
+		[NotNullWhen (true)] out string? delegateName)
+	{
+		delegateName = null;
+		if (typeInfo.Delegate is null)
+			return false;
+
+		// generate the delegate and get its name, if we already emitted it, skip it
+		var delegateDeclaration = GetTrampolineDelegateDeclaration (typeInfo, out delegateName);
+		if (addedDelegates.Add (delegateName)) {
+			// print the attributes needed for the delegate and the delegate itself
+			classBuilder.WriteLine ("[UnmanagedFunctionPointerAttribute (CallingConvention.Cdecl)]");
+			classBuilder.WriteLine ($"[UserDelegateType (typeof ({typeInfo.GetIdentifierSyntax ()}))]");
+			classBuilder.WriteLine (delegateDeclaration.ToString ());
+		}
+		return true;
+	}
+
+	/// <summary>
+	/// Write the using statements for the namespaces used by the trampolines.
+	/// </summary>
+	/// <param name="trampolines">The trampolines to generate.</param>
+	public void WriteUsedNamespaces (IReadOnlySet<TypeInfo> trampolines)
+	{
+		// create set with the default namespaces
+		var namespaces = new HashSet<string> () {
+			"Foundation",
+			"ObjCBindings",
+			"ObjCRuntime",
+			"System",
+		};
+		// loop through the trampolines and add the namespaces used by the delegates
+		foreach (var info in trampolines)
+			namespaces.Add (string.Join ('.', info.Namespace));
+
+		// sort the namespaces so that we can write them in a deterministic way
+		foreach (var ns in namespaces.OrderBy (x => x)) {
+			builder.WriteLine ($"using {ns};");
+		}
+	}
+
+	/// <summary>
+	/// Generate the trampolines for the given set of types.
+	/// </summary>
+	/// <param name="trampolines">The trampolines type info to use for the code generation.</param>
+	/// <param name="diagnostics">Possible diagnostic errors.</param>
+	/// <returns>True if the code was generated, false otherwise.</returns>
 	public bool TryEmit (IReadOnlySet<TypeInfo> trampolines,
 		[NotNullWhen (false)] out ImmutableArray<Diagnostic>? diagnostics)
 	{
@@ -25,19 +168,35 @@ class TrampolineEmitter (
 		// and some comments with the trampolines to emit
 		diagnostics = null;
 
-		builder.WriteLine ("using Foundation;");
-		builder.WriteLine ("using ObjCBindings;");
-		builder.WriteLine ("using ObjCRuntime;");
-		builder.WriteLine ("using System;");
+		// write the using statements
+		WriteUsedNamespaces (trampolines);
 
 		builder.WriteLine ();
-		builder.WriteLine ($"namespace ObjCRuntime;");
+		builder.WriteLine ("namespace ObjCRuntime;");
 		builder.WriteLine ();
+
+		// keep track of the already emitted delegates
+		var addedDelegates = new HashSet<string> ();
 
 		using (var classBlock = builder.CreateBlock ($"static partial class {SymbolName}", true)) {
 			classBlock.WriteLine ($"// Generate trampolines for compilation");
 			_ = context.CurrentPlatform;
 			foreach (var info in trampolines) {
+				var trampolineName = nomenclator.GetTrampolineName (info);
+				// write the delegate declaration
+				if (!TryEmitInternalDelegate (info, classBlock, addedDelegates, out var delegateDeclaration)) {
+					diagnostics = [];
+					return false;
+				}
+
+				classBlock.WriteLine (); // empty line for readability
+
+				// generate the static class
+				if (!TryEmitStaticClass (info, trampolineName, classBlock)) {
+					diagnostics = [];
+					return false;
+				}
+
 				classBlock.WriteLine ($"// TODO: generate trampoline for {info.FullyQualifiedName}");
 				classBlock.WriteLine ();
 			}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/BaseGeneratorTestClass.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/BaseGeneratorTestClass.cs
@@ -122,7 +122,7 @@ public class BaseGeneratorTestClass {
 
 			if (testData.ExpectedTrampolineText is not null) {
 				// validate that Library.g.cs was created by the LibraryEmitter and matches the expectation
-				var generatedLibSyntax = runResult.GeneratedTrees.Single (t => t.FilePath.EndsWith ("Trampolines.g.cs"));
+				var generatedLibSyntax = runResult.GeneratedTrees.Single (t => t.FilePath.EndsWith ("ObjCRuntime/Trampolines.g.cs"));
 				Assert.Equal (testData.ExpectedTrampolineText, generatedLibSyntax.GetText ().ToString ());
 			}
 		}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedTrampolinePropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedTrampolinePropertyTests.cs
@@ -2,7 +2,9 @@
 
 #nullable enable
 
+using AVFoundation;
 using CoreGraphics;
+using CoreImage;
 using Foundation;
 using ObjCBindings;
 using ObjCRuntime;
@@ -21,12 +23,76 @@ namespace Microsoft.Macios.Generator.Tests.Classes.Data.TestNamespace;
 public partial class TrampolinePropertyTests
 {
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selCreateObjectHandlerX = "createObjectHandler";
+	static readonly global::ObjCRuntime.NativeHandle selCreateObjectHandlerXHandle = global::ObjCRuntime.Selector.GetHandle ("createObjectHandler");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetCreateObjectHandler_X = "setCreateObjectHandler:";
+	static readonly global::ObjCRuntime.NativeHandle selSetCreateObjectHandler_XHandle = global::ObjCRuntime.Selector.GetHandle ("setCreateObjectHandler:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	const string selCompletionHandlerX = "completionHandler";
 	static readonly global::ObjCRuntime.NativeHandle selCompletionHandlerXHandle = global::ObjCRuntime.Selector.GetHandle ("completionHandler");
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	const string selSetCompletionHandler_X = "setCompletionHandler:";
 	static readonly global::ObjCRuntime.NativeHandle selSetCompletionHandler_XHandle = global::ObjCRuntime.Selector.GetHandle ("setCompletionHandler:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selDuplicateCompletionHandlerX = "duplicateCompletionHandler";
+	static readonly global::ObjCRuntime.NativeHandle selDuplicateCompletionHandlerXHandle = global::ObjCRuntime.Selector.GetHandle ("duplicateCompletionHandler");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetDuplicateCompletionHandler_X = "setDuplicateCompletionHandler:";
+	static readonly global::ObjCRuntime.NativeHandle selSetDuplicateCompletionHandler_XHandle = global::ObjCRuntime.Selector.GetHandle ("setDuplicateCompletionHandler:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selImageGeneratorCompletionHandlerX = "imageGeneratorCompletionHandler";
+	static readonly global::ObjCRuntime.NativeHandle selImageGeneratorCompletionHandlerXHandle = global::ObjCRuntime.Selector.GetHandle ("imageGeneratorCompletionHandler");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetImageGeneratorCompletionHandler_X = "setImageGeneratorCompletionHandler:";
+	static readonly global::ObjCRuntime.NativeHandle selSetImageGeneratorCompletionHandler_XHandle = global::ObjCRuntime.Selector.GetHandle ("setImageGeneratorCompletionHandler:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selKernelRoiCallbackX = "kernelRoiCallback";
+	static readonly global::ObjCRuntime.NativeHandle selKernelRoiCallbackXHandle = global::ObjCRuntime.Selector.GetHandle ("kernelRoiCallback");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetKernelRoiCallback_X = "setKernelRoiCallback:";
+	static readonly global::ObjCRuntime.NativeHandle selSetKernelRoiCallback_XHandle = global::ObjCRuntime.Selector.GetHandle ("setKernelRoiCallback:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selStringActionHandlerX = "stringActionHandler";
+	static readonly global::ObjCRuntime.NativeHandle selStringActionHandlerXHandle = global::ObjCRuntime.Selector.GetHandle ("stringActionHandler");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetStringActionHandler_X = "setStringActionHandler:";
+	static readonly global::ObjCRuntime.NativeHandle selSetStringActionHandler_XHandle = global::ObjCRuntime.Selector.GetHandle ("setStringActionHandler:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selIntActionHandlerX = "intActionHandler";
+	static readonly global::ObjCRuntime.NativeHandle selIntActionHandlerXHandle = global::ObjCRuntime.Selector.GetHandle ("intActionHandler");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetIntActionHandler_X = "setIntActionHandler:";
+	static readonly global::ObjCRuntime.NativeHandle selSetIntActionHandler_XHandle = global::ObjCRuntime.Selector.GetHandle ("setIntActionHandler:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selBoolActionHandlerX = "boolActionHandler";
+	static readonly global::ObjCRuntime.NativeHandle selBoolActionHandlerXHandle = global::ObjCRuntime.Selector.GetHandle ("boolActionHandler");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetBoolActionHandler_X = "setBoolActionHandler:";
+	static readonly global::ObjCRuntime.NativeHandle selSetBoolActionHandler_XHandle = global::ObjCRuntime.Selector.GetHandle ("setBoolActionHandler:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selManualRenderingCallbackX = "manualRenderingCallback";
+	static readonly global::ObjCRuntime.NativeHandle selManualRenderingCallbackXHandle = global::ObjCRuntime.Selector.GetHandle ("manualRenderingCallback");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetManualRenderingCallback_X = "setManualRenderingCallback:";
+	static readonly global::ObjCRuntime.NativeHandle selSetManualRenderingCallback_XHandle = global::ObjCRuntime.Selector.GetHandle ("setManualRenderingCallback:");
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	static readonly global::ObjCRuntime.NativeHandle class_ptr = global::ObjCRuntime.Class.GetHandle ("TrampolinePropertyTests");
@@ -114,6 +180,27 @@ public partial class TrampolinePropertyTests
 	protected internal TrampolinePropertyTests (global::ObjCRuntime.NativeHandle handle) : base (handle) {}
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public partial global::System.Action<bool> BoolActionHandler
+	{
+		get
+		{
+			global::System.Action<bool> ret;
+			if (IsDirectBinding) {
+				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("boolActionHandler"));
+			} else {
+				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("boolActionHandler"));
+			}
+			GC.KeepAlive (this);
+			return ret;
+		}
+
+		set
+		{
+			throw new NotImplementedException();
+		}
+	}
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	public partial global::System.Action CompletionHandler
 	{
 		get
@@ -123,6 +210,195 @@ public partial class TrampolinePropertyTests
 				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completionHandler"));
 			} else {
 				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completionHandler"));
+			}
+			GC.KeepAlive (this);
+			return ret;
+		}
+
+		set
+		{
+			throw new NotImplementedException();
+		}
+	}
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public partial global::Microsoft.Macios.Generator.Tests.Classes.Data.TestNamespace.TrampolinePropertyTests.CreateObject CreateObjectHandler
+	{
+		get
+		{
+			global::Microsoft.Macios.Generator.Tests.Classes.Data.TestNamespace.TrampolinePropertyTests.CreateObject ret;
+			if (IsDirectBinding) {
+				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("createObjectHandler"));
+			} else {
+				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("createObjectHandler"));
+			}
+			GC.KeepAlive (this);
+			return ret;
+		}
+
+		set
+		{
+			throw new NotImplementedException();
+		}
+	}
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public partial global::System.Action DuplicateCompletionHandler
+	{
+		get
+		{
+			global::System.Action ret;
+			if (IsDirectBinding) {
+				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("duplicateCompletionHandler"));
+			} else {
+				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("duplicateCompletionHandler"));
+			}
+			GC.KeepAlive (this);
+			return ret;
+		}
+
+		set
+		{
+			throw new NotImplementedException();
+		}
+	}
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public partial global::AVFoundation.AVAssetImageGenerator.AsynchronouslyForTimeCompletionHandler ImageGeneratorCompletionHandler
+	{
+		get
+		{
+			global::AVFoundation.AVAssetImageGenerator.AsynchronouslyForTimeCompletionHandler ret;
+			if (IsDirectBinding) {
+				ret = global::ObjCRuntime.Messaging._objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("imageGeneratorCompletionHandler"));
+			} else {
+				ret = global::ObjCRuntime.Messaging._objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("imageGeneratorCompletionHandler"));
+			}
+			GC.KeepAlive (this);
+			return ret;
+		}
+
+		set
+		{
+			throw new NotImplementedException();
+		}
+	}
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public partial global::AVFoundation.AVAssetImageGenerateAsynchronouslyForTimeCompletionHandler ImageGeneratorCompletionHandler
+	{
+		get
+		{
+			global::AVFoundation.AVAssetImageGenerateAsynchronouslyForTimeCompletionHandler ret;
+			if (IsDirectBinding) {
+				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("imageGeneratorCompletionHandler"));
+			} else {
+				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("imageGeneratorCompletionHandler"));
+			}
+			GC.KeepAlive (this);
+			return ret;
+		}
+
+		set
+		{
+			throw new NotImplementedException();
+		}
+	}
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public partial global::System.Action<int> IntActionHandler
+	{
+		get
+		{
+			global::System.Action<int> ret;
+			if (IsDirectBinding) {
+				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("intActionHandler"));
+			} else {
+				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("intActionHandler"));
+			}
+			GC.KeepAlive (this);
+			return ret;
+		}
+
+		set
+		{
+			throw new NotImplementedException();
+		}
+	}
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public partial global::CoreImage.CIKernelRoiCallback KernelRoiCallback
+	{
+		get
+		{
+			global::CoreImage.CIKernelRoiCallback ret;
+			if (IsDirectBinding) {
+				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("kernelRoiCallback"));
+			} else {
+				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("kernelRoiCallback"));
+			}
+			GC.KeepAlive (this);
+			return ret;
+		}
+
+		set
+		{
+			throw new NotImplementedException();
+		}
+	}
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public partial global::CoreImage.CIKernelRoiCallback KernelRoiCallback
+	{
+		get
+		{
+			global::CoreImage.CIKernelRoiCallback ret;
+			if (IsDirectBinding) {
+				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("kernelRoiCallback"));
+			} else {
+				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("kernelRoiCallback"));
+			}
+			GC.KeepAlive (this);
+			return ret;
+		}
+
+		set
+		{
+			throw new NotImplementedException();
+		}
+	}
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public partial global::AVFoundation.AVAudioEngineManualRenderingBlock ManualRendering
+	{
+		get
+		{
+			global::AVFoundation.AVAudioEngineManualRenderingBlock ret;
+			if (IsDirectBinding) {
+				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("manualRenderingCallback"));
+			} else {
+				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("manualRenderingCallback"));
+			}
+			GC.KeepAlive (this);
+			return ret;
+		}
+
+		set
+		{
+			throw new NotImplementedException();
+		}
+	}
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public partial global::System.Action<string> StringActionHandler
+	{
+		get
+		{
+			global::System.Action<string> ret;
+			if (IsDirectBinding) {
+				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("stringActionHandler"));
+			} else {
+				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("stringActionHandler"));
 			}
 			GC.KeepAlive (this);
 			return ret;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedTrampolinePropertyTestsTrampolines.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedTrampolinePropertyTestsTrampolines.cs
@@ -2,7 +2,10 @@
 
 #nullable enable
 
+using AVFoundation;
+using CoreImage;
 using Foundation;
+using Microsoft.Macios.Generator.Tests.Classes.Data.TestNamespace;
 using ObjCBindings;
 using ObjCRuntime;
 using System;
@@ -12,6 +15,282 @@ namespace ObjCRuntime;
 static partial class Trampolines
 {
 	// Generate trampolines for compilation
+	[UnmanagedFunctionPointerAttribute (CallingConvention.Cdecl)]
+	[UserDelegateType (typeof (global::Microsoft.Macios.Generator.Tests.Classes.Data.TestNamespace.TrampolinePropertyTests.CreateObject))]
+	unsafe internal delegate global::ObjCRuntime.NativeHandle DTrampolinePropertyTests.CreateObject (global::System.IntPtr block_ptr, global::ObjCRuntime.NativeHandle obj);
+
+	/// <summary>This class bridges native block invocations that call into C#</summary>
+	static internal class SDTrampolinePropertyTests.CreateObject
+	{
+		[Preserve (Conditional = true)]
+		[UnmanagedCallersOnly]
+		[UserDelegateType (typeof (global::Microsoft.Macios.Generator.Tests.Classes.Data.TestNamespace.TrampolinePropertyTests.CreateObject))]
+		internal static unsafe global::ObjCRuntime.NativeHandle Invoke (global::System.IntPtr block_ptr, global::ObjCRuntime.NativeHandle obj)
+		{
+			var del = global::ObjCRuntime.BlockLiteral.GetTarget<global::Microsoft.Macios.Generator.Tests.Classes.Data.TestNamespace.TrampolinePropertyTests.CreateObject> (block_ptr);
+			if (del is not null)
+			{
+				var ret = del (global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSObject> (obj)!);
+				return global::ObjCRuntime.Runtime.RetainAndAutoreleaseNSObject (ret);
+			}
+			return default;
+		}
+
+		internal static unsafe global::ObjCRuntime.BlockLiteral CreateNullableBlock (global::Microsoft.Macios.Generator.Tests.Classes.Data.TestNamespace.TrampolinePropertyTests.CreateObject? callback)
+		{
+			if (callback is null)
+				return default (global::ObjCRuntime.BlockLiteral);
+			return CreateBlock (callback);
+		}
+
+		[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+		internal static unsafe global::ObjCRuntime.BlockLiteral CreateBlock (global::Microsoft.Macios.Generator.Tests.Classes.Data.TestNamespace.TrampolinePropertyTests.CreateObject callback)
+		{
+			delegate* unmanaged<global::System.IntPtr, global::ObjCRuntime.NativeHandle, global::ObjCRuntime.NativeHandle> trampoline = &Invoke;
+			return new global::ObjCRuntime.BlockLiteral (trampoline, callback, typeof (SDTrampolinePropertyTests.CreateObject), nameof (Invoke));
+		}
+	}
+	// TODO: generate trampoline for Microsoft.Macios.Generator.Tests.Classes.Data.TestNamespace.TrampolinePropertyTests.CreateObject
+
+	[UnmanagedFunctionPointerAttribute (CallingConvention.Cdecl)]
+	[UserDelegateType (typeof (global::System.Action))]
+	unsafe internal delegate void DAction (global::System.IntPtr block_ptr);
+
+	/// <summary>This class bridges native block invocations that call into C#</summary>
+	static internal class SDAction
+	{
+		[Preserve (Conditional = true)]
+		[UnmanagedCallersOnly]
+		[UserDelegateType (typeof (global::System.Action))]
+		internal static unsafe void Invoke (global::System.IntPtr block_ptr)
+		{
+			var del = global::ObjCRuntime.BlockLiteral.GetTarget<global::System.Action> (block_ptr);
+			if (del is not null)
+			{
+				del ();
+			}
+		}
+
+		internal static unsafe global::ObjCRuntime.BlockLiteral CreateNullableBlock (global::System.Action? callback)
+		{
+			if (callback is null)
+				return default (global::ObjCRuntime.BlockLiteral);
+			return CreateBlock (callback);
+		}
+
+		[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+		internal static unsafe global::ObjCRuntime.BlockLiteral CreateBlock (global::System.Action callback)
+		{
+			delegate* unmanaged<global::System.IntPtr, void> trampoline = &Invoke;
+			return new global::ObjCRuntime.BlockLiteral (trampoline, callback, typeof (SDAction), nameof (Invoke));
+		}
+	}
 	// TODO: generate trampoline for System.Action
+
+	[UnmanagedFunctionPointerAttribute (CallingConvention.Cdecl)]
+	[UserDelegateType (typeof (global::CoreImage.CIKernelRoiCallback))]
+	unsafe internal delegate global::CoreGraphics.CGRect DCIKernelRoiCallback (global::System.IntPtr block_ptr, int index, global::CoreGraphics.CGRect rect);
+
+	/// <summary>This class bridges native block invocations that call into C#</summary>
+	static internal class SDCIKernelRoiCallback
+	{
+		[Preserve (Conditional = true)]
+		[UnmanagedCallersOnly]
+		[UserDelegateType (typeof (global::CoreImage.CIKernelRoiCallback))]
+		internal static unsafe global::CoreGraphics.CGRect Invoke (global::System.IntPtr block_ptr, int index, global::CoreGraphics.CGRect rect)
+		{
+			var del = global::ObjCRuntime.BlockLiteral.GetTarget<global::CoreImage.CIKernelRoiCallback> (block_ptr);
+			if (del is not null)
+			{
+				var ret = del (index, rect);
+				return ret;
+			}
+			return default;
+		}
+
+		internal static unsafe global::ObjCRuntime.BlockLiteral CreateNullableBlock (global::CoreImage.CIKernelRoiCallback? callback)
+		{
+			if (callback is null)
+				return default (global::ObjCRuntime.BlockLiteral);
+			return CreateBlock (callback);
+		}
+
+		[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+		internal static unsafe global::ObjCRuntime.BlockLiteral CreateBlock (global::CoreImage.CIKernelRoiCallback callback)
+		{
+			delegate* unmanaged<global::System.IntPtr, int, global::CoreGraphics.CGRect, global::CoreGraphics.CGRect> trampoline = &Invoke;
+			return new global::ObjCRuntime.BlockLiteral (trampoline, callback, typeof (SDCIKernelRoiCallback), nameof (Invoke));
+		}
+	}
+	// TODO: generate trampoline for CoreImage.CIKernelRoiCallback
+
+
+	/// <summary>This class bridges native block invocations that call into C#</summary>
+	static internal class SDActionArity1V0
+	{
+		[Preserve (Conditional = true)]
+		[UnmanagedCallersOnly]
+		[UserDelegateType (typeof (global::System.Action<string>))]
+		internal static unsafe void Invoke (global::System.IntPtr block_ptr, global::ObjCRuntime.NativeHandle obj)
+		{
+			var del = global::ObjCRuntime.BlockLiteral.GetTarget<global::System.Action<string>> (block_ptr);
+			if (del is not null)
+			{
+				del (global::CoreFoundation.CFString.FromHandle (obj)!);
+			}
+		}
+
+		internal static unsafe global::ObjCRuntime.BlockLiteral CreateNullableBlock (global::System.Action<string>? callback)
+		{
+			if (callback is null)
+				return default (global::ObjCRuntime.BlockLiteral);
+			return CreateBlock (callback);
+		}
+
+		[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+		internal static unsafe global::ObjCRuntime.BlockLiteral CreateBlock (global::System.Action<string> callback)
+		{
+			delegate* unmanaged<global::System.IntPtr, global::ObjCRuntime.NativeHandle, void> trampoline = &Invoke;
+			return new global::ObjCRuntime.BlockLiteral (trampoline, callback, typeof (SDActionArity1V0), nameof (Invoke));
+		}
+	}
+	// TODO: generate trampoline for System.Action<string>
+
+
+	/// <summary>This class bridges native block invocations that call into C#</summary>
+	static internal class SDActionArity1V1
+	{
+		[Preserve (Conditional = true)]
+		[UnmanagedCallersOnly]
+		[UserDelegateType (typeof (global::System.Action<int>))]
+		internal static unsafe void Invoke (global::System.IntPtr block_ptr, int obj)
+		{
+			var del = global::ObjCRuntime.BlockLiteral.GetTarget<global::System.Action<int>> (block_ptr);
+			if (del is not null)
+			{
+				del (obj);
+			}
+		}
+
+		internal static unsafe global::ObjCRuntime.BlockLiteral CreateNullableBlock (global::System.Action<int>? callback)
+		{
+			if (callback is null)
+				return default (global::ObjCRuntime.BlockLiteral);
+			return CreateBlock (callback);
+		}
+
+		[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+		internal static unsafe global::ObjCRuntime.BlockLiteral CreateBlock (global::System.Action<int> callback)
+		{
+			delegate* unmanaged<global::System.IntPtr, int, void> trampoline = &Invoke;
+			return new global::ObjCRuntime.BlockLiteral (trampoline, callback, typeof (SDActionArity1V1), nameof (Invoke));
+		}
+	}
+	// TODO: generate trampoline for System.Action<int>
+
+
+	/// <summary>This class bridges native block invocations that call into C#</summary>
+	static internal class SDActionArity1V2
+	{
+		[Preserve (Conditional = true)]
+		[UnmanagedCallersOnly]
+		[UserDelegateType (typeof (global::System.Action<bool>))]
+		internal static unsafe void Invoke (global::System.IntPtr block_ptr, byte obj)
+		{
+			var del = global::ObjCRuntime.BlockLiteral.GetTarget<global::System.Action<bool>> (block_ptr);
+			if (del is not null)
+			{
+				del (obj != 0);
+			}
+		}
+
+		internal static unsafe global::ObjCRuntime.BlockLiteral CreateNullableBlock (global::System.Action<bool>? callback)
+		{
+			if (callback is null)
+				return default (global::ObjCRuntime.BlockLiteral);
+			return CreateBlock (callback);
+		}
+
+		[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+		internal static unsafe global::ObjCRuntime.BlockLiteral CreateBlock (global::System.Action<bool> callback)
+		{
+			delegate* unmanaged<global::System.IntPtr, byte, void> trampoline = &Invoke;
+			return new global::ObjCRuntime.BlockLiteral (trampoline, callback, typeof (SDActionArity1V2), nameof (Invoke));
+		}
+	}
+	// TODO: generate trampoline for System.Action<bool>
+
+	[UnmanagedFunctionPointerAttribute (CallingConvention.Cdecl)]
+	[UserDelegateType (typeof (global::AVFoundation.AVAssetImageGenerateAsynchronouslyForTimeCompletionHandler))]
+	unsafe internal delegate void DAVAssetImageGenerateAsynchronouslyForTimeCompletionHandler (global::System.IntPtr block_ptr, global::ObjCRuntime.NativeHandle imageRef, global::CoreMedia.CMTime actualTime, global::ObjCRuntime.NativeHandle error);
+
+	/// <summary>This class bridges native block invocations that call into C#</summary>
+	static internal class SDAVAssetImageGenerateAsynchronouslyForTimeCompletionHandler
+	{
+		[Preserve (Conditional = true)]
+		[UnmanagedCallersOnly]
+		[UserDelegateType (typeof (global::AVFoundation.AVAssetImageGenerateAsynchronouslyForTimeCompletionHandler))]
+		internal static unsafe void Invoke (global::System.IntPtr block_ptr, global::ObjCRuntime.NativeHandle imageRef, global::CoreMedia.CMTime actualTime, global::ObjCRuntime.NativeHandle error)
+		{
+			var del = global::ObjCRuntime.BlockLiteral.GetTarget<global::AVFoundation.AVAssetImageGenerateAsynchronouslyForTimeCompletionHandler> (block_ptr);
+			if (del is not null)
+			{
+				del (global::ObjCRuntime.Runtime.GetINativeObject<global::CoreGraphics.CGImage> (imageRef, false)!, actualTime, global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSError> (error)!);
+			}
+		}
+
+		internal static unsafe global::ObjCRuntime.BlockLiteral CreateNullableBlock (global::AVFoundation.AVAssetImageGenerateAsynchronouslyForTimeCompletionHandler? callback)
+		{
+			if (callback is null)
+				return default (global::ObjCRuntime.BlockLiteral);
+			return CreateBlock (callback);
+		}
+
+		[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+		internal static unsafe global::ObjCRuntime.BlockLiteral CreateBlock (global::AVFoundation.AVAssetImageGenerateAsynchronouslyForTimeCompletionHandler callback)
+		{
+			delegate* unmanaged<global::System.IntPtr, global::ObjCRuntime.NativeHandle, global::CoreMedia.CMTime, global::ObjCRuntime.NativeHandle, void> trampoline = &Invoke;
+			return new global::ObjCRuntime.BlockLiteral (trampoline, callback, typeof (SDAVAssetImageGenerateAsynchronouslyForTimeCompletionHandler), nameof (Invoke));
+		}
+	}
+	// TODO: generate trampoline for AVFoundation.AVAssetImageGenerateAsynchronouslyForTimeCompletionHandler
+
+	[UnmanagedFunctionPointerAttribute (CallingConvention.Cdecl)]
+	[UserDelegateType (typeof (global::AVFoundation.AVAudioEngineManualRenderingBlock))]
+	unsafe internal delegate global::System.IntPtr DAVAudioEngineManualRenderingBlock (global::System.IntPtr block_ptr, uint numberOfFrames, global::ObjCRuntime.NativeHandle outBuffer, int* outError);
+
+	/// <summary>This class bridges native block invocations that call into C#</summary>
+	static internal class SDAVAudioEngineManualRenderingBlock
+	{
+		[Preserve (Conditional = true)]
+		[UnmanagedCallersOnly]
+		[UserDelegateType (typeof (global::AVFoundation.AVAudioEngineManualRenderingBlock))]
+		internal static unsafe global::System.IntPtr Invoke (global::System.IntPtr block_ptr, uint numberOfFrames, global::ObjCRuntime.NativeHandle outBuffer, int* outError)
+		{
+			*outError = default;
+			var del = global::ObjCRuntime.BlockLiteral.GetTarget<global::AVFoundation.AVAudioEngineManualRenderingBlock> (block_ptr);
+			if (del is not null)
+			{
+				var ret = del (numberOfFrames, new global::AudioToolbox.AudioBuffers (outBuffer), ref global::System.Runtime.CompilerServices.Unsafe.AsRef<int> (outError));
+				return (IntPtr) (long) ret;
+			}
+			return default;
+		}
+
+		internal static unsafe global::ObjCRuntime.BlockLiteral CreateNullableBlock (global::AVFoundation.AVAudioEngineManualRenderingBlock? callback)
+		{
+			if (callback is null)
+				return default (global::ObjCRuntime.BlockLiteral);
+			return CreateBlock (callback);
+		}
+
+		[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+		internal static unsafe global::ObjCRuntime.BlockLiteral CreateBlock (global::AVFoundation.AVAudioEngineManualRenderingBlock callback)
+		{
+			delegate* unmanaged<global::System.IntPtr, uint, global::ObjCRuntime.NativeHandle, int*, global::System.IntPtr> trampoline = &Invoke;
+			return new global::ObjCRuntime.BlockLiteral (trampoline, callback, typeof (SDAVAudioEngineManualRenderingBlock), nameof (Invoke));
+		}
+	}
+	// TODO: generate trampoline for AVFoundation.AVAudioEngineManualRenderingBlock
 
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/TrampolinePropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/TrampolinePropertyTests.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Macios.Generator.Tests.Classes.Data;
 
 using System;
 using System.Runtime.Versioning;
+using AVFoundation;
+using CoreImage;
 using CoreGraphics;
 using Foundation;
 using ObjCBindings;
@@ -17,7 +19,47 @@ namespace TestNamespace;
 
 [BindingType<Class>]
 public partial class TrampolinePropertyTests {
+	
+	public delegate NSObject CreateObject (NSObject obj);
+	
+	[Export<Property> ("createObjectHandler", ArgumentSemantic.Copy)]
+	public partial CreateObject CreateObjectHandler { get; set; }
 
 	[Export<Property> ("completionHandler", ArgumentSemantic.Copy)]
 	public partial Action CompletionHandler { get; set; }
+
+	// Duplicate property using Action
+	[Export<Property> ("duplicateCompletionHandler", ArgumentSemantic.Copy)]
+	public partial Action DuplicateCompletionHandler { get; set; }
+
+	[Export<Property> ("imageGeneratorCompletionHandler", ArgumentSemantic.Copy)]
+	public partial AVAssetImageGenerator.AsynchronouslyForTimeCompletionHandler ImageGeneratorCompletionHandler { get; set; }
+
+	// Property using CIKernelRoiCallback
+	[Export<Property> ("kernelRoiCallback", ArgumentSemantic.Copy)]
+	public partial CIKernelRoiCallback KernelRoiCallback { get; set; }]
+
+	// Property using Action<string>
+	[Export<Property> ("stringActionHandler", ArgumentSemantic.Copy)]
+	public partial Action<string> StringActionHandler { get; set; }
+
+	// Property using Action<int>
+	[Export<Property> ("intActionHandler", ArgumentSemantic.Copy)]
+	public partial Action<int> IntActionHandler { get; set; }
+	
+	// Property using Action<bool>
+	[Export<Property>("boolActionHandler", ArgumentSemantic.Copy)]
+	public partial Action<bool> BoolActionHandler { get; set; }
+
+	// Property using AVAssetImageGenerator.AsynchronouslyForTimeCompletionHandler
+	[Export<Property> ("imageGeneratorCompletionHandler", ArgumentSemantic.Copy)]
+	public partial AVAssetImageGenerateAsynchronouslyForTimeCompletionHandler ImageGeneratorCompletionHandler { get; set; }
+
+	// Property using CIKernelRoiCallback
+	[Export<Property> ("kernelRoiCallback", ArgumentSemantic.Copy)]
+	public partial CIKernelRoiCallback KernelRoiCallback { get; set; }
+	
+	// Property using AVAssetImageGenerator.AsynchronouslyForTimeCompletionHandler
+	[Export<Property>("manualRenderingCallback", ArgumentSemantic.Copy)]
+	public partial AVAudioEngineManualRenderingBlock ManualRendering { get; set; }
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Microsoft.Macios.Generator.Tests.csproj
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Microsoft.Macios.Generator.Tests.csproj
@@ -61,9 +61,11 @@
     <ItemGroup>
         <Compile Remove="SmartEnum\Data\*.cs" />
         <Compile Remove="Classes\Data\*.cs" />
+        <Compile Remove="Classes\Data\Trampolines\*.cs" />
         
         <None Include="SmartEnum\Data\*.cs" />
         <None Include="Classes\Data\*.cs" />
+        <None Include="Classes\Data\Trampolines\*.cs" />
     </ItemGroup>
 
 


### PR DESCRIPTION
This is the initial implementation of the trampoline emitter. It just focuses on the delegate and the static class. A generic class has been added but more tests will come per framework, we simply want to make the diff manageable for the team, so we have not added all the tests in a single PR.