### PR TITLE
[Rgen] Be consistent in the use of global when we encounter a nint/nuint.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -255,7 +255,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 
 	static (string Name, ImmutableArray<string> Namespace) GetTypeNameAndNamespace (ITypeSymbol symbol)
 	{
-		if (symbol.SpecialType == SpecialType.None)
+		if (symbol.SpecialType is SpecialType.None or SpecialType.System_IntPtr or SpecialType.System_UIntPtr)
 			return (GetName (symbol), GetNamespaceComponents (symbol));
 
 		var token = symbol.SpecialType.GetKeyword ();

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/ClassGenerationTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/ClassGenerationTests.cs
@@ -36,7 +36,7 @@ public class ClassGenerationTests : BaseGeneratorTestClass {
 			(ApplePlatform.MacCatalyst, "ThreadSafeUIKitPropertyTests", "ThreadSafeUIKitPropertyTests.cs", "ExpectedThreadSafeUIKitPropertyTests.cs", null, null),
 			(ApplePlatform.MacOSX, "AppKitPropertyTests", "AppKitPropertyTests.cs", "ExpectedAppKitPropertyTests.cs", null, null),
 			(ApplePlatform.MacOSX, "ThreadSafeAppKitPropertyTests", "ThreadSafeAppKitPropertyTests.cs", "ExpectedThreadSafeAppKitPropertyTests.cs", null, null),
-			
+
 			(ApplePlatform.iOS, "NSUserDefaults", "NSUserDefaults.cs", "ExpectedNSUserDefaults.cs", null, null),
 			(ApplePlatform.TVOS, "NSUserDefaults", "NSUserDefaults.cs", "ExpectedNSUserDefaults.cs", null, null),
 			(ApplePlatform.MacCatalyst, "NSUserDefaults", "NSUserDefaults.cs", "ExpectedNSUserDefaults.cs", null, null),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/ClassGenerationTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/ClassGenerationTests.cs
@@ -36,7 +36,7 @@ public class ClassGenerationTests : BaseGeneratorTestClass {
 			(ApplePlatform.MacCatalyst, "ThreadSafeUIKitPropertyTests", "ThreadSafeUIKitPropertyTests.cs", "ExpectedThreadSafeUIKitPropertyTests.cs", null, null),
 			(ApplePlatform.MacOSX, "AppKitPropertyTests", "AppKitPropertyTests.cs", "ExpectedAppKitPropertyTests.cs", null, null),
 			(ApplePlatform.MacOSX, "ThreadSafeAppKitPropertyTests", "ThreadSafeAppKitPropertyTests.cs", "ExpectedThreadSafeAppKitPropertyTests.cs", null, null),
-
+			
 			(ApplePlatform.iOS, "NSUserDefaults", "NSUserDefaults.cs", "ExpectedNSUserDefaults.cs", null, null),
 			(ApplePlatform.TVOS, "NSUserDefaults", "NSUserDefaults.cs", "ExpectedNSUserDefaults.cs", null, null),
 			(ApplePlatform.MacCatalyst, "NSUserDefaults", "NSUserDefaults.cs", "ExpectedNSUserDefaults.cs", null, null),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedAppKitPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedAppKitPropertyTests.cs
@@ -113,7 +113,7 @@ public partial class AppKitPropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial UIntPtr Count
+	public virtual partial global::System.UIntPtr Count
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -123,7 +123,7 @@ public partial class AppKitPropertyTests
 		{
 			AppKit.NSApplication.EnsureUIThread ();
 
-			UIntPtr ret;
+			global::System.UIntPtr ret;
 			if (IsDirectBinding) {
 				ret = global::ObjCRuntime.Messaging.UIntPtr_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("count"));
 			} else {

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedThreadSafeAppKitPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedThreadSafeAppKitPropertyTests.cs
@@ -113,7 +113,7 @@ public partial class ThreadSafeAppKitPropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial UIntPtr Count
+	public virtual partial global::System.UIntPtr Count
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -121,7 +121,7 @@ public partial class ThreadSafeAppKitPropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			UIntPtr ret;
+			global::System.UIntPtr ret;
 			if (IsDirectBinding) {
 				ret = global::ObjCRuntime.Messaging.UIntPtr_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("count"));
 			} else {

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedThreadSafeUIKitPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedThreadSafeUIKitPropertyTests.cs
@@ -113,7 +113,7 @@ public partial class ThreadSafeUIKitPropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial UIntPtr Count
+	public virtual partial global::System.UIntPtr Count
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -121,7 +121,7 @@ public partial class ThreadSafeUIKitPropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			UIntPtr ret;
+			global::System.UIntPtr ret;
 			if (IsDirectBinding) {
 				ret = global::ObjCRuntime.Messaging.UIntPtr_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("count"));
 			} else {

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedUIKitPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedUIKitPropertyTests.cs
@@ -113,7 +113,7 @@ public partial class UIKitPropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial UIntPtr Count
+	public virtual partial global::System.UIntPtr Count
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -123,7 +123,7 @@ public partial class UIKitPropertyTests
 		{
 			UIKit.UIApplication.EnsureUIThread ();
 
-			UIntPtr ret;
+			global::System.UIntPtr ret;
 			if (IsDirectBinding) {
 				ret = global::ObjCRuntime.Messaging.UIntPtr_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("count"));
 			} else {

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
@@ -349,7 +349,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial UIntPtr Count
+	public virtual partial global::System.UIntPtr Count
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -357,7 +357,7 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			UIntPtr ret;
+			global::System.UIntPtr ret;
 			if (IsDirectBinding) {
 				ret = global::ObjCRuntime.Messaging.UIntPtr_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("count"));
 			} else {
@@ -718,7 +718,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial UIntPtr[] Sizes
+	public virtual partial global::System.UIntPtr[] Sizes
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -726,7 +726,7 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			UIntPtr[] ret;
+			global::System.UIntPtr[] ret;
 			if (IsDirectBinding) {
 				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("sizes"));
 			} else {

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
@@ -349,7 +349,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial UIntPtr Count
+	public virtual partial global::System.UIntPtr Count
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -357,7 +357,7 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			UIntPtr ret;
+			global::System.UIntPtr ret;
 			if (IsDirectBinding) {
 				ret = global::ObjCRuntime.Messaging.UIntPtr_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("count"));
 			} else {
@@ -718,7 +718,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial UIntPtr[] Sizes
+	public virtual partial global::System.UIntPtr[] Sizes
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -726,7 +726,7 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			UIntPtr[] ret;
+			global::System.UIntPtr[] ret;
 			if (IsDirectBinding) {
 				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("sizes"));
 			} else {

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
@@ -349,7 +349,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial UIntPtr Count
+	public virtual partial global::System.UIntPtr Count
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -357,7 +357,7 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			UIntPtr ret;
+			global::System.UIntPtr ret;
 			if (IsDirectBinding) {
 				ret = global::ObjCRuntime.Messaging.UIntPtr_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("count"));
 			} else {
@@ -718,7 +718,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial UIntPtr[] Sizes
+	public virtual partial global::System.UIntPtr[] Sizes
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -726,7 +726,7 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			UIntPtr[] ret;
+			global::System.UIntPtr[] ret;
 			if (IsDirectBinding) {
 				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("sizes"));
 			} else {

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryFieldBackingVariableTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryFieldBackingVariableTests.cs
@@ -411,7 +411,7 @@ namespace CoreGraphics {
 
 			yield return [
 				intPtrFieldProperty,
-				"static IntPtr _GenericGray;"
+				$"static {Global ("System.IntPtr")} _GenericGray;"
 			];
 
 
@@ -434,7 +434,7 @@ namespace CoreGraphics {
 
 			yield return [
 				uintPtrFieldProperty,
-				"static UIntPtr _GenericGray;"
+				$"static {Global ("System.UIntPtr")} _GenericGray;"
 			];
 
 			const string nintFieldProperty = @"
@@ -456,7 +456,7 @@ namespace CoreGraphics {
 
 			yield return [
 				nintFieldProperty,
-				"static IntPtr _GenericGray;"
+				$"static {Global ("System.IntPtr")} _GenericGray;"
 			];
 
 			const string nuintFieldProperty = @"
@@ -478,7 +478,7 @@ namespace CoreGraphics {
 
 			yield return [
 				nuintFieldProperty,
-				"static UIntPtr _GenericGray;"
+				$"static {Global ("System.UIntPtr")} _GenericGray;"
 			];
 
 			const string nfloatFieldProperty = @"

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -1973,7 +1973,7 @@ namespace NS {
 }
 ";
 			yield return [
-				intPtrParameters ,
+				intPtrParameters,
 				"DCallback",
 				"unsafe internal delegate int DCallback (global::System.IntPtr block_ptr, global::System.IntPtr timestamp, uint frameCount, global::System.IntPtr inputData);",
 			];

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -1959,6 +1959,24 @@ namespace NS {
 				"DCallback",
 				"unsafe internal delegate global::ObjCRuntime.NativeHandle DCallback (global::System.IntPtr block_ptr, byte boolParameter);",
 			];
+
+			var intPtrParameters = @"
+using System;
+using Foundation;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate int Callback (IntPtr timestamp, uint frameCount, IntPtr inputData);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				intPtrParameters ,
+				"DCallback",
+				"unsafe internal delegate int DCallback (global::System.IntPtr block_ptr, global::System.IntPtr timestamp, uint frameCount, global::System.IntPtr inputData);",
+			];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Formatters/MethodFormatterTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Formatters/MethodFormatterTests.cs
@@ -543,7 +543,7 @@ public partial class MyClass {
 	public partial IntPtr TestMethod(string myParam, int myParamInt);
 }
 ";
-			yield return [intPtrReturnMethod, "public partial IntPtr TestMethod (string myParam, int myParamInt)"];
+			yield return [intPtrReturnMethod, $"public partial {Global ("System.IntPtr")} TestMethod (string myParam, int myParamInt)"];
 
 			const string nullableIntPtrReturnMethod = @"
 using System;
@@ -554,7 +554,7 @@ public partial class MyClass {
 	public partial IntPtr? TestMethod(string myParam, int myParamInt);
 }
 ";
-			yield return [nullableIntPtrReturnMethod, "public partial IntPtr? TestMethod (string myParam, int myParamInt)"];
+			yield return [nullableIntPtrReturnMethod, $"public partial {Global ("System.IntPtr")}? TestMethod (string myParam, int myParamInt)"];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();


### PR DESCRIPTION
nint and nuint are meta types that point to IntPtr and UIntPtr. Due to that fact, we are not using the global::System.IntPtr string in the cases we find a nint. The way to fix this is to look at the special type, and if it matches IntPtr/UIntPtr, use the fully qualified name.

With this change we are consistent in all the generated code and we will always find global::System.IntPtr no matter if the user used nint or IntPtr.