### PR TITLE
[Nomenclator] Make nomenclator stateless.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/TrampolineEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/TrampolineEmitter.cs
@@ -17,12 +17,7 @@ namespace Microsoft.Macios.Generator.Emitters;
 class TrampolineEmitter (
 	RootContext context,
 	TabbedStringBuilder builder) {
-	/// <summary>
-	/// The nomenclator is used to generate the name of the static class that will contain the trampoline, needs to
-	/// be an instance class since we want to keep track of the already generated names.
-	/// </summary>
-	Nomenclator nomenclator = new ();
-
+	
 	public string SymbolNamespace => "ObjCRuntime";
 	public string SymbolName => "Trampolines";
 
@@ -183,7 +178,7 @@ return CreateBlock (callback);
 			classBlock.WriteLine ($"// Generate trampolines for compilation");
 			_ = context.CurrentPlatform;
 			foreach (var info in trampolines) {
-				var trampolineName = nomenclator.GetTrampolineName (info);
+				var trampolineName = Nomenclator.GetTrampolineName (info);
 				// write the delegate declaration
 				if (!TryEmitInternalDelegate (info, classBlock, addedDelegates, out var delegateDeclaration)) {
 					diagnostics = [];

--- a/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.Macios.Generator.DataModel;
 using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
@@ -16,8 +17,9 @@ namespace Microsoft.Macios.Generator;
 ///
 /// In this case, the Nomenclator is used to generate the names of the bindings.
 /// </summary>
-class Nomenclator {
+static class Nomenclator {
 
+	const string globalPrefix = "global::";
 	public enum VariableType {
 		BlockLiteral,
 		Handle,
@@ -28,10 +30,6 @@ class Nomenclator {
 		StringPointer,
 		BindFrom,
 	}
-
-	// keep track of the generic versions of a trampoline, we will use the fully qualified name
-	// of the type to keep track of the generic versions.
-	readonly Dictionary<string, int> trampolinesGenericVersions = new ();
 
 	/// <summary>
 	/// Returns the name to be used by the extension classes for smart enumerators.
@@ -45,23 +43,8 @@ class Nomenclator {
 	/// </summary>
 	/// <param name="typeInfo">The type info whose trampoline name we require.</param>
 	/// <returns>The name of the trampoline to be used for the given type.</returns>
-	public string GetTrampolineName (TypeInfo typeInfo)
+	public static string GetTrampolineName (TypeInfo typeInfo)
 	{
-		// The following algo is used to generate the same trampoline name that bgen used to generate.
-		// for that we need to understand how bgen generates the name:
-		// old code:
-		//
-		// var trampolineName = typeInfo.Name.Replace ("`", "Arity");
-		// if (typeInfo.IsGenericType) {
-		// 	var gdef = typeInfo.GetGenericTypeDefinition ();
-		//
-		// 	if (!trampolinesGenericVersions.ContainsKey (gdef))
-		// 		trampolinesGenericVersions.Add (gdef, 0);
-		//
-		// 	trampolineName = trampolineName + "V" + trampolinesGenericVersions [gdef]++;
-		// }
-		// return trampolineName;
-
 		// trampoline name will the name of the type + the arity + the length of the generic types
 		// else it will be the trampoline name. We will replace any . with _ to ensure that the name is valid
 		// when working with nested classes.
@@ -73,12 +56,22 @@ class Nomenclator {
 		if (!typeInfo.IsGenericType)
 			return trampolineName;
 
-		// TryAdd will only insert 0 if it is not already present, reduces the dict access to a single operation
-		// rather than a contain + add
-		trampolinesGenericVersions.TryAdd (typeInfo.Name, 0);
-		trampolineName = trampolineName + "V" + trampolinesGenericVersions [typeInfo.Name]++;
-
-		return trampolineName;
+		// trampoline names have to be deterministic. We are going to use the name of the argyment types 
+		// to calculate the name of the trampoline.
+		var sb = new StringBuilder (trampolineName);
+		foreach (var typeArgument in typeInfo.TypeArguments) {
+			// we will use the name of the type argument to generate the name of the trampoline
+			// we will replace any . with _ to ensure that the name is valid when working with nested classes.
+			var argumentName = typeArgument.Replace ('.', '_');
+			if (GeneratorConfiguration.UseGlobalNamespace) {
+				// remove the global alias if it is present
+				argumentName = argumentName.StartsWith (globalPrefix) 
+					? argumentName.Substring (globalPrefix.Length) 
+					: argumentName;
+			}
+			sb.Append (argumentName);
+		}
+		return sb.ToString ();
 	}
 
 	/// <summary>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedTrampolinePropertyTestsTrampolines.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedTrampolinePropertyTestsTrampolines.cs
@@ -121,7 +121,7 @@ static partial class Trampolines
 
 
 	/// <summary>This class bridges native block invocations that call into C#</summary>
-	static internal class SDActionArity1V0
+	static internal class SDActionArity1string
 	{
 		[Preserve (Conditional = true)]
 		[UnmanagedCallersOnly]
@@ -145,14 +145,14 @@ static partial class Trampolines
 		internal static unsafe global::ObjCRuntime.BlockLiteral CreateBlock (global::System.Action<string> callback)
 		{
 			delegate* unmanaged<global::System.IntPtr, global::ObjCRuntime.NativeHandle, void> trampoline = &Invoke;
-			return new global::ObjCRuntime.BlockLiteral (trampoline, callback, typeof (SDActionArity1V0), nameof (Invoke));
+			return new global::ObjCRuntime.BlockLiteral (trampoline, callback, typeof (SDActionArity1string), nameof (Invoke));
 		}
 	}
 	// TODO: generate trampoline for System.Action<string>
 
 
 	/// <summary>This class bridges native block invocations that call into C#</summary>
-	static internal class SDActionArity1V1
+	static internal class SDActionArity1int
 	{
 		[Preserve (Conditional = true)]
 		[UnmanagedCallersOnly]
@@ -176,14 +176,14 @@ static partial class Trampolines
 		internal static unsafe global::ObjCRuntime.BlockLiteral CreateBlock (global::System.Action<int> callback)
 		{
 			delegate* unmanaged<global::System.IntPtr, int, void> trampoline = &Invoke;
-			return new global::ObjCRuntime.BlockLiteral (trampoline, callback, typeof (SDActionArity1V1), nameof (Invoke));
+			return new global::ObjCRuntime.BlockLiteral (trampoline, callback, typeof (SDActionArity1int), nameof (Invoke));
 		}
 	}
 	// TODO: generate trampoline for System.Action<int>
 
 
 	/// <summary>This class bridges native block invocations that call into C#</summary>
-	static internal class SDActionArity1V2
+	static internal class SDActionArity1bool
 	{
 		[Preserve (Conditional = true)]
 		[UnmanagedCallersOnly]
@@ -207,7 +207,7 @@ static partial class Trampolines
 		internal static unsafe global::ObjCRuntime.BlockLiteral CreateBlock (global::System.Action<bool> callback)
 		{
 			delegate* unmanaged<global::System.IntPtr, byte, void> trampoline = &Invoke;
-			return new global::ObjCRuntime.BlockLiteral (trampoline, callback, typeof (SDActionArity1V2), nameof (Invoke));
+			return new global::ObjCRuntime.BlockLiteral (trampoline, callback, typeof (SDActionArity1bool), nameof (Invoke));
 		}
 	}
 	// TODO: generate trampoline for System.Action<bool>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/NomenclatorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/NomenclatorTests.cs
@@ -25,8 +25,6 @@ public class NomenclatorTests : BaseGeneratorTestClass {
 	[AllSupportedPlatforms]
 	public void GetTrampolineNameGeneric (ApplePlatform platform)
 	{
-		var nomenclator = new Nomenclator ();
-
 		// write a sample code to retrieve the roslyn symbol and type info so that 
 		// we can test the nomenclator.
 		var code = @"
@@ -58,20 +56,18 @@ public class Example {
 		Assert.NotNull (property);
 		var type = property.Value.ReturnType;
 
-		var name1 = nomenclator.GetTrampolineName (type);
-		var name2 = nomenclator.GetTrampolineName (type);
+		// should always return the same name for the trampoline, even if called multiple times
+		var name1 = Nomenclator.GetTrampolineName (type);
+		var name2 = Nomenclator.GetTrampolineName (type);
 		// compare names and ensure that the correct number is used
-		Assert.Equal ("GenericTrampolineArity1V0", name1);
-		Assert.Equal ("GenericTrampolineArity1V1", name2);
-		Assert.NotEqual (name1, name2);
+		Assert.Equal ("GenericTrampolineArity1string", name1);
+		Assert.Equal (name1, name2);
 	}
 
 	[Theory]
 	[AllSupportedPlatforms]
 	public void GetTrampolineNestedClass (ApplePlatform platform)
 	{
-		var nomenclator = new Nomenclator ();
-
 		// write a sample code to retrieve the roslyn symbol and type info so that 
 		// we can test the nomenclator.
 		var code = @"
@@ -103,20 +99,17 @@ public class Example {
 		Assert.NotNull (property);
 		var type = property.Value.ReturnType;
 
-		var name1 = nomenclator.GetTrampolineName (type);
-		var name2 = nomenclator.GetTrampolineName (type);
+		var name1 = Nomenclator.GetTrampolineName (type);
+		var name2 = Nomenclator.GetTrampolineName (type);
 		// compare names and ensure that the correct number is used
-		Assert.Equal ("Example_GenericTrampolineArity1V0", name1);
-		Assert.Equal ("Example_GenericTrampolineArity1V1", name2);
-		Assert.NotEqual (name1, name2);
+		Assert.Equal ("Example_GenericTrampolineArity1string", name1);
+		Assert.Equal (name1, name2);
 	}
 
 	[Theory]
 	[AllSupportedPlatforms]
 	public void GetTrampolineClassNameTest (ApplePlatform platform)
 	{
-		var nomenclator = new Nomenclator ();
-
 		// write a sample code to retrieve the roslyn symbol and type info so that 
 		// we can test the nomenclator.
 		var code = @"
@@ -148,7 +141,7 @@ public class Example {
 		Assert.NotNull (property);
 		var type = property.Value.ReturnType;
 
-		var trampolineName = nomenclator.GetTrampolineName (type);
+		var trampolineName = Nomenclator.GetTrampolineName (type);
 		// get the class name for each of the types and ensure that the correct value is used
 		Assert.Equal ($"D{trampolineName}", Nomenclator.GetTrampolineClassName (trampolineName, Nomenclator.TrampolineClassType.DelegateType));
 		Assert.Equal ($"SD{trampolineName}", Nomenclator.GetTrampolineClassName (trampolineName, Nomenclator.TrampolineClassType.StaticBridgeClass));


### PR DESCRIPTION
If we look at how the ingremental generators get registered we can see the following:

```csharp
var provider = context.SyntaxProvider
	.CreateSyntaxProvider (static (node, _) => IsValidNode (node),
		static (ctx, _) => GetChangesForSourceGen (ctx))
	.Where (tuple => tuple.BindingAttributeFound);

var bindings = provider
	.Select (static (tuple, _) => (tuple.RootBindingContext, tuple.Bindings))
	.WithComparer (equalityComparer);

// ideally we could do a distinct, because each code change can return the same libs, this makes the library
// generation more common than what we would like, but it is the smallest code generation.
var libraryProvider = provider
	.Select ((tuple, _) => (tuple.RootBindingContext, tuple.Bindings.LibraryPaths));

var trampolineProvider = provider
	.Select ((tuple, _) => (tuple.RootBindingContext, tuple.Bindings.Trampolines));

context.RegisterSourceOutput (context.CompilationProvider.Combine (bindings.Collect ()),
	((ctx, t) => GenerateCode (ctx, t.Right)));

context.RegisterSourceOutput (context.CompilationProvider.Combine (libraryProvider.Collect ()),
	((ctx, t) => GenerateLibraryCode (ctx, t.Right)));

context.RegisterSourceOutput (context.CompilationProvider.Combine (trampolineProvider.Collect ()),
	((ctx, t) => GenerateTrampolineCode (ctx, t.Right)));
```

From the above code it is important to know that  context.RegisterSourceOutput calls register independent source output steps with the Roslyn incremental generator infrastructure. They are not guaranteed to execute sequentially; each is triggered as needed by the build system, potentially in parallel, depending on what inputs change and how the generator host schedules work.

That means, that any order can happen. If that is the case, the trampoline name generation has to be stable so that no matter in which order we call the nomenclator we will always get the same name for the same type. This was not an issue with bgen because bgen is sequential, that is not longer the case.