### PR TITLE
[release/9.0.1xx] Add a useless commit to make apidiff work.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,3 +102,4 @@ git-clean-all:
 	fi; \
 
 SUBDIRS += tests
+


### PR DESCRIPTION
API diff doesn't currently work when the two last commits need two
different versions of Xcode.

The last commit in the release/9.0.1xx branch requires Xcode 16.4, and the
previous commit requires Xcode 16.3, so API diff didn't work for the last
commit.

So add a useless commit so that API diff runs successfully.