### PR TITLE
[msbuild] Fix build break.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileEntitlements.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileEntitlements.cs
@@ -980,7 +980,7 @@ namespace Xamarin.MacDev.Tasks {
 			}
 		}
 
-		void ValidateTypeOrArray<T, M> (MobileProvision? profile, EntitlementInfo info, bool onlyWarn, string key, KeyValuePair<string?, PObject> kvp, string? provisioningProfileName, PDictionary? provisioningEntitlements, string requiredType)
+		void ValidateTypeOrArray<T, M> (MobileProvision? profile, EntitlementInfo info, bool onlyWarn, string key, KeyValuePair<string, PObject> kvp, string? provisioningProfileName, PDictionary? provisioningEntitlements, string requiredType)
 			where T : PObject
 		{
 			// entitlement is a boolean, provisioning profile has the entitlement with either a string or an array of strings of valid values for the entitlement


### PR DESCRIPTION
Fixes:

    macios/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileEntitlements.cs(951,74): error CS8620: Argument of type 'KeyValuePair<string, PObject>' cannot be used for parameter 'kvp' of type 'KeyValuePair<string?, PObject>' in 'void CompileEntitlements.ValidateTypeOrArray<PString, string>(MobileProvision? profile, EntitlementInfo info, bool onlyWarn, string key, KeyValuePair<string?, PObject> kvp, string? provisioningProfileName, PDictionary? provisioningEntitlements, string requiredType)' due to differences in the nullability of reference types.
    macios/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileEntitlements.cs(956,73): error CS8620: Argument of type 'KeyValuePair<string, PObject>' cannot be used for parameter 'kvp' of type 'KeyValuePair<string?, PObject>' in 'void CompileEntitlements.ValidateTypeOrArray<PBoolean, bool>(MobileProvision? profile, EntitlementInfo info, bool onlyWarn, string key, KeyValuePair<string?, PObject> kvp, string? provisioningProfileName, PDictionary? provisioningEntitlements, string requiredType)' due to differences in the nullability of reference types.