### PR TITLE
[msbuild] Correctly handle 'SkipCodesignItems' that are directories. Fixes #19222.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ComputeCodesignItems.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ComputeCodesignItems.cs
@@ -228,8 +228,8 @@ namespace Xamarin.MacDev.Tasks {
 					continue;
 				}
 
-				if (!Directory.Exists (outputPath))
-					continue;
+				if (Directory.Exists (outputPath))
+					outputPath = PathUtils.EnsureTrailingSlash (outputPath);
 
 				var matchingDirectory = canonicalizedDirectoriesToSkip.FirstOrDefault (v => outputPath.StartsWith (v, StringComparison.OrdinalIgnoreCase));
 				if (matchingDirectory is not null) {

--- a/tests/dotnet/CustomizedCodeSigning/shared.csproj
+++ b/tests/dotnet/CustomizedCodeSigning/shared.csproj
@@ -41,12 +41,21 @@
 			DestinationFiles="$(AppBundleDir)/$(SharedSupportDir)/lib3.dylib">
 		</Copy>
 
+		<Copy
+			Condition="'$(RuntimeIdentifiers)' ==''"
+			SourceFiles="$(MSBuildThisFileDirectory)/../../test-libraries/libraries/.libs/$(RuntimeIdentifier)/libNoneE.dylib"
+			DestinationFiles="$(AppBundleDir)/$(SharedSupportDir)/app3.app/$(DylibDir)/lib3.dylib">
+		</Copy>
+
 		<WriteLinesToFile File="$(AppBundleDir)/$(SharedSupportDir)/app1.app/$(AppExecutableDir)/app1" Lines="app1" Overwrite="true" />
 		<WriteLinesToFile File="$(AppBundleDir)/$(SharedSupportDir)/app2.app/$(AppExecutableDir)/app2" Lines="app2" Overwrite="true" />
+		<WriteLinesToFile File="$(AppBundleDir)/$(SharedSupportDir)/app3.app/$(AppExecutableDir)/app3" Lines="app3" Overwrite="true" />
 
 		<ItemGroup>
 			<!-- Sign the first bundle -->
 			<CodesignBundle Include="$(AssemblyName).app/$(SharedSupportDir)/app1.app" />
+			<!-- Sign the third bundle, which has a dylib -->
+			<CodesignBundle Include="$(AssemblyName).app/$(SharedSupportDir)/app3.app" />
 			<!-- But not the second, and that includes the *.dylib inside too -->
 			<SkipCodesignItems Include="$(SharedSupportDir)/app2.app" />
 			<!-- Don't sign this dylib located outside an app bundle either -->

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1793,6 +1793,7 @@ namespace Xamarin.Tests {
 			var directoriesThatMustExist = new string [] {
 				Path.Combine (codesignDirectory, "_CodeSignature"),
 				Path.Combine (sharedSupportDir, "app1.app", codesignDirectory, "_CodeSignature"),
+				Path.Combine (sharedSupportDir, "app3.app", codesignDirectory, "_CodeSignature"),
 			};
 
 			foreach (var mustExist in directoriesThatMustExist)
@@ -1802,12 +1803,12 @@ namespace Xamarin.Tests {
 
 			// And that there are no other signed apps
 			var signatures = appBundleContents.Where (v => v.EndsWith ("_CodeSignature", StringComparison.Ordinal));
-			Assert.That (signatures, Is.Empty, "No other signed app budnles");
+			Assert.That (signatures, Is.Empty, "No other signed app bundles");
 
 			// Assert that some dylibs are signed
 			var dylibs = appBundleContents.Where (v => Path.GetExtension (v) == ".dylib").ToList ();
 			var signedDylibs = new List<string> {
-				Path.Combine (sharedSupportDir, "app2.app", dylibDir, "lib2.dylib"),
+				Path.Combine (sharedSupportDir, "app3.app", dylibDir, "lib3.dylib"),
 			};
 
 			foreach (var dylib in signedDylibs) {
@@ -1825,7 +1826,7 @@ namespace Xamarin.Tests {
 				Assert.That (path, Does.Exist, "unsigned dylib existence");
 				Assert.IsFalse (IsDylibSigned (path), $"Unsigned: {path}");
 			}
-			Assert.AreEqual (1, remainingDylibs.Length, "Unsigned count");
+			Assert.AreEqual (2, remainingDylibs.Length, "Unsigned count");
 
 			// Verify that a Resources subdirectory causes the build to fail.
 			switch (platform) {

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ComputeCodesignItemsTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ComputeCodesignItemsTaskTests.cs
@@ -489,7 +489,7 @@ namespace Xamarin.MacDev.Tasks {
 
 				var task = CreateTask<ComputeCodesignItems> ();
 				task.AppBundleDir = "Bundle.app";
-				task.SkipCodesignItems =new TaskItem [] { new TaskItem ("Contents/Frameworks/XTest2.framework") };
+				task.SkipCodesignItems = new TaskItem [] { new TaskItem ("Contents/Frameworks/XTest2.framework") };
 				task.CodesignBundle = codesignBundle.ToArray ();
 				task.CodesignStampPath = "codesign-stamp-path/";
 				task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (platform).ToString ();

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ComputeCodesignItemsTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ComputeCodesignItemsTaskTests.cs
@@ -422,6 +422,87 @@ namespace Xamarin.MacDev.Tasks {
 		}
 
 		[Test]
+		[TestCase (ApplePlatform.MacOSX)]
+		[TestCase (ApplePlatform.MacCatalyst)]
+		public void SkipDirectories (ApplePlatform platform)
+		{
+			var tmpdir = Cache.CreateTemporaryDirectory ();
+
+			var currentDir = Environment.CurrentDirectory;
+			try {
+				Environment.CurrentDirectory = tmpdir;
+
+				var fwsdir = Path.Combine (tmpdir, "Bundle.app", "Contents", "Frameworks");
+				Directory.CreateDirectory (fwsdir);
+
+				var fwdir = Path.Combine (fwsdir, "XTest.framework");
+
+				Directory.CreateDirectory (Path.Combine (fwdir, "Versions", "A", "Resources"));
+				File.WriteAllText (Path.Combine (fwdir, "Versions", "A", "Resources", "Info.plist"), "Info.plist placeholder");
+				Directory.CreateDirectory (Path.Combine (fwdir, "Versions", "A", "Libraries"));
+				File.WriteAllText (Path.Combine (fwdir, "Versions", "A", "Libraries", "libTest.dylib"), "dylib placeholder");
+				File.WriteAllText (Path.Combine (fwdir, "Versions", "A", "XTest"), "Executable placeholder");
+				File.CreateSymbolicLink (Path.Combine (fwdir, "Versions", "Current"), "A");
+				File.CreateSymbolicLink (Path.Combine (fwdir, "Resources"), "Versions/A/Resources");
+				File.CreateSymbolicLink (Path.Combine (fwdir, "XTest"), "Versions/A/XTest");
+				File.CreateSymbolicLink (Path.Combine (fwdir, "Libraries"), "Versions/A/Libraries");
+
+				var fw2dir = Path.Combine (fwsdir, "XTest2.framework");
+
+				Directory.CreateDirectory (Path.Combine (fw2dir, "Versions", "A", "Resources"));
+				File.WriteAllText (Path.Combine (fw2dir, "Versions", "A", "Resources", "Info.plist"), "Info.plist placeholder");
+				Directory.CreateDirectory (Path.Combine (fw2dir, "Versions", "A", "Libraries"));
+				File.WriteAllText (Path.Combine (fw2dir, "Versions", "A", "Libraries", "libTest.dylib"), "dylib placeholder");
+				File.WriteAllText (Path.Combine (fw2dir, "Versions", "A", "XTest2"), "Executable placeholder");
+				File.CreateSymbolicLink (Path.Combine (fw2dir, "Versions", "Current"), "A");
+				File.CreateSymbolicLink (Path.Combine (fw2dir, "Resources"), "Versions/A/Resources");
+				File.CreateSymbolicLink (Path.Combine (fw2dir, "XTest2"), "Versions/A/XTest2");
+				File.CreateSymbolicLink (Path.Combine (fw2dir, "Libraries"), "Versions/A/Libraries");
+
+				var codesignItems = new List<ITaskItem> ();
+				var codesignBundle = new List<ITaskItem> ();
+
+				string codeSignatureSubdirectory = string.Empty;
+				string symlinkSubdirectory = string.Empty;
+				switch (platform) {
+				case ApplePlatform.MacCatalyst:
+				case ApplePlatform.MacOSX:
+					codeSignatureSubdirectory = "Contents/";
+					symlinkSubdirectory = "Versions/A/";
+					break;
+				}
+
+				var bundleAppMetadata = new Dictionary<string, string> {
+					{ "RequireCodeSigning", "true" },
+					{ "CodesignSigningKey", "-" },
+				};
+
+				codesignBundle = new List<ITaskItem> {
+					new TaskItem ("Bundle.app", bundleAppMetadata),
+				};
+
+				var infos = new CodesignInfo [] {
+					new CodesignInfo ($"Bundle.app", Platforms.All, bundleAppMetadata.Set ("CodesignStampFile", $"codesign-stamp-path/Bundle.app/.stampfile")),
+					new CodesignInfo ($"Bundle.app/{codeSignatureSubdirectory}Frameworks/XTest.framework", Platforms.All, bundleAppMetadata.Set ("CodesignStampFile", $"codesign-stamp-path/Bundle.app/{codeSignatureSubdirectory}Frameworks/XTest.framework/.stampfile")),
+					new CodesignInfo ($"Bundle.app/{codeSignatureSubdirectory}Frameworks/XTest.framework/{symlinkSubdirectory}Libraries/libTest.dylib", Platforms.All, bundleAppMetadata.Set ("CodesignStampFile", $"codesign-stamp-path/Bundle.app/{codeSignatureSubdirectory}Frameworks/XTest.framework/{symlinkSubdirectory}Libraries/libTest.dylib")),
+				};
+
+				var task = CreateTask<ComputeCodesignItems> ();
+				task.AppBundleDir = "Bundle.app";
+				task.SkipCodesignItems =new TaskItem [] { new TaskItem ("Contents/Frameworks/XTest2.framework") };
+				task.CodesignBundle = codesignBundle.ToArray ();
+				task.CodesignStampPath = "codesign-stamp-path/";
+				task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (platform).ToString ();
+				Assert.IsTrue (task.Execute (), "Execute");
+				Assert.AreEqual (0, Engine.Logger.WarningsEvents.Count, "Warning Count");
+
+				VerifyCodesigningResults (infos, task.OutputCodesignItems, platform);
+			} finally {
+				Environment.CurrentDirectory = currentDir;
+			}
+		}
+
+		[Test]
 		[TestCase (ApplePlatform.iOS)]
 		[TestCase (ApplePlatform.TVOS)]
 		[TestCase (ApplePlatform.MacOSX)]


### PR DESCRIPTION
Handle the following cases:

* If the item to be skipped is a file, checking if it's a directory first will fail.
* If the item is a directory, we need to canonicalize it to have a trailing slash.

Fixes https://github.com/dotnet/macios/issues/19222.