### PR TITLE
[RGen] Allow to use BindFrom in delegates.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/DelegateParameter.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/DelegateParameter.Generator.cs
@@ -9,7 +9,7 @@ using Microsoft.Macios.Generator.Extensions;
 namespace Microsoft.Macios.Generator.DataModel;
 
 readonly partial struct DelegateParameter {
-	
+
 	/// <summary>
 	/// Returns the bind from data if present in the binding.
 	/// </summary>
@@ -19,7 +19,7 @@ readonly partial struct DelegateParameter {
 	/// Returns the forced type data if present in the binding.
 	/// </summary>
 	public ForcedTypeData? ForcedType { get; init; }
-	
+
 	public static bool TryCreate (IParameterSymbol symbol,
 		[NotNullWhen (true)] out DelegateParameter? parameter)
 	{

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/DelegateParameter.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/DelegateParameter.Generator.cs
@@ -9,16 +9,22 @@ using Microsoft.Macios.Generator.Extensions;
 namespace Microsoft.Macios.Generator.DataModel;
 
 readonly partial struct DelegateParameter {
+	
+	/// <summary>
+	/// Returns the bind from data if present in the binding.
+	/// </summary>
+	public BindFromData? BindAs { get; init; }
 
 	/// <summary>
 	/// Returns the forced type data if present in the binding.
 	/// </summary>
 	public ForcedTypeData? ForcedType { get; init; }
-
+	
 	public static bool TryCreate (IParameterSymbol symbol,
 		[NotNullWhen (true)] out DelegateParameter? parameter)
 	{
 		parameter = new (symbol.Ordinal, new (symbol.Type), symbol.GetSafeName ()) {
+			BindAs = symbol.GetBindFromData (),
 			ForcedType = symbol.GetForceTypeData (),
 			IsOptional = symbol.IsOptional,
 			IsParams = symbol.IsParams,

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/DelegateParameter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/DelegateParameter.cs
@@ -87,6 +87,8 @@ readonly partial struct DelegateParameter : IEquatable<DelegateParameter> {
 			return false;
 		if (ForcedType != other.ForcedType)
 			return false;
+		if (BindAs != other.BindAs)
+			return false;
 		return ReferenceKind == other.ReferenceKind;
 	}
 

--- a/src/rgen/Microsoft.Macios.Transformer.Generator/Microsoft.Macios.Transformer.Generator/XamarinBindingAPIGenerator.cs
+++ b/src/rgen/Microsoft.Macios.Transformer.Generator/Microsoft.Macios.Transformer.Generator/XamarinBindingAPIGenerator.cs
@@ -244,6 +244,7 @@ public class XamarinBindingAPIGenerator : IIncrementalGenerator {
 		var models = new (string Model, AttributeTargets[] Targets) [] {
 			("EnumMember", [AttributeTargets.Field]), 
 			("Parameter", [AttributeTargets.Parameter]),
+			("DelegateParameter", [AttributeTargets.Parameter]),
 			("Accessor", [AttributeTargets.Property]),
 			("Property", [AttributeTargets.Property]),
 			("Constructor", [AttributeTargets.Constructor]),

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/DelegateParameter.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/DelegateParameter.Transformer.cs
@@ -14,7 +14,7 @@ readonly partial struct DelegateParameter {
 	/// Returns the bind from data if present in the binding.
 	/// </summary>
 	public BindAsData? BindAs => BindAsAttribute;
-	
+
 	/// <summary>
 	/// Returns the forced type data if present in the binding.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/DelegateParameter.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/DelegateParameter.Transformer.cs
@@ -11,6 +11,11 @@ namespace Microsoft.Macios.Generator.DataModel;
 readonly partial struct DelegateParameter {
 
 	/// <summary>
+	/// Returns the bind from data if present in the binding.
+	/// </summary>
+	public BindAsData? BindAs => BindAsAttribute;
+	
+	/// <summary>
 	/// Returns the forced type data if present in the binding.
 	/// </summary>
 	public ForcedTypeData? ForcedType { get; init; }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/DelegateInfoTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/DelegateInfoTests.cs
@@ -582,7 +582,7 @@ namespace NS {
 					]
 				)
 			];
-			
+
 			const string customDelegateBindFrom = @"
 using System;
 using Foundation;
@@ -628,7 +628,7 @@ namespace NS {
 											type: ReturnTypeForInt (),
 											name: "value"
 										) {
-											BindAs =  new (ReturnTypeForNSObject ("Foundation.NSNumber")),
+											BindAs = new (ReturnTypeForNSObject ("Foundation.NSNumber")),
 										},
 									]
 								) {

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/DelegateInfoTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/DelegateInfoTests.cs
@@ -582,6 +582,68 @@ namespace NS {
 					]
 				)
 			];
+			
+			const string customDelegateBindFrom = @"
+using System;
+using Foundation;
+using ObjCRuntime;
+using ObjCBindings;
+
+namespace NS {
+
+	public class MyNSObject : NSObject {
+	}
+
+	public class MyClass {
+		public delegate int? Callback([BindFrom (typeof(NSNumber))] int value);
+
+		public void MyMethod ([BlockCallback] Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				customDelegateBindFrom,
+				new Method (
+					type: "NS.MyClass",
+					name: "MyMethod",
+					returnType: ReturnTypeForVoid (),
+					symbolAvailability: new (),
+					exportMethodData: new (),
+					attributes: [],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					parameters: [
+						new (
+							position: 0,
+							type: ReturnTypeForDelegate (
+								"NS.MyClass.Callback",
+								delegateInfo: new (
+									name: "Invoke",
+									returnType: ReturnTypeForInt (isNullable: true),
+									parameters: [
+										new (
+											position: 0,
+											type: ReturnTypeForInt (),
+											name: "value"
+										) {
+											BindAs =  new (ReturnTypeForNSObject ("Foundation.NSNumber")),
+										},
+									]
+								) {
+									IsBlockCallback = true,
+								}
+							),
+							name: "cb"
+						) {
+							Attributes = [
+								new ("ObjCRuntime.BlockCallbackAttribute")
+							]
+						}
+					]
+				)
+			];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();


### PR DESCRIPTION
This will allow to make the bindings more user friendly by allow to use a managed value in a delegate that later gets converted to the native one.