### PR TITLE
[RGen] Update the factory method to support non array BindFrom delegate arguments.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/DelegateParameter.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/DelegateParameter.Generator.cs
@@ -9,7 +9,7 @@ using Microsoft.Macios.Generator.Extensions;
 namespace Microsoft.Macios.Generator.DataModel;
 
 readonly partial struct DelegateParameter {
-	
+
 	/// <summary>
 	/// Returns the bind from data if present in the binding.
 	/// </summary>
@@ -19,7 +19,7 @@ readonly partial struct DelegateParameter {
 	/// Returns the forced type data if present in the binding.
 	/// </summary>
 	public ForcedTypeData? ForcedType { get; init; }
-	
+
 	public static bool TryCreate (IParameterSymbol symbol,
 		[NotNullWhen (true)] out DelegateParameter? parameter)
 	{

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/DelegateParameter.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/DelegateParameter.Generator.cs
@@ -9,16 +9,22 @@ using Microsoft.Macios.Generator.Extensions;
 namespace Microsoft.Macios.Generator.DataModel;
 
 readonly partial struct DelegateParameter {
+	
+	/// <summary>
+	/// Returns the bind from data if present in the binding.
+	/// </summary>
+	public BindFromData? BindAs { get; init; }
 
 	/// <summary>
 	/// Returns the forced type data if present in the binding.
 	/// </summary>
 	public ForcedTypeData? ForcedType { get; init; }
-
+	
 	public static bool TryCreate (IParameterSymbol symbol,
 		[NotNullWhen (true)] out DelegateParameter? parameter)
 	{
 		parameter = new (symbol.Ordinal, new (symbol.Type), symbol.GetSafeName ()) {
+			BindAs = symbol.GetBindFromData (),
 			ForcedType = symbol.GetForceTypeData (),
 			IsOptional = symbol.IsOptional,
 			IsParams = symbol.IsParams,

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/DelegateParameter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/DelegateParameter.cs
@@ -87,6 +87,8 @@ readonly partial struct DelegateParameter : IEquatable<DelegateParameter> {
 			return false;
 		if (ForcedType != other.ForcedType)
 			return false;
+		if (BindAs != other.BindAs)
+			return false;
 		return ReferenceKind == other.ReferenceKind;
 	}
 

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -870,4 +870,71 @@ static partial class BindingSyntaxFactory {
 	internal static string? GetObjCMessageSendMethod (in Method method, bool isSuper = false, bool isStret = false)
 		=> GetObjCMessageSendMethodName (method.ExportMethodData, method.ReturnType, method.Parameters, isSuper,
 			isStret);
+
+	/// <summary>
+	/// Gets the name of the NSValue instance method used to retrieve its underlying value, based on the provided type.
+	/// For example, if the type is CGPoint, this returns "CGPointValue".
+	/// </summary>
+	/// <param name="type">The <see cref="TypeInfo"/> representing the expected underlying type of the NSValue.</param>
+	/// <returns>A string representing the name of the NSValue method to call (e.g., "CGPointValue", "CGRectValue"),
+	/// or an empty string if the type is not a supported NSValue underlying type.</returns>
+	internal static string GetNSValueValue (in TypeInfo type)
+	{
+		// return the method needed to retrieve the value from the NSValue object based on the type
+#pragma warning disable format
+		// get the factory method based on the parameter type, if it is not found, return null
+		return type switch { 
+			{ FullyQualifiedName: "CoreGraphics.CGAffineTransform" } => "CGAffineTransformValue", 
+			{ FullyQualifiedName: "Foundation.NSRange" } => "RangeValue", 
+			{ FullyQualifiedName: "CoreGraphics.CGVector" } => "CGVectorValue", 
+			{ FullyQualifiedName: "SceneKit.SCNMatrix4" } => "SCNMatrix4Value", 
+			{ FullyQualifiedName: "CoreLocation.CLLocationCoordinate2D" } => "MKCoordinateValue", 
+			{ FullyQualifiedName: "SceneKit.SCNVector3" } => "VectorValue", 
+			{ FullyQualifiedName: "SceneKit.SCNVector4" } => "VectorValue", 
+			{ FullyQualifiedName: "CoreGraphics.CGPoint" } => "CGPointValue", 
+			{ FullyQualifiedName: "CoreGraphics.CGRect" } => "CGRectValue", 
+			{ FullyQualifiedName: "CoreGraphics.CGSize" } => "CGSizeValue", 
+			{ FullyQualifiedName: "UIKit.UIEdgeInsets" } => "UIEdgeInsetsValue", 
+			{ FullyQualifiedName: "UIKit.UIOffset" } => "UIOffsetValue", 
+			{ FullyQualifiedName: "MapKit.MKCoordinateSpan" } => "MKCoordinateSpanValue", 
+			{ FullyQualifiedName: "CoreMedia.CMTimeRange" } => "CMTimeRangeValue", 
+			{ FullyQualifiedName: "CoreMedia.CMTime" } => "CMTimeValue", 
+			{ FullyQualifiedName: "CoreMedia.CMTimeMapping" } => "CMTimeMappingValue", 
+			{ FullyQualifiedName: "CoreAnimation.CATransform3D" } => "CATransform3DValue",
+			_ => string.Empty,
+		};
+#pragma warning restore format
+	}
+
+	/// <summary>
+	/// Gets the name of the NSNumber instance method used to retrieve its underlying value, based on the provided type.
+	/// For example, if the type is `int`, this returns "Int32Value".
+	/// </summary>
+	/// <param name="type">The <see cref="TypeInfo"/> representing the expected underlying type of the NSNumber.</param>
+	/// <returns>A string representing the name of the NSNumber method to call (e.g., "Int32Value", "DoubleValue"),
+	/// or an empty string if the type is not a supported NSNumber underlying type.</returns>
+	internal static string GetNSNumberValue (in TypeInfo type)
+	{
+#pragma warning disable format
+		return type switch {
+			{ Name: "nint" } => "NIntValue",
+			{ Name: "nuint" } => "NUIntValue",
+			{ Name: "nfloat" or "NFloat" } => "NFloatValue",
+			{ SpecialType: SpecialType.System_Boolean } => "BooleanValue",
+			{ SpecialType: SpecialType.System_Byte } => "ByteValue",
+			{ SpecialType: SpecialType.System_Double } => "DoubleValue",
+			{ SpecialType: SpecialType.System_Single } => "FloatValue",
+			{ SpecialType: SpecialType.System_Int16 } => "Int16Value",
+			{ SpecialType: SpecialType.System_Int32 } => "Int32Value",
+			{ SpecialType: SpecialType.System_Int64 } => "Int64Value",
+			{ SpecialType: SpecialType.System_SByte } => "SByteValue",
+			{ SpecialType: SpecialType.System_UInt16 } => "UInt16Value",
+			{ SpecialType: SpecialType.System_UInt32 } => "UInt32Value",
+			{ SpecialType: SpecialType.System_UInt64 } => "UInt64Value",
+			{ SpecialType: SpecialType.System_IntPtr } => "NintValue",
+			{ SpecialType: SpecialType.System_UIntPtr } => "NUintValue",
+			_ => string.Empty,
+		};
+#pragma warning restore format
+	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -931,8 +931,8 @@ static partial class BindingSyntaxFactory {
 			{ SpecialType: SpecialType.System_UInt16 } => "UInt16Value",
 			{ SpecialType: SpecialType.System_UInt32 } => "UInt32Value",
 			{ SpecialType: SpecialType.System_UInt64 } => "UInt64Value",
-			{ SpecialType: SpecialType.System_IntPtr } => "NintValue",
-			{ SpecialType: SpecialType.System_UIntPtr } => "NUintValue",
+			{ SpecialType: SpecialType.System_IntPtr } => "NIntValue",
+			{ SpecialType: SpecialType.System_UIntPtr } => "NUIntValue",
 			_ => string.Empty,
 		};
 #pragma warning restore format

--- a/src/rgen/Microsoft.Macios.Transformer.Generator/Microsoft.Macios.Transformer.Generator/XamarinBindingAPIGenerator.cs
+++ b/src/rgen/Microsoft.Macios.Transformer.Generator/Microsoft.Macios.Transformer.Generator/XamarinBindingAPIGenerator.cs
@@ -244,6 +244,7 @@ public class XamarinBindingAPIGenerator : IIncrementalGenerator {
 		var models = new (string Model, AttributeTargets[] Targets) [] {
 			("EnumMember", [AttributeTargets.Field]), 
 			("Parameter", [AttributeTargets.Parameter]),
+			("DelegateParameter", [AttributeTargets.Parameter]),
 			("Accessor", [AttributeTargets.Property]),
 			("Property", [AttributeTargets.Property]),
 			("Constructor", [AttributeTargets.Constructor]),

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/DelegateParameter.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/DelegateParameter.Transformer.cs
@@ -14,7 +14,7 @@ readonly partial struct DelegateParameter {
 	/// Returns the bind from data if present in the binding.
 	/// </summary>
 	public BindAsData? BindAs => BindAsAttribute;
-	
+
 	/// <summary>
 	/// Returns the forced type data if present in the binding.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/DelegateParameter.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/DelegateParameter.Transformer.cs
@@ -11,6 +11,11 @@ namespace Microsoft.Macios.Generator.DataModel;
 readonly partial struct DelegateParameter {
 
 	/// <summary>
+	/// Returns the bind from data if present in the binding.
+	/// </summary>
+	public BindAsData? BindAs => BindAsAttribute;
+	
+	/// <summary>
 	/// Returns the forced type data if present in the binding.
 	/// </summary>
 	public ForcedTypeData? ForcedType { get; init; }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/DelegateInfoTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/DelegateInfoTests.cs
@@ -582,7 +582,7 @@ namespace NS {
 					]
 				)
 			];
-			
+
 			const string customDelegateBindFrom = @"
 using System;
 using Foundation;
@@ -628,7 +628,7 @@ namespace NS {
 											type: ReturnTypeForInt (),
 											name: "value"
 										) {
-											BindAs =  new (ReturnTypeForNSObject ("Foundation.NSNumber")),
+											BindAs = new (ReturnTypeForNSObject ("Foundation.NSNumber")),
 										},
 									]
 								) {

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/DelegateInfoTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/DelegateInfoTests.cs
@@ -582,6 +582,68 @@ namespace NS {
 					]
 				)
 			];
+			
+			const string customDelegateBindFrom = @"
+using System;
+using Foundation;
+using ObjCRuntime;
+using ObjCBindings;
+
+namespace NS {
+
+	public class MyNSObject : NSObject {
+	}
+
+	public class MyClass {
+		public delegate int? Callback([BindFrom (typeof(NSNumber))] int value);
+
+		public void MyMethod ([BlockCallback] Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				customDelegateBindFrom,
+				new Method (
+					type: "NS.MyClass",
+					name: "MyMethod",
+					returnType: ReturnTypeForVoid (),
+					symbolAvailability: new (),
+					exportMethodData: new (),
+					attributes: [],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					parameters: [
+						new (
+							position: 0,
+							type: ReturnTypeForDelegate (
+								"NS.MyClass.Callback",
+								delegateInfo: new (
+									name: "Invoke",
+									returnType: ReturnTypeForInt (isNullable: true),
+									parameters: [
+										new (
+											position: 0,
+											type: ReturnTypeForInt (),
+											name: "value"
+										) {
+											BindAs =  new (ReturnTypeForNSObject ("Foundation.NSNumber")),
+										},
+									]
+								) {
+									IsBlockCallback = true,
+								}
+							),
+							name: "cb"
+						) {
+							Attributes = [
+								new ("ObjCRuntime.BlockCallbackAttribute")
+							]
+						}
+					]
+				)
+			];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -2016,7 +2016,7 @@ namespace NS {
 				"DCallback",
 				"unsafe internal delegate int DCallback (global::System.IntPtr block_ptr, global::System.IntPtr timestamp, uint frameCount, global::System.IntPtr inputData);",
 			];
-			
+
 			var nsNumberType = @"
 using System;
 using Foundation;
@@ -2148,7 +2148,7 @@ namespace NS {
 				severalParametersConversionReturn,
 				$"var ret = del (global::System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<{Global ("System.Action")}> (callbackParameter), NIDsomeTrampolineName.Create (callbackParameter)!);",
 			];
-			
+
 			var nsNumberParameterWithReturn = @"
 using System;
 using Foundation;
@@ -2166,7 +2166,7 @@ namespace NS {
 				nsNumberParameterWithReturn,
 				$"var ret = del ({Global ("ObjCRuntime.Runtime")}.GetNSObject<{Global ("Foundation.NSNumber")}> (pointerParameter)!.Int32Value);",
 			];
-			
+
 			var nsValueParameterWithReturn = @"
 using System;
 using Foundation;
@@ -2185,7 +2185,7 @@ namespace NS {
 				nsValueParameterWithReturn,
 				$"var ret = del ({Global ("ObjCRuntime.Runtime")}.GetNSObject<{Global ("Foundation.NSValue")}> (size)!.CGSizeValue);",
 			];
-			
+
 			var smartEnumParameterWithReturn = @"
 using System;
 using Foundation;
@@ -2599,7 +2599,7 @@ namespace NS {
 				valueType,
 				"int valueType",
 			];
-			
+
 			var nsNumberType = @"
 using System;
 using Foundation;
@@ -2975,7 +2975,7 @@ namespace NS {
 				doubleBlockNamedParameter,
 				"internal static unsafe global::ObjCRuntime.NativeHandle Invoke (global::System.IntPtr block_ptr_1, byte block_ptr, byte block_ptr_0)",
 			];
-			
+
 			var nsNumberIntParameter = @"
 using System;
 using Foundation;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -2148,6 +2148,73 @@ namespace NS {
 				severalParametersConversionReturn,
 				$"var ret = del (global::System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<{Global ("System.Action")}> (callbackParameter), NIDsomeTrampolineName.Create (callbackParameter)!);",
 			];
+			
+			var nsNumberParameterWithReturn = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public delegate int Callback ([BindFrom (typeof(NSNumber))]int pointerParameter);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				"someTrampolineName",
+				nsNumberParameterWithReturn,
+				$"var ret = del ({Global ("ObjCRuntime.Runtime")}.GetNSObject<{Global ("Foundation.NSNumber")}> (pointerParameter)!.Int32Value);",
+			];
+			
+			var nsValueParameterWithReturn = @"
+using System;
+using Foundation;
+using CoreGraphics;
+using ObjCBindings;
+
+namespace NS {
+	public delegate int Callback ([BindFrom (typeof(NSValue))]CGSize size);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				"someTrampolineName",
+				nsValueParameterWithReturn,
+				$"var ret = del ({Global ("ObjCRuntime.Runtime")}.GetNSObject<{Global ("Foundation.NSValue")}> (size)!.CGSizeValue);",
+			];
+			
+			var smartEnumParameterWithReturn = @"
+using System;
+using Foundation;
+using AVFoundation;
+using ObjCBindings;
+
+namespace NS {
+
+	[BindingType<SmartEnum>]
+	public enum CustomLibraryEnum {
+		[Field<EnumValue> (""None"", ""/path/to/customlibrary.framework"")]
+		None,
+		[Field<EnumValue> (""Medium"", ""/path/to/customlibrary.framework"")]
+		Medium,
+		[Field<EnumValue> (""High"", ""/path/to/customlibrary.framework"")]
+		High,
+	}
+
+	public delegate int Callback ([BindFrom (typeof(NSString))]CustomLibraryEnum level);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				"someTrampolineName",
+				smartEnumParameterWithReturn,
+				$"var ret = del ({Global ("NS.CustomLibraryEnum")}.GetValue ({Global ("ObjCRuntime.Runtime")}.GetNSObject<{Global ("Foundation.NSString")}> (level)!));",
+			];
 
 		}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -2016,6 +2016,24 @@ namespace NS {
 				"DCallback",
 				"unsafe internal delegate int DCallback (global::System.IntPtr block_ptr, global::System.IntPtr timestamp, uint frameCount, global::System.IntPtr inputData);",
 			];
+			
+			var nsNumberType = @"
+using System;
+using Foundation;
+using ObjCBindings;
+namespace NS {
+	public delegate void Callback ([BindFrom (typeof(NSNumber))]int valueType);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				nsNumberType,
+				"DCallback",
+				$"unsafe internal delegate void DCallback ({Global ("System.IntPtr")} block_ptr, {Global ("ObjCRuntime.NativeHandle")} valueType);",
+			];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
@@ -2514,6 +2532,24 @@ namespace NS {
 				valueType,
 				"int valueType",
 			];
+			
+			var nsNumberType = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public delegate void Callback ([BindFrom (typeof(NSNumber))]int valueType);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				nsNumberType,
+				$"{Global ("ObjCRuntime.NativeHandle")} valueType",
+			];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
@@ -2871,6 +2907,23 @@ namespace NS {
 			yield return [
 				doubleBlockNamedParameter,
 				"internal static unsafe global::ObjCRuntime.NativeHandle Invoke (global::System.IntPtr block_ptr_1, byte block_ptr, byte block_ptr_0)",
+			];
+			
+			var nsNumberIntParameter = @"
+using System;
+using Foundation;
+using ObjCBindings; 
+
+namespace NS {
+	public delegate void Callback ([BindFrom (typeof(NSNumber))] int pointerParameter);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				nsNumberIntParameter,
+				$"internal static unsafe void Invoke ({Global ("System.IntPtr")} block_ptr, {Global ("ObjCRuntime.NativeHandle")} pointerParameter)",
 			];
 		}
 


### PR DESCRIPTION
This allows to get the native object either a NSNumber, NSValue or NSString and upper its type to the managed one expected by the delegate.

Example of code generated for an NSValue
```csharp
var ret = del (global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSValue> (size)!.CGSizeValue);
```

Example of code generated for a NSString that represents a SmartEnum:
```csharp
var ret = del (global::NS.CustomLibraryEnum.GetValue (global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSString> (level)!));
```

Array will be added in a following PR to simplify the review process.