### PR TITLE
[monotouch-test] Tweak tests a bit to make them more reliable on bots.a

### DIFF
--- a/tests/monotouch-test/AudioUnit/AUGraphTestMac.cs
+++ b/tests/monotouch-test/AudioUnit/AUGraphTestMac.cs
@@ -91,6 +91,7 @@ namespace Xamarin.Mac.Tests {
 						return;
 					Thread.Sleep (10);
 				}
+				TestRuntime.IgnoreInCI ("This test is unreliable on bots.");
 				Assert.Fail ("Did not see events after 1 second");
 			} finally {
 				graph.Stop ();

--- a/tests/monotouch-test/AudioUnit/AudioUnit.cs
+++ b/tests/monotouch-test/AudioUnit/AudioUnit.cs
@@ -33,8 +33,7 @@ namespace Xamarin.Mac.Tests {
 
 			theUnit unit = GetAudioUnitForTest ();
 
-			uint device = unit.GetCurrentDevice (AudioUnitScopeType.Global);
-			Assert.IsTrue (device != 0);
+			Assert.DoesNotThrow (() => unit.GetCurrentDevice (AudioUnitScopeType.Global));
 		}
 
 		[Test]

--- a/tests/monotouch-test/CoreMedia/CMClockTest.cs
+++ b/tests/monotouch-test/CoreMedia/CMClockTest.cs
@@ -31,6 +31,8 @@ namespace MonoTouchFixtures.CoreMedia {
 		{
 			CMClockError ce;
 			using (var clock = CMClock.CreateAudioClock (out ce)) {
+				if (ce == (CMClockError) (-101))
+					TestRuntime.IgnoreInCI ("For unknown reasons, we might get -101 as an error code on the bots sometimes.");
 				Assert.AreEqual (CMClockError.None, ce);
 			}
 		}


### PR DESCRIPTION
Sample failures this will hopefully fix:

    Xamarin.Mac.Tests.AudioUnitTests
    	[PASS] AudioObjectPropertyScope4CCTest
    	[PASS] AudioObjectPropertySelector4CCTest
    	[FAIL] GetCurrentDevice_Test :   Expected: True
      But was:  False

    		   at Xamarin.Mac.Tests.AudioUnitTests.GetCurrentDevice_Test() in /Users/builder/azdo/_work/1/s/macios/tests/monotouch-test/AudioUnit/AudioUnit.cs:line 37
    Xamarin.Mac.Tests.AudioUnitTests : 9.0972 ms

    Xamarin.Mac.Tests.AUGraphTests
    	[FAIL] DoTest : Did not see events after 1 second
    		   at Xamarin.Mac.Tests.AUGraphTests.WaitOnGraphAndMixerCallbacks() in /Users/builder/azdo/_work/1/s/macios/tests/monotouch-test/AudioUnit/AUGraphTestMac.cs:line 94
    		   at Xamarin.Mac.Tests.AUGraphTests.DoTest() in /Users/builder/azdo/_work/1/s/macios/tests/monotouch-test/AudioUnit/AUGraphTestMac.cs:line 67
    Xamarin.Mac.Tests.AUGraphTests : 3955.9891 ms

    MonoTouchFixtures.CoreMedia.CMClockTest
    	[FAIL] CreateAudioClock :   Expected: None
      But was:  -101
    		   at MonoTouchFixtures.CoreMedia.CMClockTest.CreateAudioClock() in /Users/builder/azdo/_work/1/s/macios/tests/monotouch-test/CoreMedia/CMClockTest.cs:line 34
    	[PASS] HostTimeClock
    MonoTouchFixtures.CoreMedia.CMClockTest : 5.667 ms