### PR TITLE
[devops] Clear old Xcode settings.

### DIFF
--- a/tools/devops/automation/templates/windows/reserve-mac.yml
+++ b/tools/devops/automation/templates/windows/reserve-mac.yml
@@ -94,6 +94,11 @@ steps:
 - bash: make -C $(Build.SourcesDirectory)/$(BUILD_REPOSITORY_TITLE)/tools/devops provisioning
   displayName: 'Generate Xcode provisioning csx file'
 
+- bash:
+    rm -f ~/Library/Preferences/maui/Settings.plist
+    rm -f ~/Library/Preferences/Xamarin/Settings.plist
+  displayName: 'Clear old Xcode settings'
+
 - task: xamops.azdevex.provisionator-task.provisionator@2
   displayName: 'Provision Xcode'
   inputs:


### PR DESCRIPTION
Provisionator isn't able to write to the new location yet, so remove both
settings locations just to make sure everything is pristine before asking the
provisionator to install Xcode.

This will hopefully fix an issue where the build picks up an earlier version of the settings plist with the wrong Xcode version.