### PR TITLE
[release/9.0.1xx] Use 'EnableDiagnostics' instead of 'EnableProfiler'.

### DIFF
--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -314,9 +314,9 @@ If the .pkg that was created (if `CreatePackage` was enabled) should be signed.
 
 Only applicable to macOS and Mac Catalyst.
 
-## EnableProfiler
+## EnableDiagnostics
 
-Enable components that are required for profiling to work.
+Enable components that are required for diagnostics (such as profiling) to work.
 
 It's enabled by default for debug builds (when [MtouchDebug](#MtouchDebug) or
 [MmpDebug](#MmpDebug) is enabled), but needs to be enabled manually before
@@ -324,14 +324,14 @@ profiling release builds:
 
 ```xml
 <PropertyGroup>
-  <EnableProfiler>true</EnableProfiler>
+  <EnableDiagnostics>true</EnableDiagnostics>
 </PropertyGroup>
 ```
 
 This will increase the app size slightly.
 
 Only applicable when using the Mono runtime (CoreCLR always supports
-profiling, while NativeAOT never does).
+diagnostics, while NativeAOT never does).
 
 ## EnableSGenConc
 

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -452,7 +452,7 @@
 		<ItemGroup>
 			<_MonoComponent Include="hot_reload" Condition="'$(MtouchInterpreter)' != ''" />
 			<_MonoComponent Include="debugger" Condition="'$(_BundlerDebug)' == 'true'" />
-			<_MonoComponent Include="diagnostics_tracing" Condition="'$(EnableProfiler)' == 'true'" />
+			<_MonoComponent Include="diagnostics_tracing" Condition="'$(EnableDiagnostics)' == 'true'" />
 			<_MonoComponent Include="marshal-ilgen" Condition="'$(_AppleExcludeMarshalIlgenComponent)' != 'true'" />
 		</ItemGroup>
 	</Target>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.props
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.props
@@ -237,7 +237,7 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 		<!-- that also encapsulates whether we're a library or not (this makes conditions simpler) -->
 		<_BundleOriginalResources Condition="'$(OutputType)' == 'Library' And '$(IsAppExtension)' != 'true' And '$(BundleOriginalResources)' == 'true'">true</_BundleOriginalResources>
 
-		<EnableProfiler Condition="'$(EnableProfiler)' == '' And '$(_BundlerDebug)' == 'true'">true</EnableProfiler>
+		<EnableDiagnostics Condition="'$(EnableDiagnostics)' == '' And '$(_BundlerDebug)' == 'true'">true</EnableDiagnostics>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(IsBindingProject)' == 'true'">

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -148,7 +148,7 @@ namespace Xamarin.Bundler {
 		public List<string> WarnOnTypeRef = new List<string> ();
 
 		public bool EnableSGenConc;
-		public bool EnableProfiling;
+		public bool EnableDiagnostics;
 		public bool? DebugTrack;
 
 		public Dictionary<string, string> EnvironmentVariables = new Dictionary<string, string> ();

--- a/tools/common/Target.cs
+++ b/tools/common/Target.cs
@@ -360,7 +360,7 @@ namespace Xamarin.Bundler {
 				}
 
 #if MONOTOUCH
-				if (App.EnableProfiling && App.LibProfilerLinkMode == AssemblyBuildTarget.StaticObject)
+				if (App.EnableDiagnostics && App.LibProfilerLinkMode == AssemblyBuildTarget.StaticObject)
 					dynamic_symbols.AddFunction ("mono_profiler_init_log");
 #endif
 
@@ -678,7 +678,7 @@ namespace Xamarin.Bundler {
 			// On iOS we can pass -u to the native linker, but that doesn't work on tvOS, where
 			// we're building with bitcode (even when bitcode is disabled, we still build with the
 			// bitcode marker, which makes the linker reject -u).
-			if (app.EnableProfiling) {
+			if (app.EnableDiagnostics) {
 				sw.WriteLine ("extern \"C\" { void mono_profiler_init_log (); }");
 				sw.WriteLine ("typedef void (*xamarin_profiler_symbol_def)();");
 				sw.WriteLine ("extern xamarin_profiler_symbol_def xamarin_profiler_symbol;");
@@ -706,7 +706,7 @@ namespace Xamarin.Bundler {
 			sw.WriteLine ("void xamarin_setup_impl ()");
 			sw.WriteLine ("{");
 
-			if (app.EnableProfiling)
+			if (app.EnableDiagnostics)
 				sw.WriteLine ("\txamarin_profiler_symbol = mono_profiler_init_log;");
 
 			if (app.UseInterpreter) {


### PR DESCRIPTION
Ref: https://github.com/dotnet/runtime/issues/115473#issuecomment-2933946678

Android will do the same.

Backport of #22982.