### PR TITLE
[msbuild] Don't connect to a remote mac for library projects that are bundling original resources.

### DIFF
--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
@@ -32,7 +32,7 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 
 	<Target Name="EnsureMacConnection" 
 		DependsOnTargets="_SayHello" 
-		Condition="'$(_RequiresMacConnection) == 'true'"
+		Condition="'$(_RequiresMacConnection)' == 'true'"
 		BeforeTargets="_CleanDebugSymbols;_CleanAppBundle;_DetectAppManifest;_DetectSdkLocations;_GenerateBundleName" />
 	
 	<PropertyGroup>

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
@@ -24,8 +24,15 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Messaging.Build.targets" Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Messaging.Build.targets') And '$(MessagingBuildTargetsImported)' != 'true'" />
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.iOS.Windows.After.targets" Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.iOS.Windows.After.targets')" />
 
+	<PropertyGroup>
+		<_RequiresMacConnection Condition="'$(_RequiresMacConnection)' == '' And '$(_CanOutputAppBundle)' == 'true'">true</_RequiresMacConnection>
+		<_RequiresMacConnection Condition="'$(_RequiresMacConnection)' == '' And '$(_BundleOriginalResources)' != 'true'">true</_RequiresMacConnection>
+		<_RequiresMacConnection Condition="'$(_RequiresMacConnection)' == ''">false</_RequiresMacConnection>
+	</PropertyGroup>
+
 	<Target Name="EnsureMacConnection" 
 		DependsOnTargets="_SayHello" 
+		Condition="'$(_RequiresMacConnection) == 'true'"
 		BeforeTargets="_CleanDebugSymbols;_CleanAppBundle;_DetectAppManifest;_DetectSdkLocations;_GenerateBundleName" />
 	
 	<PropertyGroup>


### PR DESCRIPTION
Recently we added support for fully building library and binding projects on
Windows, without connecting to a remote Mac.

This fix makes it so that we won't connect to the Mac when it's not needed.