### PR TITLE
[msbuild] Enable design-time builds for binding projects when bundling original resources. Fixes #10148.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.ObjCBinding.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.ObjCBinding.targets
@@ -30,7 +30,7 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 
 	<Target Name="_CollectGeneratedSources"
 		DependsOnTargets="_GenerateBindings;_CompressNativeFrameworkResources"
-		Condition="'$(DesignTimeBuild)' != 'true'"
+		Condition="'$(_DisableBindingProjectBuild)' != 'true'"
 	>
 
 		<ReadLinesFromFile File="$(_GeneratedSourcesFileList)" >
@@ -109,7 +109,7 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 		</ItemGroup>
 	</Target>
 
-	<Target Name="_PrepareNativeReferences" Condition="'$(DesignTimeBuild)' != 'true'" DependsOnTargets="_SanitizeNativeReferences">
+	<Target Name="_PrepareNativeReferences" Condition="'$(_DisableBindingProjectBuild)' != 'true'" DependsOnTargets="_SanitizeNativeReferences">
 		<PrepareNativeReferences
 			IntermediateOutputPath="$(IntermediateOutputPath)"
 			NativeReferences="@(NativeReference)"

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.props
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.props
@@ -265,6 +265,9 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 
 		<!-- Default NoBindingEmbedding to 'true' for .NET projects, it's the new way -->
 		<NoBindingEmbedding Condition="'$(NoBindingEmbedding)' == ''">true</NoBindingEmbedding>
+
+		<!-- We don't want to build a binding project when in design time mode, and not bundling original resources, because we might end up requiring a connection to a remote mac, which is not a good idea for a supposedly quick design-time build. -->
+		<_DisableBindingProjectBuild Condition="'$(_DisableBindingProjectBuild)' == '' And '$(BundleOriginalResources)' != 'true' And '$(DesignTimeBuild)' == 'true'">true</_DisableBindingProjectBuild>
 	</PropertyGroup>
 
 	<Target Name="_ComputeTargetFrameworkMoniker" Condition="'$(_ComputedTargetFrameworkMoniker)' == ''">

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -144,7 +144,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		@(NativeReference) are not safe to use as an Input to a task, as frameworks are a directory and will appears unbuilt every time.
 		So we split it into two camps as a prebuild step
 	-->
-	<Target Name="_ExpandNativeReferences" Condition="'$(DesignTimeBuild)' != 'true'" DependsOnTargets="_DetectSdkLocations;_ComputeTargetArchitectures;_GenerateBundleName;_SanitizeNativeReferences">
+	<Target Name="_ExpandNativeReferences" Condition="'$(_DisableBindingProjectBuild)' != 'true'" DependsOnTargets="_DetectSdkLocations;_ComputeTargetArchitectures;_GenerateBundleName;_SanitizeNativeReferences">
 		<ItemGroup>
 			<_XCFrameworkNativeReference Include="@(NativeReference -> '%(Identity)/.')" Condition="'%(Extension)' == '.xcframework' Or $([MSBuild]::ValueOrDefault('%(FileName)%(Extension)', '').EndsWith('.xcframework.zip'))" />
 			<_FrameworkNativeReference Include="@(NativeReference -> '%(Identity)/%(Filename)')" Condition="'%(Extension)' == '.framework'" />
@@ -174,7 +174,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	</PropertyGroup>
 
 	<Target Name="_CreateBindingResourcePackage"
-		Condition="'$(DesignTimeBuild)' != 'true' And '$(NoBindingEmbedding)' == 'true'"
+		Condition="'$(_DisableBindingProjectBuild)' != 'true' And '$(NoBindingEmbedding)' == 'true'"
 		DependsOnTargets="_ExpandNativeReferences"
 		Inputs="$(MSBuildAllProjects);$(MSBuildProjectFullPath);@(ObjcBindingApiDefinition);@(ObjcBindingCoreSource);@(ReferencePath);@(ObjcBindingNativeLibrary);@(_FrameworkNativeReference);@(_FileNativeReference)"
 		Outputs="$(BindingResourcePath).stamp">
@@ -1859,7 +1859,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			@(_CompiledApiDefinitionsCompile);"
 		Outputs="$(_CompiledApiDefinitionAssembly);$(_CompiledApiDefinitionDocumentationFile)"
 		DependsOnTargets="_ComputeCompileApiDefinitionsInputs"
-		Condition="'$(IsBindingProject)' == 'true' And '$(DesignTimeBuild)' != 'true'"
+		Condition="'$(IsBindingProject)' == 'true' And '$(_DisableBindingProjectBuild)' != 'true'"
 		>
 
 		<!-- This is a mirror of the method GetCompiledApiBindingsAssembly in BindingTouch.cs where the compilation is done inside bgen -->
@@ -1897,7 +1897,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		Inputs="$(MSBuildAllProjects);@(ObjcBindingApiDefinition);@(ObjcBindingCoreSource);@(ReferencePath);@(ObjcBindingNativeLibrary)"
 		Outputs="$(_GeneratedSourcesFileList)"
 		DependsOnTargets="$(_GenerateBindingsDependsOn)"
-		Condition="'$(IsBindingProject)' == 'true' And '$(DesignTimeBuild)' != 'true'">
+		Condition="'$(IsBindingProject)' == 'true' And '$(_DisableBindingProjectBuild)' != 'true'">
 
 		<Error Condition="'$(IsMacEnabled)' != 'true' And '$(BuildBindingProjectLocally)' != 'true'" Text="The property 'BuildBindingProjectLocally' build is disabled, but there's no connection to a remote Mac." />
 

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.ObjCBinding.CSharp.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.ObjCBinding.CSharp.After.targets
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 ***********************************************************************************************
 Xamarin.iOS.ObjcBinding.CSharp.After.targets
@@ -19,29 +19,6 @@ Copyright (C) 2013-2016 Xamarin Inc. All rights reserved.
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.iOS.Windows.After.targets" Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.iOS.Windows.After.targets')" />
 
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.PrepareObjCBindingNativeFrameworks" AssemblyFile="$(CoreiOSSdkDirectory)$(_TaskAssemblyFileName)" />
-	
-	<PropertyGroup Condition="'$(DesignTimeBuild)' != 'true'">
-		<CompileDependsOn>
-			_SetupDesignTimeBuildForCompile;
-			$(CompileDependsOn)
-		</CompileDependsOn>
-		<BuildDependsOn>
-			_SetupDesignTimeBuildForBuild;
-			$(BuildDependsOn);
-		</BuildDependsOn>
-	</PropertyGroup>
-	
-	<Target Name="_SetupDesignTimeBuildForCompile">
-		<PropertyGroup>
-			<DesignTimeBuild Condition=" '$(DesignTimeBuild)' == '' ">true</DesignTimeBuild>
-		</PropertyGroup>
-	</Target>
-	
-	<Target Name="_SetupDesignTimeBuildForBuild">
-		<PropertyGroup>
-			<DesignTimeBuild Condition=" '$(DesignTimeBuild)' == '' ">false</DesignTimeBuild>
-		</PropertyGroup>
-	</Target>
 
 	<Target Name="CopyCompressedNativeFrameworkResources" Condition="'@(_NativeFrameworkResource)' != ''" AfterTargets="_CompressNativeFrameworkResources">
 		<CopyFileFromBuildServer SessionId="$(BuildSessionId)" File="$(IntermediateOutputPath)%(_NativeFramework.Filename)%(_NativeFramework.Extension)" />


### PR DESCRIPTION
Traditionally we've disabled building projects when doing design-time builds
(in an IDE), because such builds have to be quick, but building binding
projects required a remote connection to a Mac when building from Windows.

However, we recently completed support for building binding projects fully on
Windows, with one caveat: the option to bundle original resources in the
binding assembly has to be enabled (off by default in .NET 9, on by default in
.NET 10+), because otherwise the remote mac connection is still needed.

So here we enable design-time builds, as long as the project is bundling
original resources, since the entire binding project will be built on Windows.

Fixes https://github.com/dotnet/macios/issues/10148.