### PR TITLE
[src] Misc NSString improvements.

### DIFF
--- a/docs/api/Foundation/NSString.xml
+++ b/docs/api/Foundation/NSString.xml
@@ -36,31 +36,4 @@
     </remarks>
     <related type="externalDocumentation" href="https://developer.apple.com/library/ios/documentation/Cocoa/Reference/Foundation/Classes/NSString_Class/index.html">Apple documentation for <c>NSString</c></related>
   </Docs>
-  <Docs DocId="M:Foundation.NSString.CreateNative(System.String)">
-        <param name="str">C# String to wrap</param>
-        <summary>Creates an Objective-C NSString from the C# string and returns a pointer to it.</summary>
-        <returns>Pointer to the <see cref="NSString" /> object, must be released with <see cref="ReleaseNative" />.</returns>
-        <remarks>
-          <para>
-	    This method creates an Objective-C NSString and returns an
-	    IntPtr that points to it.  This does not create the managed
-	    NSString object that points to it, which is ideal for
-	    transient strings that must be passed to Objectiv-C as it is
-	    not necessary for Mono's Garbage collector or the
-	    MonoTouch/Xamarin.Mac Framework engines to track this object.
-	  </para>
-          <para>
-	    The memory associated with this object should be released
-	    by calling the <see cref="Foundation.NSString.ReleaseNative" />
-	    method.
-	  </para>
-          <example>
-            <code lang="csharp lang-csharp"><![CDATA[
-IntPtr objcString = NSString.CreateNative ("Hello");
-// You can pass objcString to any methods that expect an Objective-C NSString pointer
-NSString.ReleaseNative (objcString);
-]]></code>
-          </example>
-        </remarks>
-      </Docs>
 </Documentation>

--- a/src/AppKit/NSImage.cs
+++ b/src/AppKit/NSImage.cs
@@ -96,7 +96,7 @@ namespace AppKit {
 		///         <remarks>To be added.</remarks>
 		public static NSImage? ImageNamed (NSImageName name)
 		{
-			return ImageNamed (name.GetConstant ());
+			return ImageNamed (name.GetConstant ()!);
 		}
 	}
 

--- a/src/AppKit/NSStringAttributes.cs
+++ b/src/AppKit/NSStringAttributes.cs
@@ -413,9 +413,9 @@ namespace AppKit {
 		/// <summary>To be added.</summary>
 		///         <value>To be added.</value>
 		///         <remarks>To be added.</remarks>
-		public string ToolTip {
+		public string? ToolTip {
 			get { return Get (NSStringAttributeKey.ToolTip, handle => new NSString (handle)); }
-			set { SetNativeValue (NSStringAttributeKey.ToolTip, new NSString (value)); }
+			set { SetNativeValue (NSStringAttributeKey.ToolTip, (NSString?) value); }
 		}
 
 		/// <summary>To be added.</summary>

--- a/src/CoreMedia/CMAttachmentBearer.cs
+++ b/src/CoreMedia/CMAttachmentBearer.cs
@@ -97,7 +97,7 @@ namespace CoreMedia {
 		///         <remarks>To be added.</remarks>
 		public static T? GetAttachment<T> (this ICMAttachmentBearer target, CMSampleBufferAttachmentKey key, out CMAttachmentMode attachmentModeOut) where T : class, INativeObject
 		{
-			return GetAttachment<T> (target, key.GetConstant (), out attachmentModeOut);
+			return GetAttachment<T> (target, key.GetConstant ()!, out attachmentModeOut);
 		}
 
 		[DllImport (Constants.CoreMediaLibrary)]

--- a/src/CoreServices/LaunchServices.cs
+++ b/src/CoreServices/LaunchServices.cs
@@ -378,14 +378,14 @@ namespace CoreServices {
 		///         <remarks>To be added.</remarks>
 		[SupportedOSPlatform ("macos")]
 		[ObsoletedOSPlatform ("macos14.0")]
-		public static string GetDefaultRoleHandlerForContentType (string contentType, LSRoles roles = LSRoles.All)
+		public static string? GetDefaultRoleHandlerForContentType (string contentType, LSRoles roles = LSRoles.All)
 		{
 			if (contentType is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (contentType));
 
 			var contentTypeHandle = CFString.CreateNative (contentType);
 			try {
-				return (string) Runtime.GetNSObject<NSString> (
+				return Runtime.GetNSObject<NSString> (
 					LSCopyDefaultRoleHandlerForContentType (contentTypeHandle, roles)
 				);
 			}
@@ -470,14 +470,14 @@ namespace CoreServices {
 		///         <remarks>To be added.</remarks>
 		[SupportedOSPlatform ("macos")]
 		[ObsoletedOSPlatform ("macos10.15", "Use 'GetDefaultApplicationUrlForUrl' instead.")]
-		public static string GetDefaultHandlerForUrlScheme (string urlScheme)
+		public static string? GetDefaultHandlerForUrlScheme (string urlScheme)
 		{
 			if (urlScheme is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (urlScheme));
 
 			var urlSchemeHandle = CFString.CreateNative (urlScheme);
 			try {
-				return (string) Runtime.GetNSObject<NSString> (
+				return Runtime.GetNSObject<NSString> (
 					LSCopyDefaultHandlerForURLScheme (urlSchemeHandle)
 				);
 			}

--- a/src/CoreTelephony/CoreTelephony.cs
+++ b/src/CoreTelephony/CoreTelephony.cs
@@ -11,7 +11,7 @@ namespace CoreTelephony {
 		/// <summary>To be added.</summary>
 		///         <value>To be added.</value>
 		///         <remarks>To be added.</remarks>
-		public string StateDialing {
+		public string? StateDialing {
 			get {
 				return Dlfcn.SlowGetStringConstant (Constants.CoreTelephonyLibrary, "CTCallStateDialing");
 			}
@@ -20,7 +20,7 @@ namespace CoreTelephony {
 		/// <summary>To be added.</summary>
 		///         <value>To be added.</value>
 		///         <remarks>To be added.</remarks>
-		public string StateIncoming {
+		public string? StateIncoming {
 			get {
 				return Dlfcn.SlowGetStringConstant (Constants.CoreTelephonyLibrary, "CTCallStateIncoming");
 			}
@@ -29,7 +29,7 @@ namespace CoreTelephony {
 		/// <summary>To be added.</summary>
 		///         <value>To be added.</value>
 		///         <remarks>To be added.</remarks>
-		public string StateConnected {
+		public string? StateConnected {
 			get {
 				return Dlfcn.SlowGetStringConstant (Constants.CoreTelephonyLibrary, "CTCallStateConnected");
 			}
@@ -38,7 +38,7 @@ namespace CoreTelephony {
 		/// <summary>To be added.</summary>
 		///         <value>To be added.</value>
 		///         <remarks>To be added.</remarks>
-		public string StateDisconnected {
+		public string? StateDisconnected {
 			get {
 				return Dlfcn.SlowGetStringConstant (Constants.CoreTelephonyLibrary, "CTCallStateDisconnected");
 			}

--- a/src/Foundation/NSExceptionError.cs
+++ b/src/Foundation/NSExceptionError.cs
@@ -14,7 +14,7 @@ namespace Foundation {
 		public Exception Exception { get => exception; }
 
 		public NSExceptionError (Exception exception)
-			: base ((NSString) exception.GetType ().FullName, exception.HResult, GetDictionary (exception))
+			: base ((NSString) exception.GetType ().FullName!, exception.HResult, GetDictionary (exception))
 		{
 			this.exception = exception;
 			IsDirectBinding = false;

--- a/src/Foundation/NSString.cs
+++ b/src/Foundation/NSString.cs
@@ -25,6 +25,7 @@ using System;
 using System.Reflection;
 using System.Collections;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 #if !COREBUILD
@@ -33,8 +34,7 @@ using CoreGraphics;
 #endif
 using ObjCRuntime;
 
-// Disable until we get around to enable + fix any issues.
-#nullable disable
+#nullable enable
 
 namespace Foundation {
 
@@ -53,103 +53,71 @@ namespace Foundation {
 #endif
 	 {
 #if !COREBUILD
-		const string selUTF8String = "UTF8String";
-		const string selInitWithCharactersLength = "initWithCharacters:length:";
-
-#if MONOMAC
-		static IntPtr selUTF8StringHandle = Selector.GetHandle (selUTF8String);
-		static IntPtr selInitWithCharactersLengthHandle = Selector.GetHandle (selInitWithCharactersLength);
-#endif
-
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>An <see cref="NSString" /> instance for an empty (zero-length) string.</summary>
 		public static readonly NSString Empty = new NSString (String.Empty);
 
 		internal NSString (NativeHandle handle, bool owns) : base (handle, owns)
 		{
 		}
 
-		static NativeHandle CreateWithCharacters (NativeHandle handle, string str, int offset, int length, bool autorelease = false)
-		{
-			unsafe {
-				fixed (char* ptrFirstChar = str) {
-					var ptrStart = (IntPtr) (ptrFirstChar + offset);
-#if MONOMAC
-					handle = Messaging.IntPtr_objc_msgSend_IntPtr_IntPtr (handle, selInitWithCharactersLengthHandle, ptrStart, (IntPtr) length);
-#else
-					handle = Messaging.IntPtr_objc_msgSend_IntPtr_IntPtr (handle, Selector.GetHandle (selInitWithCharactersLength), ptrStart, (IntPtr) length);
-#endif
-
-					if (autorelease)
-						NSObject.DangerousAutorelease (handle);
-
-					return handle;
-				}
-			}
-		}
-
-		/// <include file="../../docs/api/Foundation/NSString.xml" path="/Documentation/Docs[@DocId='M:Foundation.NSString.CreateNative(System.String)']/*" />
-		[Obsolete ("Use of 'CFString.CreateNative' offers better performance.")]
-		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static NativeHandle CreateNative (string str)
+		/// <summary>Creates an Objective-C NSString from the C# string and returns a pointer to it.</summary>
+		/// <param name="str">C# String to wrap</param>
+		/// <returns>Pointer to the <see cref="NSString" /> object, must be released with <see cref="ReleaseNative" />.</returns>
+		/// <remarks>
+		///   <para>
+		///     This method creates an Objective-C NSString and returns an
+		///     <see cref="NativeHandle" /> that points to it.  This does not create the managed
+		///     NSString object that points to it, which is ideal for
+		///     transient strings that must be passed to Objective-C as it is
+		///     not necessary for the garbage collector to track this object.
+		///   </para>
+		///   <para>
+		///     The memory associated with this object should be released
+		///     by calling the <see cref="ReleaseNative" />
+		///     method.
+		///   </para>
+		///   <example>
+		///     <code lang="csharp lang-csharp"><![CDATA[
+		/// IntPtr objcString = NSString.CreateNative ("Hello");
+		/// // You can pass objcString to any methods that expect an Objective-C NSString pointer
+		/// NSString.ReleaseNative (objcString);
+		/// ]]></code></example>
+		///   </remarks>
+		public static NativeHandle CreateNative (string? str)
 		{
 			return CreateNative (str, false);
 		}
 
-		/// <param name="str">To be added.</param>
-		///         <param name="autorelease">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
-		public static NativeHandle CreateNative (string str, bool autorelease)
+		/// <inheritdoc cref="CreateNative(string)" />
+		/// <param name="str">C# String to wrap</param>
+		/// <param name="autorelease">Whether the return value is autoreleased (in which case <see cref="ReleaseNative" /> must not be called on the return value).</param>
+		public static NativeHandle CreateNative (string? str, bool autorelease)
 		{
-			if (str is null)
-				return NativeHandle.Zero;
-
-			return CreateNative (str, 0, str.Length, autorelease);
+			return CFString.CreateNative (str, autorelease);
 		}
 
-		/// <param name="value">To be added.</param>
-		///         <param name="start">To be added.</param>
-		///         <param name="length">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
-		public static NativeHandle CreateNative (string value, int start, int length)
+		/// <inheritdoc cref="CreateNative(string)" />
+		/// <param name="value">C# String to wrap</param>
+		/// <param name="start">The offset of the managed string to create the native string from.</param>
+		/// <param name="length">The length of the managed string to create the native string from.</param>
+		public static NativeHandle CreateNative (string? value, int start, int length)
 		{
-			return CreateNative (value, start, length, false);
+			return CFString.CreateNative (value, start, length, false);
 		}
 
-		/// <param name="value">To be added.</param>
-		///         <param name="start">To be added.</param>
-		///         <param name="length">To be added.</param>
-		///         <param name="autorelease">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
-		public static NativeHandle CreateNative (string value, int start, int length, bool autorelease)
+		/// <inheritdoc cref="CreateNative(string)" />
+		/// <param name="value">C# String to wrap</param>
+		/// <param name="start">The offset of the managed string to create the native string from.</param>
+		/// <param name="length">The length of the managed string to create the native string from.</param>
+		/// <param name="autorelease">Whether the return value is autoreleased (in which case <see cref="ReleaseNative" /> must not be called on the return value).</param>
+		public static NativeHandle CreateNative (string? value, int start, int length, bool autorelease)
 		{
-			if (value is null)
-				return NativeHandle.Zero;
-
-			if (start < 0 || start > value.Length)
-				throw new ArgumentOutOfRangeException (nameof (start));
-
-			if (length < 0 || start > value.Length - length)
-				throw new ArgumentOutOfRangeException (nameof (length));
-
-#if MONOMAC
-			var handle = Messaging.IntPtr_objc_msgSend (class_ptr, Selector.AllocHandle);
-#else
-			var handle = Messaging.IntPtr_objc_msgSend (class_ptr, Selector.GetHandle (Selector.Alloc));
-#endif
-
-			return CreateWithCharacters (handle, value, start, length, autorelease);
+			return CFString.CreateNative (value, start, length, autorelease);
 		}
 
 		/// <param name="handle">Handle to the Objective-C native NSString object.</param>
 		/// <summary>Releases a native Objective-C string.</summary>
-		/// <remarks>Use this method to release Objective-C NSString handles that were previously allocated with <see cref="Foundation.NSString.CreateNative(System.String)" />.</remarks>
+		/// <remarks>Use this method to release Objective-C NSString handles that were previously allocated with <see cref="CreateNative(System.String)" />.</remarks>
 		public static void ReleaseNative (NativeHandle handle)
 		{
 			NSObject.DangerousRelease (handle);
@@ -158,12 +126,8 @@ namespace Foundation {
 		/// <summary>Creates an <see cref="NSString" /> from a C# string.</summary>
 		/// <param name="str">A C# string to create an <see cref="NSString" /> from.</param>
 		public NSString (string str)
-			: base (NSObjectFlag.Empty)
+			: base (CFString.CreateNative (ThrowHelper.ThrowIfNull (str)))
 		{
-			if (str is null)
-				throw new ArgumentNullException (nameof (str));
-
-			InitializeHandle (CreateWithCharacters (Handle, str, 0, str.Length));
 		}
 
 		/// <summary>Creates an <see cref="NSString" /> from a C# string.</summary>
@@ -171,92 +135,63 @@ namespace Foundation {
 		/// <param name="start">The starting index of the <paramref name="value" /> string to create the <see cref="NSString" /> from.</param>
 		/// <param name="length">The length, starting at <paramref name="start" />, of the <paramref name="value" /> string to create the <see cref="NSString" /> from.</param>
 		public NSString (string value, int start, int length)
-			: base (NSObjectFlag.Empty)
+			: base (CFString.CreateNative (ThrowHelper.ThrowIfNull (value), start, length, false))
 		{
-			if (value is null)
-				throw new ArgumentNullException (nameof (value));
-
-			if (start < 0 || start > value.Length)
-				throw new ArgumentOutOfRangeException (nameof (start));
-
-			if (length < 0 || start > value.Length - length)
-				throw new ArgumentOutOfRangeException (nameof (length));
-
-			InitializeHandle (CreateWithCharacters (Handle, value, start, length));
 		}
 
 		/// <summary>Returns a string representation of the value of the current instance.</summary>
-		///         <returns>
-		///         </returns>
-		///         <remarks>
-		///         </remarks>
 		public override string ToString ()
 		{
-			return FromHandle (Handle);
+			return FromHandle (Handle)!;
 		}
 
-		/// <param name="str">The NSString.</param>
-		/// <summary>Converts the NSString to a CIL/C# string.</summary>
-		/// <returns />
-		/// <remarks>To be added.</remarks>
-		public static implicit operator string (NSString str)
+		/// <summary>Converts the <see cref="NSString" /> to a managed string.</summary>
+		/// <param name="str">The NSString to convert.</param>
+		/// <returns>A managed string.</returns>
+		[return: NotNullIfNotNull (nameof (str))]
+		public static implicit operator string? (NSString? str)
 		{
-			if (((object) str) is null)
-				return null;
-			return str.ToString ();
+			return str?.ToString ();
 		}
 
-		public static explicit operator NSString (string str)
+		/// <summary>Converts the managed string to an <see cref="NSString" />.</summary>
+		/// <param name="str">The managed string to convert.</param>
+		/// <returns>A <see cref="NSString" /> instance.</returns>
+		[return: NotNullIfNotNull (nameof (str))]
+		public static explicit operator NSString? (string? str)
 		{
 			if (str is null)
 				return null;
 			return new NSString (str);
 		}
 
-		/// <summary>Utility method that returns a string from a pointer that points to an Objective-C NSString object.</summary>
-		/// <param name="usrhandle">Pointer to an Objective-C NSString object (not the managed NSString object).</param>
+		/// <summary>Utility method that returns a string from a pointer that points to an Objective-C NSString or CFString object.</summary>
+		/// <param name="usrhandle">Pointer to an Objective-C NSString or CFString object (not the managed NSString object).</param>
 		/// <returns>The Objective-C string in the NSString as a C# string.</returns>
-		[EditorBrowsable (EditorBrowsableState.Never)]
-		[Obsolete ("Use of 'CFString.FromHandle' offers better performance.")]
-		public static string FromHandle (NativeHandle usrhandle)
+		public static string? FromHandle (NativeHandle usrhandle)
 		{
 			return FromHandle (usrhandle, false);
 		}
 
-		/// <summary>Utility method that returns a string from a pointer that points to an Objective-C NSString object.</summary>
-		/// <param name="handle">Pointer to an Objective-C NSString object (not the managed NSString object).</param>
+		/// <summary>Utility method that returns a string from a pointer that points to an Objective-C NSString or CFString object.</summary>
+		/// <param name="handle">Pointer to an Objective-C NSString or CFString object (not the managed NSString object).</param>
 		/// <param name="owns">Whether the <paramref name="handle" /> should be released or not.</param>
 		/// <returns>The Objective-C string in the NSString as a C# string.</returns>
-		[EditorBrowsable (EditorBrowsableState.Never)]
-		[Obsolete ("Use of 'CFString.FromHandle' offers better performance.")]
-		public static string FromHandle (NativeHandle handle, bool owns)
+		public static string? FromHandle (NativeHandle handle, bool owns)
 		{
-			if (handle == NativeHandle.Zero)
-				return null;
-
-			try {
-#if MONOMAC
-				return Marshal.PtrToStringAuto (Messaging.IntPtr_objc_msgSend (handle, selUTF8StringHandle));
-#else
-				return Marshal.PtrToStringAuto (Messaging.IntPtr_objc_msgSend (handle, Selector.GetHandle (selUTF8String)));
-#endif
-			} finally {
-				if (owns)
-					DangerousRelease (handle);
-			}
+			return CFString.FromHandle (handle, owns);
 		}
 
-		/// <param name="a">To be added.</param>
-		///         <param name="b">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
-		public static bool Equals (NSString a, NSString b)
+		/// <summary>Compare two <see cref="NSString" /> instances.</summary>
+		/// <param name="a">The first <see cref="NSString" /> to compare.</param>
+		/// <param name="b">The second <see cref="NSString" /> to compare.</param>
+		/// <returns><see langword="true" /> if equal, <see langword="false" /> otherwise.</returns>
+		public static bool Equals (NSString? a, NSString? b)
 		{
 			if ((a as object) == (b as object))
 				return true;
 
-			if (((object) a) is null || ((object) b) is null)
+			if (a is null || b is null)
 				return false;
 
 			if (a.Handle == b.Handle)
@@ -266,21 +201,28 @@ namespace Foundation {
 			return result;
 		}
 
-		public static bool operator == (NSString a, NSString b)
+		/// <summary>Compare two <see cref="NSString" /> instances.</summary>
+		/// <param name="a">The first <see cref="NSString" /> to compare.</param>
+		/// <param name="b">The second <see cref="NSString" /> to compare.</param>
+		/// <returns><see langword="true" /> if equal, <see langword="false" /> otherwise.</returns>
+		public static bool operator == (NSString? a, NSString? b)
 		{
 			return Equals (a, b);
 		}
 
-		public static bool operator != (NSString a, NSString b)
+		/// <summary>Compare two <see cref="NSString" /> instances.</summary>
+		/// <param name="a">The first <see cref="NSString" /> to compare.</param>
+		/// <param name="b">The second <see cref="NSString" /> to compare.</param>
+		/// <returns><see langword="true" /> if not equal, <see langword="false" /> otherwise.</returns>
+		public static bool operator != (NSString? a, NSString? b)
 		{
 			return !Equals (a, b);
 		}
 
-		/// <param name="obj">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
-		public override bool Equals (Object obj)
+		/// <summary>Compare this <see cref="NSString" /> to another object.</summary>
+		/// <param name="obj">The other object to compare against.</param>
+		/// <returns><see langword="true" /> if equal, <see langword="false" /> otherwise.</returns>
+		public override bool Equals (object? obj)
 		{
 			return Equals (this, obj as NSString);
 		}
@@ -306,22 +248,20 @@ namespace Foundation {
 		[DllImport ("__Internal")]
 		extern static IntPtr xamarin_localized_string_format_9 (IntPtr fmt, IntPtr arg1, IntPtr arg2, IntPtr arg3, IntPtr arg4, IntPtr arg5, IntPtr arg6, IntPtr arg7, IntPtr arg8, IntPtr arg9);
 
-		/// <param name="format">To be added.</param>
-		///         <param name="args">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Format a localizable string with the specified arguments.</summary>
+		/// <param name="format">The localizable string to format.</param>
+		/// <param name="args">The arguments to apply to the localizable string.</param>
+		/// <returns>A localized string with the specified format arguments applied.</returns>
 		public static NSString LocalizedFormat (string format, params object [] args)
 		{
 			using (var ns = new NSString (format))
 				return LocalizedFormat (ns, args);
 		}
 
-		/// <param name="format">To be added.</param>
-		///         <param name="args">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Format a localizable string with the specified arguments.</summary>
+		/// <param name="format">The localizable string to format.</param>
+		/// <param name="args">The arguments to apply to the localizable string.</param>
+		/// <returns>A localized string with the specified format arguments applied.</returns>
 		public static NSString LocalizedFormat (NSString format, params object [] args)
 		{
 			int argc = args.Length;
@@ -332,11 +272,10 @@ namespace Foundation {
 			return LocalizedFormat (format, nso);
 		}
 
-		/// <param name="format">To be added.</param>
-		///         <param name="args">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Format a localizable string with the specified arguments.</summary>
+		/// <param name="format">The localizable string to format.</param>
+		/// <param name="args">The arguments to apply to the localizable string.</param>
+		/// <returns>A localized string with the specified format arguments applied.</returns>
 		public static NSString LocalizedFormat (NSString format, NSObject [] args)
 		{
 			NSString result;
@@ -380,19 +319,18 @@ namespace Foundation {
 			return result;
 		}
 
-		/// <param name="transform">To be added.</param>
-		///         <param name="reverse">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
-		public NSString TransliterateString (NSStringTransform transform, bool reverse)
+		/// <summary>Transliterate this string using the specified string transformation.</summary>
+		/// <param name="transform">The string transformation to use.</param>
+		/// <param name="reverse">Whether to apply the transformation in reverse or not.</param>
+		/// <returns>The transliterated string.</returns>
+		public NSString? TransliterateString (NSStringTransform transform, bool reverse)
 		{
-			return TransliterateString (transform.GetConstant (), reverse);
+			return TransliterateString (transform.GetConstant ()!, reverse);
 		}
 
 		/// <summary>Generates a hash code for the current instance.</summary>
-		///         <returns>A int containing the hash code for this instance.</returns>
-		///         <remarks>The algorithm used to generate the hash code is unspecified.</remarks>
+		/// <returns>A int containing the hash code for this instance.</returns>
+		/// <remarks>The algorithm used to generate the hash code is unspecified.</remarks>
 		public override int GetHashCode ()
 		{
 			return base.GetHashCode ();

--- a/src/MediaPlayer/MPNowPlayingInfoCenter.cs
+++ b/src/MediaPlayer/MPNowPlayingInfoCenter.cs
@@ -297,11 +297,11 @@ namespace MediaPlayer {
 				GC.KeepAlive (result);
 			}
 			if (TryGetValue (source, MPNowPlayingInfoCenter.PropertyCollectionIdentifier, out result))
-				CollectionIdentifier = (string) (result as NSString);
+				CollectionIdentifier = (string?) (result as NSString);
 			if (TryGetValue (source, MPNowPlayingInfoCenter.PropertyExternalContentIdentifier, out result))
-				ExternalContentIdentifier = (string) (result as NSString);
+				ExternalContentIdentifier = (string?) (result as NSString);
 			if (TryGetValue (source, MPNowPlayingInfoCenter.PropertyExternalUserProfileIdentifier, out result))
-				ExternalUserProfileIdentifier = (string) (result as NSString);
+				ExternalUserProfileIdentifier = (string?) (result as NSString);
 			if (TryGetValue (source, MPNowPlayingInfoCenter.PropertyPlaybackProgress, out result))
 				PlaybackProgress = (result as NSNumber)?.FloatValue;
 			if (TryGetValue (source, MPNowPlayingInfoCenter.PropertyMediaType, out result))
@@ -327,17 +327,17 @@ namespace MediaPlayer {
 				PlaybackDuration = (result as NSNumber)?.DoubleValue;
 
 			if (TryGetValue (source, MPMediaItem.AlbumTitleProperty, out result))
-				AlbumTitle = (string) (result as NSString);
+				AlbumTitle = (string?) (result as NSString);
 			if (TryGetValue (source, MPMediaItem.ArtistProperty, out result))
-				Artist = (string) (result as NSString);
+				Artist = (string?) (result as NSString);
 			if (TryGetValue (source, MPMediaItem.ArtworkProperty, out result))
 				Artwork = result as MPMediaItemArtwork;
 			if (TryGetValue (source, MPMediaItem.ComposerProperty, out result))
-				Composer = (string) (result as NSString);
+				Composer = (string?) (result as NSString);
 			if (TryGetValue (source, MPMediaItem.GenreProperty, out result))
-				Genre = (string) (result as NSString);
+				Genre = (string?) (result as NSString);
 			if (TryGetValue (source, MPMediaItem.TitleProperty, out result))
-				Title = (string) (result as NSString);
+				Title = (string?) (result as NSString);
 		}
 	}
 

--- a/src/ObjCRuntime/ThrowHelper.cs
+++ b/src/ObjCRuntime/ThrowHelper.cs
@@ -53,7 +53,7 @@ namespace ObjCRuntime {
 			throw new ObjectDisposedException (o.GetType ().ToString ());
 		}
 
-		internal static T ThrowIfNull<T> (T? value, [CallerArgumentExpression ("value")] string paramName = "") where T: class
+		internal static T ThrowIfNull<T> (T? value, [CallerArgumentExpression ("value")] string paramName = "") where T : class
 		{
 			if (value is null)
 				ThrowArgumentNullException (paramName);

--- a/src/ObjCRuntime/ThrowHelper.cs
+++ b/src/ObjCRuntime/ThrowHelper.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 // the linker will remove the attributes
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 #nullable enable
 
@@ -50,6 +51,13 @@ namespace ObjCRuntime {
 		public static void ThrowObjectDisposedException (object o)
 		{
 			throw new ObjectDisposedException (o.GetType ().ToString ());
+		}
+
+		internal static T ThrowIfNull<T> (T? value, [CallerArgumentExpression ("value")] string paramName = "") where T: class
+		{
+			if (value is null)
+				ThrowArgumentNullException (paramName);
+			return value;
 		}
 	}
 }

--- a/src/Security/SecStatusCodeExtensions.cs
+++ b/src/Security/SecStatusCodeExtensions.cs
@@ -39,7 +39,7 @@ namespace Security {
 		[SupportedOSPlatform ("tvos")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
-		public static string GetStatusDescription (this SecStatusCode status)
+		public static string? GetStatusDescription (this SecStatusCode status)
 		{
 			var ret = SecCopyErrorMessageString (status, IntPtr.Zero);
 			return Runtime.GetNSObject<NSString> (ret, owns: true);

--- a/src/VideoToolbox/VTVideoEncoder.cs
+++ b/src/VideoToolbox/VTVideoEncoder.cs
@@ -56,19 +56,19 @@ namespace VideoToolbox {
 		/// <summary>To be added.</summary>
 		///         <value>To be added.</value>
 		///         <remarks>To be added.</remarks>
-		public string CodecName { get; private set; }
+		public string? CodecName { get; private set; }
 		/// <summary>To be added.</summary>
 		///         <value>To be added.</value>
 		///         <remarks>To be added.</remarks>
-		public string DisplayName { get; private set; }
+		public string? DisplayName { get; private set; }
 		/// <summary>To be added.</summary>
 		///         <value>To be added.</value>
 		///         <remarks>To be added.</remarks>
-		public string EncoderId { get; private set; }
+		public string? EncoderId { get; private set; }
 		/// <summary>To be added.</summary>
 		///         <value>To be added.</value>
 		///         <remarks>To be added.</remarks>
-		public string EncoderName { get; private set; }
+		public string? EncoderName { get; private set; }
 
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios13.0")]

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -24688,7 +24688,7 @@ namespace AppKit {
 		/// <param name="identifier">To be added.</param>
 		/// <summary>To be added.</summary>
 		/// <remarks>To be added.</remarks>
-		[Wrap ("this (identifier.GetConstant ())")]
+		[Wrap ("this (identifier.GetConstant ()!)")]
 		NativeHandle Constructor (NSTouchBarItemIdentifier identifier);
 
 		[Export ("identifier")]

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -5381,7 +5381,7 @@ namespace AVFoundation {
 		///         <summary>Returns an array of tracks of the specified media type.</summary>
 		///         <returns>To be added.</returns>
 		///         <remarks>To be added.</remarks>
-		[Wrap ("TracksWithMediaType (mediaType.GetConstant ())")]
+		[Wrap ("TracksWithMediaType (mediaType.GetConstant ()!)")]
 		AVAssetTrack [] GetTracks (AVMediaTypes mediaType);
 
 		[Deprecated (PlatformName.MacOSX, 15, 0)]
@@ -5395,7 +5395,7 @@ namespace AVFoundation {
 		///         <summary>Returns an array of tracks that have the specified characteristic.</summary>
 		///         <returns>To be added.</returns>
 		///         <remarks>To be added.</remarks>
-		[Wrap ("TracksWithMediaType (mediaCharacteristic.GetConstant ())")]
+		[Wrap ("TracksWithMediaType (mediaCharacteristic.GetConstant ()!)")]
 		AVAssetTrack [] GetTracks (AVMediaCharacteristics mediaCharacteristic);
 
 		[Export ("lyrics"), NullAllowed]
@@ -5693,7 +5693,7 @@ namespace AVFoundation {
 		/// <summary>To be added.</summary>
 		/// <returns>To be added.</returns>
 		/// <remarks>To be added.</remarks>
-		[Wrap ("This.GetTracks (mediaType.GetConstant ())")]
+		[Wrap ("This.GetTracks (mediaType.GetConstant ()!)")]
 		AVFragmentedAssetTrack [] GetTracks (AVMediaTypes mediaType);
 
 		/// <param name="mediaCharacteristic">To be added.</param>
@@ -5707,7 +5707,7 @@ namespace AVFoundation {
 		/// <summary>To be added.</summary>
 		/// <returns>To be added.</returns>
 		/// <remarks>To be added.</remarks>
-		[Wrap ("This.GetTracksWithMediaCharacteristic (mediaCharacteristic.GetConstant ())")]
+		[Wrap ("This.GetTracksWithMediaCharacteristic (mediaCharacteristic.GetConstant ()!)")]
 		AVFragmentedAssetTrack [] GetTracks (AVMediaCharacteristics mediaCharacteristic);
 
 		[Async]
@@ -12378,7 +12378,7 @@ namespace AVFoundation {
 		/// <summary>To be added.</summary>
 		/// <returns>To be added.</returns>
 		/// <remarks>To be added.</remarks>
-		[Wrap ("This.GetTracks (mediaType.GetConstant ())")]
+		[Wrap ("This.GetTracks (mediaType.GetConstant ()!)")]
 		AVMovieTrack [] GetTracks (AVMediaTypes mediaType);
 
 		/// <param name="mediaCharacteristic">To be added.</param>
@@ -12392,7 +12392,7 @@ namespace AVFoundation {
 		/// <summary>To be added.</summary>
 		/// <returns>To be added.</returns>
 		/// <remarks>To be added.</remarks>
-		[Wrap ("This.GetTracksWithMediaCharacteristic (mediaCharacteristic.GetConstant ())")]
+		[Wrap ("This.GetTracksWithMediaCharacteristic (mediaCharacteristic.GetConstant ()!)")]
 		AVMovieTrack [] GetTracks (AVMediaCharacteristics mediaCharacteristic);
 
 		[Async]
@@ -12609,7 +12609,7 @@ namespace AVFoundation {
 		/// <summary>To be added.</summary>
 		/// <returns>To be added.</returns>
 		/// <remarks>To be added.</remarks>
-		[Wrap ("This.GetTracks (mediaType.GetConstant ())")]
+		[Wrap ("This.GetTracks (mediaType.GetConstant ()!)")]
 		AVMutableMovieTrack [] GetTracks (AVMediaTypes mediaType);
 
 		/// <param name="mediaCharacteristic">To be added.</param>
@@ -12623,7 +12623,7 @@ namespace AVFoundation {
 		/// <summary>To be added.</summary>
 		/// <returns>To be added.</returns>
 		/// <remarks>To be added.</remarks>
-		[Wrap ("This.GetTracksWithMediaCharacteristic (mediaCharacteristic.GetConstant ())")]
+		[Wrap ("This.GetTracksWithMediaCharacteristic (mediaCharacteristic.GetConstant ()!)")]
 		AVMutableMovieTrack [] GetTracks (AVMediaCharacteristics mediaCharacteristic);
 	}
 
@@ -12703,7 +12703,7 @@ namespace AVFoundation {
 		/// <summary>To be added.</summary>
 		/// <returns>To be added.</returns>
 		/// <remarks>To be added.</remarks>
-		[Wrap ("This.GetTracks (mediaType.GetConstant ())")]
+		[Wrap ("This.GetTracks (mediaType.GetConstant ()!)")]
 		AVFragmentedMovieTrack [] GetTracks (AVMediaTypes mediaType);
 
 		/// <param name="mediaCharacteristic">To be added.</param>
@@ -12717,7 +12717,7 @@ namespace AVFoundation {
 		/// <summary>To be added.</summary>
 		/// <returns>To be added.</returns>
 		/// <remarks>To be added.</remarks>
-		[Wrap ("This.GetTracksWithMediaCharacteristic (mediaCharacteristic.GetConstant ())")]
+		[Wrap ("This.GetTracksWithMediaCharacteristic (mediaCharacteristic.GetConstant ()!)")]
 		AVFragmentedMovieTrack [] GetTracks (AVMediaCharacteristics mediaCharacteristic);
 
 		[Async]
@@ -13302,7 +13302,7 @@ namespace AVFoundation {
 		/// <summary>To be added.</summary>
 		/// <returns>To be added.</returns>
 		/// <remarks>To be added.</remarks>
-		[Wrap ("This.GetTracks (mediaType.GetConstant ())")]
+		[Wrap ("This.GetTracks (mediaType.GetConstant ()!)")]
 		AVCompositionTrack [] GetTracks (AVMediaTypes mediaType);
 
 		/// <param name="mediaCharacteristic">To be added.</param>
@@ -13316,7 +13316,7 @@ namespace AVFoundation {
 		/// <summary>To be added.</summary>
 		/// <returns>To be added.</returns>
 		/// <remarks>To be added.</remarks>
-		[Wrap ("This.GetTracksWithMediaCharacteristic (mediaCharacteristic.GetConstant ())")]
+		[Wrap ("This.GetTracksWithMediaCharacteristic (mediaCharacteristic.GetConstant ()!)")]
 		AVCompositionTrack [] GetTracks (AVMediaCharacteristics mediaCharacteristic);
 
 		[Async]
@@ -13416,7 +13416,7 @@ namespace AVFoundation {
 		/// <summary>To be added.</summary>
 		/// <returns>To be added.</returns>
 		/// <remarks>To be added.</remarks>
-		[Wrap ("This.GetTracks (mediaType.GetConstant ())")]
+		[Wrap ("This.GetTracks (mediaType.GetConstant ()!)")]
 		AVMutableCompositionTrack [] GetTracks (AVMediaTypes mediaType);
 
 		/// <param name="mediaCharacteristic">To be added.</param>
@@ -13430,7 +13430,7 @@ namespace AVFoundation {
 		/// <summary>To be added.</summary>
 		/// <returns>To be added.</returns>
 		/// <remarks>To be added.</remarks>
-		[Wrap ("This.GetTracksWithMediaCharacteristic (mediaCharacteristic.GetConstant ())")]
+		[Wrap ("This.GetTracksWithMediaCharacteristic (mediaCharacteristic.GetConstant ()!)")]
 		AVMutableCompositionTrack [] GetTracks (AVMediaCharacteristics mediaCharacteristic);
 
 		[Async]
@@ -13551,7 +13551,7 @@ namespace AVFoundation {
 		/// <param name="preset">To be added.</param>
 		/// <summary>Creates an export session from an AVAsset and a preset.</summary>
 		/// <remarks>To be added.</remarks>
-		[Wrap ("this (asset, preset.GetConstant ())")]
+		[Wrap ("this (asset, preset.GetConstant ()!)")]
 		NativeHandle Constructor (AVAsset asset, AVAssetExportSessionPreset preset);
 
 		[Export ("exportAsynchronouslyWithCompletionHandler:")]
@@ -15549,7 +15549,7 @@ namespace AVFoundation {
 		NSDictionary GetRecommendedVideoSettings (string videoCodecType, string outputFileType, [NullAllowed] NSUrl outputFileUrl);
 
 		[TV (17, 0), MacCatalyst (17, 0), Mac (14, 0), iOS (17, 0)]
-		[Wrap ("new AVPlayerItemVideoOutputSettings (GetRecommendedVideoSettings ((string) videoCodecType.GetConstant (), (string) outputFileType.GetConstant (), outputFileUrl)!)")]
+		[Wrap ("new AVPlayerItemVideoOutputSettings (GetRecommendedVideoSettings ((string) videoCodecType.GetConstant ()!, (string) outputFileType.GetConstant ()!, outputFileUrl)!)")]
 		[return: NullAllowed]
 		AVPlayerItemVideoOutputSettings GetRecommendedVideoSettings ([BindAs (typeof (AVVideoCodecType))] NSString videoCodecType, [BindAs (typeof (AVFileTypes))] NSString outputFileType, [NullAllowed] NSUrl outputFileUrl);
 
@@ -17271,7 +17271,7 @@ namespace AVFoundation {
 		///         <returns>To be added.</returns>
 		///         <remarks>To be added.</remarks>
 		[MacCatalyst (13, 1)]
-		[Wrap ("HasMediaType ((string) mediaType.GetConstant ())")]
+		[Wrap ("HasMediaType ((string) mediaType.GetConstant ()!)")]
 		bool HasMediaType (AVMediaTypes mediaType);
 
 		[MacCatalyst (13, 1)]

--- a/src/healthkit.cs
+++ b/src/healthkit.cs
@@ -2410,7 +2410,7 @@ namespace HealthKit {
 		///         <remarks>To be added.</remarks>
 		[MacCatalyst (13, 1)]
 		[Static]
-		[Wrap ("GetPredicateForClinicalRecords (source, resourceType.GetConstant (), identifier)")]
+		[Wrap ("GetPredicateForClinicalRecords (source, resourceType.GetConstant ()!, identifier)")]
 		NSPredicate GetPredicateForClinicalRecords (HKSource source, HKFhirResourceType resourceType, string identifier);
 
 		// @interface HKElectrocardiogramPredicates (HKQuery)

--- a/src/xkit.cs
+++ b/src/xkit.cs
@@ -4733,10 +4733,10 @@ namespace UIKit {
 		/// <param name="mask">To be added.</param>
 		/// <summary>To be added.</summary>
 		/// <remarks>To be added.</remarks>
-		[Wrap ("this (format.GetConstant(), mask)")]
+		[Wrap ("this (format.GetConstant ()!, mask)")]
 		NativeHandle Constructor (NSTextListMarkerFormats format, NSTextListOptions mask);
 
-		[Wrap ("this (format.GetConstant(), NSTextListOptions.None)")]
+		[Wrap ("this (format.GetConstant ()!, NSTextListOptions.None)")]
 		NativeHandle Constructor (NSTextListMarkerFormats format);
 
 		[BindAs (typeof (NSTextListMarkerFormats))]

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -9447,12 +9447,8 @@ M:CoreFoundation.CFStream.remove_ClosedEvent(System.EventHandler{CoreFoundation.
 M:CoreFoundation.CFStream.remove_ErrorEvent(System.EventHandler{CoreFoundation.CFStream.StreamEventArgs})
 M:CoreFoundation.CFStream.remove_HasBytesAvailableEvent(System.EventHandler{CoreFoundation.CFStream.StreamEventArgs})
 M:CoreFoundation.CFStream.remove_OpenCompletedEvent(System.EventHandler{CoreFoundation.CFStream.StreamEventArgs})
-M:CoreFoundation.CFString.CreateNative(System.String)
-M:CoreFoundation.CFString.FromHandle(ObjCRuntime.NativeHandle,System.Boolean)
-M:CoreFoundation.CFString.FromHandle(ObjCRuntime.NativeHandle)
 M:CoreFoundation.CFString.op_Implicit(CoreFoundation.CFString)~System.String
 M:CoreFoundation.CFString.op_Implicit(System.String)~CoreFoundation.CFString
-M:CoreFoundation.CFString.ReleaseNative(ObjCRuntime.NativeHandle)
 M:CoreFoundation.CFWriteStream.DoSetClient(.method,System.IntPtr,System.IntPtr)
 M:CoreFoundation.CFWriteStream.Write(System.Byte[],System.IntPtr,System.IntPtr)
 M:CoreFoundation.DispatchBlock.op_Explicit(CoreFoundation.DispatchBlock)~System.Action
@@ -10994,9 +10990,6 @@ M:Foundation.NSStream.remove_OnEvent(System.EventHandler{Foundation.NSStreamEven
 M:Foundation.NSStreamSocksOptions.#ctor
 M:Foundation.NSString.CompareTo(Foundation.NSString)
 M:Foundation.NSString.LoadDataAsync(System.String,Foundation.NSProgress@)
-M:Foundation.NSString.op_Equality(Foundation.NSString,Foundation.NSString)
-M:Foundation.NSString.op_Explicit(System.String)~Foundation.NSString
-M:Foundation.NSString.op_Inequality(Foundation.NSString,Foundation.NSString)
 M:Foundation.NSTimer.Dispose(System.Boolean)
 M:Foundation.NSUrl.LoadDataAsync(System.String,Foundation.NSProgress@)
 M:Foundation.NSUrl.op_Equality(Foundation.NSUrl,Foundation.NSUrl)

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-CoreFoundation.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-CoreFoundation.ignore
@@ -353,7 +353,6 @@
 !missing-pinvoke! CFAttributedStringReplaceString is not bound
 !missing-pinvoke! CFAttributedStringSetAttribute is not bound
 !missing-pinvoke! CFAttributedStringSetAttributes is not bound
-!missing-pinvoke! CFAutorelease is not bound
 !missing-pinvoke! CFBagAddValue is not bound
 !missing-pinvoke! CFBagApplyFunction is not bound
 !missing-pinvoke! CFBagContainsValue is not bound


### PR DESCRIPTION
* Enable nullability and fix any resulting issues.
* CFString and NSString are toll-free bridged, so we can simplify the NSString
  creation code to always create CFStrings and not NSStrings - which is a
  really nice performance benefit, because creating a CFString is
  significantly faster.
* Add a few methods to CFString to match NSString's API.
* Add/improve xml docs.