### PR TITLE
[msbuild] Update ilrepack.

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "dotnet-ilrepack": {
-      "version": "1.0.0",
+      "version": "2.0.43",
       "commands": [
         "ilrepack"
       ]

--- a/msbuild/ILMerge.targets
+++ b/msbuild/ILMerge.targets
@@ -5,17 +5,6 @@
     <MergeSystemAssemblies Condition="'$(MergeSystemAssemblies)' == ''">true</MergeSystemAssemblies>
   </PropertyGroup>
 
-  <ItemGroup>
-    <!-- <PackageReference Include="ILRepack" Version="2.0.18" /> -->
-    <!-- The current version of ILRepack can't handle portable pdbs. This will be fixed when https://github.com/gluck/il-repack/pull/236 is merged and an updated NuGet is available -->
-    <!-- In the meantime use an ILRepack fork which has the fix already -->
-    <PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13" />
-  </ItemGroup>
-  <PropertyGroup>
-    <!-- Unfortunately the ILRepack.MSBuild.Task package doesn't define any variables that help us find its ilrepack.exe executable, so manually create this variable (which the IRepack package defines, so remove this workaround can be removed once we switch back to ILRepack) -->
-    <ILRepack>$(MSBuildThisFileDirectory)/../packages/ilrepack.msbuild.task/2.0.13/tools/ilrepack.exe</ILRepack>
-  </PropertyGroup>
-
   <Target Name="ILRepack" BeforeTargets="CopyFilesToOutputDirectory" Inputs="@(IntermediateAssembly -&gt; '%(FullPath)')" Outputs="$(IntermediateOutputPath)ilrepack.txt" Returns="@(MergedAssemblies)" Condition="Exists(@(IntermediateAssembly -&gt; '%(FullPath)')) And '$(ILRepack)' != 'false'">
     <ItemGroup>
       <NetstandardPath Include="@(ReferencePath -&gt; '%(RootDir)%(Directory)')" Condition="'%(FileName)%(Extension)' == 'netstandard.dll'" />
@@ -77,7 +66,8 @@
     <PropertyGroup>
       <AbsoluteAssemblyOriginatorKeyFile Condition="'$(AssemblyOriginatorKeyFile)' != ''">$([System.IO.Path]::GetFullPath($([System.IO.Path]::Combine('$(MSBuildProjectDirectory)','$(AssemblyOriginatorKeyFile)'))))</AbsoluteAssemblyOriginatorKeyFile>
       <ILRepackArgs Condition="'$(AbsoluteAssemblyOriginatorKeyFile)' != ''">/keyfile:"$(AbsoluteAssemblyOriginatorKeyFile)"</ILRepackArgs>
-	  <ILRepackArgs>$(ILRepackArgs) /union</ILRepackArgs> <!-- This is needed to merge types with identical names into one, wich happens with IFluentInterface in Merq and Merq.Core (Xamarin.Messaging dependencies) -->
+      <ILRepackArgs>$(ILRepackArgs) /union</ILRepackArgs> <!-- This is needed to merge types with identical names into one, wich happens with IFluentInterface in Merq and Merq.Core (Xamarin.Messaging dependencies) -->
+      <ILRepackArgs>$(ILRepackArgs) /illink</ILRepackArgs>
       <ILRepackArgs>$(ILRepackArgs) @(LibDir -&gt; '/lib:"%(Identity)."', ' ')</ILRepackArgs>
       <ILRepackArgs>$(ILRepackArgs) /out:"@(IntermediateAssembly -&gt; '%(FullPath)')"</ILRepackArgs>
       <ILRepackArgs>$(ILRepackArgs) "@(IntermediateAssembly -&gt; '%(FullPath)')"</ILRepackArgs>

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Tasks.Windows.csproj
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Tasks.Windows.csproj
@@ -28,6 +28,10 @@
     <!-- GitInfo is pulled in because of Xamarin.Messaging from above, but we don't want it, so just exclude all assets from it -->
     <!-- This can be removed once our package references have been updated to not expose GitInfo -->
     <PackageReference Include="GitInfo" Version="2.2.0" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkPackageVersion)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCorePackageVersion)" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCorePackageVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\external\Xamarin.MacDev\Xamarin.MacDev\Xamarin.MacDev.csproj" />


### PR DESCRIPTION
* Update the dotnet-ilrepack tool to the latest version.
* Remove some old code in ILMerge.targets. This required adding the MSBuild package
  references to Xamarin.iOS.Task.Windows.csproj, because these packages were getting
  imported by the otherwise unused ILRepack.MSBuild.Task package reference.
* Ask ilrepack to merge ILLink resources (this fixes a warning about duplicate
  ILLink.Substitutions.xml resources).