### PR TITLE
[runtime] Rework how we call 'ConformsToProtocol' a little bit.

### DIFF
--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -664,6 +664,7 @@
 		},
 
 		new XDelegate ("NSInteger", "nint", "xamarin_invoke_conforms_to_protocol",
+			"GCHandle", "IntPtr", "gchandle",
 			"id", "IntPtr", "obj",
 			"Protocol *", "IntPtr", "protocol"
 		) {

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -2644,9 +2644,9 @@ namespace ObjCRuntime {
 		[DllImport ("__Internal")]
 		static extern IntPtr xamarin_get_original_working_directory_path ();
 
-		static nint InvokeConformsToProtocol (IntPtr handle, IntPtr protocol)
+		static nint InvokeConformsToProtocol (IntPtr gchandle, IntPtr handle, IntPtr protocol)
 		{
-			var obj = Runtime.GetNSObject (handle);
+			var obj = GetGCHandleTarget (gchandle) as NSObject;
 			if (obj is null)
 				return 0;
 			var rv = obj.ConformsToProtocol (protocol);

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3490,7 +3490,8 @@ namespace Registrar {
 					sb.AppendLine ("-(BOOL) conformsToProtocol: (void *) protocol");
 					sb.AppendLine ("{");
 					sb.AppendLine ("GCHandle exception_gchandle;");
-					sb.AppendLine ("BOOL rv = xamarin_invoke_conforms_to_protocol (self, (Protocol *) protocol, &exception_gchandle) != 0;");
+					sb.AppendLine ("GCHandle obj_gchandle = xamarin_get_gchandle (self);");
+					sb.AppendLine ("BOOL rv = xamarin_invoke_conforms_to_protocol (obj_gchandle, self, (Protocol *) protocol, &exception_gchandle) != 0;");
 					sb.AppendLine ("xamarin_process_managed_exception_gchandle (exception_gchandle);");
 					sb.AppendLine ("return rv;");
 					sb.AppendLine ("}");


### PR DESCRIPTION
Use the GCHandle stored on the native instance to find the managed instance to
call 'ConformsToProtocol' on, instead of looking up the native handle in our
object dictionary.

Hopefully fixes this random exception:

    ObjCRuntime.RuntimeException: Failed to marshal the Objective-C object 0x13d566800 (type: MyType). Could not find an existing managed instance for this object, nor was it possible to create a new managed instance (because the type 'MyType' does not have a constructor that takes one NativeHandle argument).
       at ObjCRuntime.Runtime.MissingCtor(IntPtr , IntPtr , Type , MissingCtorResolution , IntPtr , RuntimeMethodHandle )
       at ObjCRuntime.Runtime.ConstructNSObject[NSObject](IntPtr , Type , MissingCtorResolution , IntPtr , RuntimeMethodHandle )
       at ObjCRuntime.Runtime.ConstructNSObject[NSObject](IntPtr , Type , MissingCtorResolution )
       at ObjCRuntime.Runtime.ConstructNSObject(IntPtr , IntPtr , MissingCtorResolution )
       at ObjCRuntime.Runtime.GetNSObject(IntPtr , MissingCtorResolution , Boolean )
       at ObjCRuntime.Runtime.GetNSObject(IntPtr )
       at ObjCRuntime.Runtime.InvokeConformsToProtocol(IntPtr , IntPtr )
       at ObjCRuntime.Runtime.invoke_conforms_to_protocol(IntPtr obj, IntPtr protocol, IntPtr* exception_gchandle)
       Exception_EndOfInnerExceptionStack

Might fix the following issues:

* https://github.com/dotnet/macios/issues/21648
* https://github.com/dotnet/maui/issues/28261