### PR TITLE
[RGen] Add support for arrays in a delegate using BindFrom.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -432,7 +432,7 @@ static partial class BindingSyntaxFactory {
 	{
 		var extensionClassName = Nomenclator.GetSmartEnumExtensionClassName (enumType.FullyQualifiedName);
 		var getValueMethod = enumType.IsNullable ? "GetNullableValue" : "GetValue";
-		
+
 		return MemberAccessExpression (SyntaxKind.SimpleMemberAccessExpression,
 			AliasQualifiedName (
 				IdentifierName (Token (SyntaxKind.GlobalKeyword)),
@@ -458,7 +458,7 @@ static partial class BindingSyntaxFactory {
 			SeparatedList<ArgumentSyntax> (arguments.ToSyntaxNodeOrTokenArray ()));
 
 		// generate: global::extensionNamespace.extensionClassName.GetValue
-		var memberAccess = SmartEnumGetValue (enumType).WithTrailingTrivia (Space); 
+		var memberAccess = SmartEnumGetValue (enumType).WithTrailingTrivia (Space);
 
 		// generate the invocation with the given params
 		return InvocationExpression (memberAccess)

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -291,7 +291,7 @@ static partial class BindingSyntaxFactory {
 			return null;
 		return MemberAccessExpression (
 			SyntaxKind.SimpleMemberAccessExpression,
-			GetIdentifierName ("NSValue"),
+			NSValue,
 			IdentifierName (memberName));
 	}
 
@@ -357,7 +357,7 @@ static partial class BindingSyntaxFactory {
 			return null;
 		return MemberAccessExpression (
 			SyntaxKind.SimpleMemberAccessExpression,
-			GetIdentifierName ("NSNumber"),
+			NSNumber,
 			IdentifierName (memberName));
 	}
 
@@ -428,49 +428,42 @@ static partial class BindingSyntaxFactory {
 			.WithArgumentList (argumentList);
 	}
 
+	internal static ExpressionSyntax SmartEnumGetValue (in TypeInfo enumType)
+	{
+		var extensionClassName = Nomenclator.GetSmartEnumExtensionClassName (enumType.FullyQualifiedName);
+		var getValueMethod = enumType.IsNullable ? "GetNullableValue" : "GetValue";
+		
+		return MemberAccessExpression (SyntaxKind.SimpleMemberAccessExpression,
+			AliasQualifiedName (
+				IdentifierName (Token (SyntaxKind.GlobalKeyword)),
+				IdentifierName (extensionClassName)),
+			IdentifierName (getValueMethod));
+	}
+
 	/// <summary>
 	/// Returns the enum extension method needed to get the value of the enum from a NativeHandle.
 	/// </summary>
 	/// <param name="enumType">The type info of the enum type.</param>
 	/// <param name="arguments">The arguments to pass to the method invocation.</param>
-	/// <param name="isNullable">If the execution should consider the enum to be nullable. This
 	/// method does not use the data in the TypeInfo to allow it to be overriden. This is because
 	/// the BindAsAttribute might need to override the call. Use the overload when the type info is all
 	/// we care about.</param>
 	/// <returns>The extension method invocation syntax.</returns>
 	internal static InvocationExpressionSyntax SmartEnumGetValue (in TypeInfo enumType,
-		ImmutableArray<ArgumentSyntax> arguments, bool isNullable)
+		ImmutableArray<ArgumentSyntax> arguments)
 	{
-		// use the nomenclator to get the class name for the extensions
-		var extensionClassName = Nomenclator.GetSmartEnumExtensionClassName (enumType.FullyQualifiedName);
-		var getValueMethod = isNullable ? "GetNullableValue" : "GetValue";
 
 		// generate (arg1, arg2, arg3)
 		var argumentList = ArgumentList (
 			SeparatedList<ArgumentSyntax> (arguments.ToSyntaxNodeOrTokenArray ()));
 
 		// generate: global::extensionNamespace.extensionClassName.GetValue
-		var memberAccess = MemberAccessExpression (SyntaxKind.SimpleMemberAccessExpression,
-			AliasQualifiedName (
-				IdentifierName (Token (SyntaxKind.GlobalKeyword)),
-				IdentifierName (extensionClassName)),
-			IdentifierName (getValueMethod).WithTrailingTrivia (Space));
+		var memberAccess = SmartEnumGetValue (enumType).WithTrailingTrivia (Space); 
 
 		// generate the invocation with the given params
 		return InvocationExpression (memberAccess)
 			.WithArgumentList (argumentList);
 	}
-
-	/// <summary>
-	/// Overload that returns the enum extension method need to get a enum value from a NativeHandle. This method
-	/// uses the type info data to decide if the result is a nullable enum value.
-	/// </summary>
-	/// <param name="enumType">The type info of the enum value.</param>
-	/// <param name="arguments">The arguments to pass to the method invocation.</param>
-	/// <returns>The extension method invocation syntax.</returns>
-	internal static InvocationExpressionSyntax SmartEnumGetValue (in TypeInfo enumType,
-		ImmutableArray<ArgumentSyntax> arguments)
-		=> SmartEnumGetValue (enumType, arguments, enumType.IsNullable);
 
 	/// <summary>
 	/// Generates the expression GetHandle () for a given expression syntax. For example:

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
@@ -269,9 +269,9 @@ public partial class PropertyTests
 		{
 			bool ret;
 			if (IsDirectBinding) {
-				ret = NSNumber.ToBool (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("canDraw")));
+				ret = global::Foundation.NSNumber.ToBool (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("canDraw")));
 			} else {
-				ret = NSNumber.ToBool (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("canDraw")));
+				ret = global::Foundation.NSNumber.ToBool (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("canDraw")));
 			}
 			GC.KeepAlive (this);
 			return ret;
@@ -302,9 +302,9 @@ public partial class PropertyTests
 		{
 			global::CoreGraphics.CGPoint ret;
 			if (IsDirectBinding) {
-				ret = NSValue.ToCGPoint (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")));
+				ret = global::Foundation.NSValue.ToCGPoint (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")));
 			} else {
-				ret = NSValue.ToCGPoint (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")));
+				ret = global::Foundation.NSValue.ToCGPoint (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")));
 			}
 			GC.KeepAlive (this);
 			return ret;
@@ -515,9 +515,9 @@ public partial class PropertyTests
 		{
 			global::CoreGraphics.CGPoint[] ret;
 			if (IsDirectBinding) {
-				ret = global::Foundation.NSArray.ArrayFromHandleFunc<global::CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")), NSValue.ToCGPoint, false);
+				ret = global::Foundation.NSArray.ArrayFromHandleFunc<global::CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")), global::Foundation.NSValue.ToCGPoint, false);
 			} else {
-				ret = global::Foundation.NSArray.ArrayFromHandleFunc<global::CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")), NSValue.ToCGPoint, false);
+				ret = global::Foundation.NSArray.ArrayFromHandleFunc<global::CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")), global::Foundation.NSValue.ToCGPoint, false);
 			}
 			GC.KeepAlive (this);
 			return ret;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
@@ -269,9 +269,9 @@ public partial class PropertyTests
 		{
 			bool ret;
 			if (IsDirectBinding) {
-				ret = NSNumber.ToBool (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("canDraw")));
+				ret = global::Foundation.NSNumber.ToBool (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("canDraw")));
 			} else {
-				ret = NSNumber.ToBool (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("canDraw")));
+				ret = global::Foundation.NSNumber.ToBool (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("canDraw")));
 			}
 			GC.KeepAlive (this);
 			return ret;
@@ -302,9 +302,9 @@ public partial class PropertyTests
 		{
 			global::CoreGraphics.CGPoint ret;
 			if (IsDirectBinding) {
-				ret = NSValue.ToCGPoint (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")));
+				ret = global::Foundation.NSValue.ToCGPoint (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")));
 			} else {
-				ret = NSValue.ToCGPoint (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")));
+				ret = global::Foundation.NSValue.ToCGPoint (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")));
 			}
 			GC.KeepAlive (this);
 			return ret;
@@ -515,9 +515,9 @@ public partial class PropertyTests
 		{
 			global::CoreGraphics.CGPoint[] ret;
 			if (IsDirectBinding) {
-				ret = global::Foundation.NSArray.ArrayFromHandleFunc<global::CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")), NSValue.ToCGPoint, false);
+				ret = global::Foundation.NSArray.ArrayFromHandleFunc<global::CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")), global::Foundation.NSValue.ToCGPoint, false);
 			} else {
-				ret = global::Foundation.NSArray.ArrayFromHandleFunc<global::CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")), NSValue.ToCGPoint, false);
+				ret = global::Foundation.NSArray.ArrayFromHandleFunc<global::CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")), global::Foundation.NSValue.ToCGPoint, false);
 			}
 			GC.KeepAlive (this);
 			return ret;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
@@ -269,9 +269,9 @@ public partial class PropertyTests
 		{
 			bool ret;
 			if (IsDirectBinding) {
-				ret = NSNumber.ToBool (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("canDraw")));
+				ret = global::Foundation.NSNumber.ToBool (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("canDraw")));
 			} else {
-				ret = NSNumber.ToBool (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("canDraw")));
+				ret = global::Foundation.NSNumber.ToBool (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("canDraw")));
 			}
 			GC.KeepAlive (this);
 			return ret;
@@ -302,9 +302,9 @@ public partial class PropertyTests
 		{
 			global::CoreGraphics.CGPoint ret;
 			if (IsDirectBinding) {
-				ret = NSValue.ToCGPoint (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")));
+				ret = global::Foundation.NSValue.ToCGPoint (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")));
 			} else {
-				ret = NSValue.ToCGPoint (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")));
+				ret = global::Foundation.NSValue.ToCGPoint (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")));
 			}
 			GC.KeepAlive (this);
 			return ret;
@@ -515,9 +515,9 @@ public partial class PropertyTests
 		{
 			global::CoreGraphics.CGPoint[] ret;
 			if (IsDirectBinding) {
-				ret = global::Foundation.NSArray.ArrayFromHandleFunc<global::CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")), NSValue.ToCGPoint, false);
+				ret = global::Foundation.NSArray.ArrayFromHandleFunc<global::CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")), global::Foundation.NSValue.ToCGPoint, false);
 			} else {
-				ret = global::Foundation.NSArray.ArrayFromHandleFunc<global::CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")), NSValue.ToCGPoint, false);
+				ret = global::Foundation.NSArray.ArrayFromHandleFunc<global::CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("Center")), global::Foundation.NSValue.ToCGPoint, false);
 			}
 			GC.KeepAlive (this);
 			return ret;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryPropertyTests.cs
@@ -292,8 +292,8 @@ public class BindingSyntaxFactoryPropertyTests {
 
 			yield return [
 				property,
-				"ret = NSNumber.ToInt32 (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))",
-				"ret = NSNumber.ToInt32 (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))",
+				$"ret = {Global ("Foundation.NSNumber")}.ToInt32 (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))",
+				$"ret = {Global ("Foundation.NSNumber")}.ToInt32 (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))",
 			];
 
 			property = new Property (
@@ -318,8 +318,8 @@ public class BindingSyntaxFactoryPropertyTests {
 
 			yield return [
 				property,
-				"ret = NSNumber.ToInt64 (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))",
-				"ret = NSNumber.ToInt64 (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))",
+				$"ret = {Global ("Foundation.NSNumber")}.ToInt64 (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))",
+				$"ret = {Global ("Foundation.NSNumber")}.ToInt64 (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))",
 			];
 
 			property = new Property (
@@ -344,8 +344,8 @@ public class BindingSyntaxFactoryPropertyTests {
 
 			yield return [
 				property,
-				"ret = global::Foundation.NSArray.ArrayFromHandleFunc<int> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")), NSNumber.ToInt32, false)",
-				"ret = global::Foundation.NSArray.ArrayFromHandleFunc<int> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")), NSNumber.ToInt32, false)",
+				$"ret = global::Foundation.NSArray.ArrayFromHandleFunc<int> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")), {Global ("Foundation.NSNumber")}.ToInt32, false)",
+				$"ret = global::Foundation.NSArray.ArrayFromHandleFunc<int> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")), {Global ("Foundation.NSNumber")}.ToInt32, false)",
 			];
 
 			property = new Property (
@@ -370,8 +370,8 @@ public class BindingSyntaxFactoryPropertyTests {
 
 			yield return [
 				property,
-				"ret = global::Foundation.NSArray.ArrayFromHandleFunc<uint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")), NSNumber.ToUInt32, false)",
-				"ret = global::Foundation.NSArray.ArrayFromHandleFunc<uint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")), NSNumber.ToUInt32, false)",
+				$"ret = global::Foundation.NSArray.ArrayFromHandleFunc<uint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")), {Global ("Foundation.NSNumber")}.ToUInt32, false)",
+				$"ret = global::Foundation.NSArray.ArrayFromHandleFunc<uint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")), {Global ("Foundation.NSNumber")}.ToUInt32, false)",
 			];
 
 			property = new Property (
@@ -422,8 +422,8 @@ public class BindingSyntaxFactoryPropertyTests {
 
 			yield return [
 				property,
-				"ret = NSValue.ToCATransform3D (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))",
-				"ret = NSValue.ToCATransform3D (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))",
+				$"ret = {Global ("Foundation.NSValue")}.ToCATransform3D (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))",
+				$"ret = {Global ("Foundation.NSValue")}.ToCATransform3D (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))",
 			];
 
 			property = new Property (
@@ -448,8 +448,8 @@ public class BindingSyntaxFactoryPropertyTests {
 
 			yield return [
 				property,
-				"ret = NSValue.ToCGPoint (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))",
-				"ret = NSValue.ToCGPoint (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))",
+				$"ret = {Global ("Foundation.NSValue")}.ToCGPoint (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))",
+				$"ret = {Global ("Foundation.NSValue")}.ToCGPoint (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")))",
 			];
 
 			property = new Property (
@@ -474,8 +474,8 @@ public class BindingSyntaxFactoryPropertyTests {
 
 			yield return [
 				property,
-				$"ret = global::Foundation.NSArray.ArrayFromHandleFunc<{Global ("CoreAnimation.CATransform3D")}> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")), NSValue.ToCATransform3D, false)",
-				$"ret = global::Foundation.NSArray.ArrayFromHandleFunc<{Global ("CoreAnimation.CATransform3D")}> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")), NSValue.ToCATransform3D, false)",
+				$"ret = global::Foundation.NSArray.ArrayFromHandleFunc<{Global ("CoreAnimation.CATransform3D")}> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")), {Global ("Foundation.NSValue")}.ToCATransform3D, false)",
+				$"ret = global::Foundation.NSArray.ArrayFromHandleFunc<{Global ("CoreAnimation.CATransform3D")}> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")), {Global ("Foundation.NSValue")}.ToCATransform3D, false)",
 			];
 
 			property = new Property (
@@ -500,8 +500,8 @@ public class BindingSyntaxFactoryPropertyTests {
 
 			yield return [
 				property,
-				$"ret = global::Foundation.NSArray.ArrayFromHandleFunc<{Global ("CoreGraphics.CGPoint")}> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")), NSValue.ToCGPoint, false)",
-				$"ret = global::Foundation.NSArray.ArrayFromHandleFunc<{Global ("CoreGraphics.CGPoint")}> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")), NSValue.ToCGPoint, false)",
+				$"ret = global::Foundation.NSArray.ArrayFromHandleFunc<{Global ("CoreGraphics.CGPoint")}> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")), {Global ("Foundation.NSValue")}.ToCGPoint, false)",
+				$"ret = global::Foundation.NSArray.ArrayFromHandleFunc<{Global ("CoreGraphics.CGPoint")}> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"myProperty\")), {Global ("Foundation.NSValue")}.ToCGPoint, false)",
 			];
 		}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -157,97 +157,97 @@ public class BindingSyntaxFactoryRuntimeTests {
 		{
 			yield return [
 				ReturnTypeForNSObject ("CoreAnimation.CATransform3D"),
-				"NSValue.ToCATransform3D"
+				$"{Global ("Foundation.NSValue")}.ToCATransform3D"
 			];
 
 			yield return [
 				ReturnTypeForNSObject ("CoreGraphics.CGAffineTransform"),
-				"NSValue.ToCGAffineTransform"
+				$"{Global ("Foundation.NSValue")}.ToCGAffineTransform"
 			];
 
 			yield return [
 				ReturnTypeForNSObject ("CoreGraphics.CGPoint"),
-				"NSValue.ToCGPoint"
+				$"{Global ("Foundation.NSValue")}.ToCGPoint"
 			];
 
 			yield return [
 				ReturnTypeForNSObject ("CoreGraphics.CGRect"),
-				"NSValue.ToCGRect"
+				$"{Global ("Foundation.NSValue")}.ToCGRect"
 			];
 
 			yield return [
 				ReturnTypeForNSObject ("CoreGraphics.CGSize"),
-				"NSValue.ToCGSize"
+				$"{Global ("Foundation.NSValue")}.ToCGSize"
 			];
 
 			yield return [
 				ReturnTypeForNSObject ("CoreGraphics.CGVector"),
-				"NSValue.ToCGVector"
+				$"{Global ("Foundation.NSValue")}.ToCGVector"
 			];
 
 			yield return [
 				ReturnTypeForNSObject ("CoreMedia.CMTime"),
-				"NSValue.ToCMTime"
+				$"{Global ("Foundation.NSValue")}.ToCMTime"
 			];
 
 			yield return [
 				ReturnTypeForNSObject ("CoreMedia.CMTimeMapping"),
-				"NSValue.ToCMTimeMapping"
+				$"{Global ("Foundation.NSValue")}.ToCMTimeMapping"
 			];
 
 			yield return [
 				ReturnTypeForNSObject ("CoreMedia.CMTimeRange"),
-				"NSValue.ToCMTimeRange"
+				$"{Global ("Foundation.NSValue")}.ToCMTimeRange"
 			];
 
 			yield return [
 				ReturnTypeForNSObject ("CoreMedia.CMVideoDimensions"),
-				"NSValue.ToCMVideoDimensions"
+				$"{Global ("Foundation.NSValue")}.ToCMVideoDimensions"
 			];
 
 			yield return [
 				ReturnTypeForNSObject ("CoreLocation.CLLocationCoordinate2D"),
-				"NSValue.ToCLLocationCoordinate2D"
+				$"{Global ("Foundation.NSValue")}.ToCLLocationCoordinate2D"
 			];
 
 			yield return [
 				ReturnTypeForNSObject ("Foundation.NSRange"),
-				"NSValue.ToNSRange"
+				$"{Global ("Foundation.NSValue")}.ToNSRange"
 			];
 
 			yield return [
 				ReturnTypeForNSObject ("MapKit.MKCoordinateSpan"),
-				"NSValue.ToMKCoordinateSpan"
+				$"{Global ("Foundation.NSValue")}.ToMKCoordinateSpan"
 			];
 
 			yield return [
 				ReturnTypeForNSObject ("SceneKit.SCNMatrix4"),
-				"NSValue.ToSCNMatrix4"
+				$"{Global ("Foundation.NSValue")}.ToSCNMatrix4"
 			];
 
 			yield return [
 				ReturnTypeForNSObject ("SceneKit.SCNVector3"),
-				"NSValue.ToSCNVector3"
+				$"{Global ("Foundation.NSValue")}.ToSCNVector3"
 			];
 
 			yield return [
 				ReturnTypeForNSObject ("SceneKit.SCNVector4"),
-				"NSValue.ToSCNVector4"
+				$"{Global ("Foundation.NSValue")}.ToSCNVector4"
 			];
 
 			yield return [
 				ReturnTypeForNSObject ("UIKit.NSDirectionalEdgeInsets"),
-				"NSValue.ToNSDirectionalEdgeInsets"
+				$"{Global ("Foundation.NSValue")}.ToNSDirectionalEdgeInsets"
 			];
 
 			yield return [
 				ReturnTypeForNSObject ("UIKit.UIEdgeInsets"),
-				"NSValue.ToUIEdgeInsets"
+				$"{Global ("Foundation.NSValue")}.ToUIEdgeInsets"
 			];
 
 			yield return [
 				ReturnTypeForNSObject ("UIKit.UIOffset"),
-				"NSValue.ToUIOffset"
+				$"{Global ("Foundation.NSValue")}.ToUIOffset"
 			];
 		}
 
@@ -268,72 +268,72 @@ public class BindingSyntaxFactoryRuntimeTests {
 
 			yield return [
 				ReturnTypeForBool (),
-				"NSNumber.ToBool"
+				$"{Global ("Foundation.NSNumber")}.ToBool"
 			];
 
 			yield return [
 				ReturnTypeForInt (),
-				"NSNumber.ToInt32"
+				$"{Global ("Foundation.NSNumber")}.ToInt32"
 			];
 
 			yield return [
 				ReturnTypeForInt (isUnsigned: true),
-				"NSNumber.ToUInt32"
+				$"{Global ("Foundation.NSNumber")}.ToUInt32"
 			];
 
 			yield return [
 				ReturnTypeForShort (),
-				"NSNumber.ToInt16"
+				$"{Global ("Foundation.NSNumber")}.ToInt16"
 			];
 
 			yield return [
 				ReturnTypeForShort (isUnsigned: true),
-				"NSNumber.ToUInt16"
+				$"{Global ("Foundation.NSNumber")}.ToUInt16"
 			];
 
 			yield return [
 				ReturnTypeForLong (),
-				"NSNumber.ToInt64"
+				$"{Global ("Foundation.NSNumber")}.ToInt64"
 			];
 
 			yield return [
 				ReturnTypeForLong (isUnsigned: true),
-				"NSNumber.ToUInt64"
+				$"{Global ("Foundation.NSNumber")}.ToUInt64"
 			];
 
 			yield return [
 				ReturnTypeForNInt (),
-				"NSNumber.ToNInt"
+				$"{Global ("Foundation.NSNumber")}.ToNInt"
 			];
 
 			yield return [
 				ReturnTypeForNInt (isUnsigned: true),
-				"NSNumber.ToNUInt"
+				$"{Global ("Foundation.NSNumber")}.ToNUInt"
 			];
 
 			yield return [
 				ReturnTypeForDouble (),
-				"NSNumber.ToDouble"
+				$"{Global ("Foundation.NSNumber")}.ToDouble"
 			];
 
 			yield return [
 				ReturnTypeForFloat (),
-				"NSNumber.ToFloat"
+				$"{Global ("Foundation.NSNumber")}.ToFloat"
 			];
 
 			yield return [
 				ReturnTypeForArray ("int", underlyingType: SpecialType.System_Int32),
-				"NSNumber.ToInt32"
+				$"{Global ("Foundation.NSNumber")}.ToInt32"
 			];
 
 			yield return [
 				ReturnTypeForArray ("uint", underlyingType: SpecialType.System_UInt32),
-				"NSNumber.ToUInt32"
+				$"{Global ("Foundation.NSNumber")}.ToUInt32"
 			];
 
 			yield return [
 				ReturnTypeForArray ("nint", underlyingType: SpecialType.System_IntPtr),
-				"NSNumber.ToNInt"
+				$"{Global ("Foundation.NSNumber")}.ToNInt"
 			];
 		}
 
@@ -386,15 +386,13 @@ public class BindingSyntaxFactoryRuntimeTests {
 				ReturnTypeForEnum ("AVFoundation.AVCaptureSystemPressureLevel", isSmartEnum: true),
 				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1"))),
-				false,
 				"global::AVFoundation.AVCaptureSystemPressureLevelExtensions.GetValue (arg1)"
 			];
 
 			yield return [
-				ReturnTypeForEnum ("AVFoundation.AVCaptureSystemPressureLevel", isSmartEnum: true),
+				ReturnTypeForEnum ("AVFoundation.AVCaptureSystemPressureLevel", isSmartEnum: true, isNullable: true),
 				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1"))),
-				true,
 				"global::AVFoundation.AVCaptureSystemPressureLevelExtensions.GetNullableValue (arg1)"
 			];
 		}
@@ -404,9 +402,9 @@ public class BindingSyntaxFactoryRuntimeTests {
 
 	[Theory]
 	[ClassData (typeof (TestDataSmartEnumGetValue))]
-	void SmartEnumGetValueTests (TypeInfo enumType, ImmutableArray<ArgumentSyntax> arguments, bool isNullable, string expectedDeclaration)
+	void SmartEnumGetValueTests (TypeInfo enumType, ImmutableArray<ArgumentSyntax> arguments, string expectedDeclaration)
 	{
-		var declaration = SmartEnumGetValue (enumType, arguments, isNullable);
+		var declaration = SmartEnumGetValue (enumType, arguments);
 		var str = declaration.ToString ();
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
 	}
@@ -446,16 +444,14 @@ public class BindingSyntaxFactoryRuntimeTests {
 			yield return [
 				SmartEnumGetValue (
 					ReturnTypeForEnum ("AVFoundation.AVCaptureSystemPressureLevel", isSmartEnum: true),
-					[Argument (IdentifierName ("arg1"))],
-					false),
+					[Argument (IdentifierName ("arg1"))]),
 				"global::AVFoundation.AVCaptureSystemPressureLevelExtensions.GetValue (arg1).GetHandle ()"
 			];
 
 			yield return [
 				SmartEnumGetValue (
-					ReturnTypeForEnum ("AVFoundation.AVCaptureSystemPressureLevel", isSmartEnum: true),
-					[Argument (IdentifierName ("arg1"))],
-					true),
+					ReturnTypeForEnum ("AVFoundation.AVCaptureSystemPressureLevel", isSmartEnum: true, isNullable: true),
+					[Argument (IdentifierName ("arg1"))]),
 				"global::AVFoundation.AVCaptureSystemPressureLevelExtensions.GetNullableValue (arg1).GetHandle ()"
 			];
 		}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -2166,7 +2166,7 @@ namespace NS {
 				nsNumberParameterWithReturn,
 				$"var ret = del ({Global ("ObjCRuntime.Runtime")}.GetNSObject<{Global ("Foundation.NSNumber")}> (pointerParameter)!.Int32Value);",
 			];
-			
+
 			var nsNumberArrayParameterWithReturn = @"
 using System;
 using Foundation;
@@ -2203,7 +2203,7 @@ namespace NS {
 				nsValueParameterWithReturn,
 				$"var ret = del ({Global ("ObjCRuntime.Runtime")}.GetNSObject<{Global ("Foundation.NSValue")}> (size)!.CGSizeValue);",
 			];
-			
+
 			var nsValueArrayParameterWithReturn = @"
 using System;
 using Foundation;
@@ -2222,7 +2222,7 @@ namespace NS {
 				nsValueArrayParameterWithReturn,
 				$"var ret = del ({Global ("Foundation.NSArray")}.ArrayFromHandleFunc<{Global ("CoreGraphics.CGSize")}> (size, {Global ("Foundation.NSValue")}.ToCGSize, false)!);"
 			];
-			
+
 			var smartEnumParameterWithReturn = @"
 using System;
 using Foundation;
@@ -2252,7 +2252,7 @@ namespace NS {
 				smartEnumParameterWithReturn,
 				$"var ret = del ({Global ("NS.CustomLibraryEnum")}.GetValue ({Global ("ObjCRuntime.Runtime")}.GetNSObject<{Global ("Foundation.NSString")}> (level)!));",
 			];
-			
+
 			var smartEnumArrayParameterWithReturn = @"
 using System;
 using Foundation;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -2166,6 +2166,24 @@ namespace NS {
 				nsNumberParameterWithReturn,
 				$"var ret = del ({Global ("ObjCRuntime.Runtime")}.GetNSObject<{Global ("Foundation.NSNumber")}> (pointerParameter)!.Int32Value);",
 			];
+			
+			var nsNumberArrayParameterWithReturn = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public delegate int Callback ([BindFrom (typeof(NSNumber))]int[] pointerParameter);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				"someTrampolineName",
+				nsNumberArrayParameterWithReturn,
+				$"var ret = del ({Global ("Foundation.NSArray")}.ArrayFromHandleFunc<int> (pointerParameter, {Global ("Foundation.NSNumber")}.ToInt32, false)!);"
+			];
 
 			var nsValueParameterWithReturn = @"
 using System;
@@ -2185,7 +2203,26 @@ namespace NS {
 				nsValueParameterWithReturn,
 				$"var ret = del ({Global ("ObjCRuntime.Runtime")}.GetNSObject<{Global ("Foundation.NSValue")}> (size)!.CGSizeValue);",
 			];
+			
+			var nsValueArrayParameterWithReturn = @"
+using System;
+using Foundation;
+using CoreGraphics;
+using ObjCBindings;
 
+namespace NS {
+	public delegate int Callback ([BindFrom (typeof(NSValue))]CGSize[] size);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				"someTrampolineName",
+				nsValueArrayParameterWithReturn,
+				$"var ret = del ({Global ("Foundation.NSArray")}.ArrayFromHandleFunc<{Global ("CoreGraphics.CGSize")}> (size, {Global ("Foundation.NSValue")}.ToCGSize, false)!);"
+			];
+			
 			var smartEnumParameterWithReturn = @"
 using System;
 using Foundation;
@@ -2215,7 +2252,36 @@ namespace NS {
 				smartEnumParameterWithReturn,
 				$"var ret = del ({Global ("NS.CustomLibraryEnum")}.GetValue ({Global ("ObjCRuntime.Runtime")}.GetNSObject<{Global ("Foundation.NSString")}> (level)!));",
 			];
+			
+			var smartEnumArrayParameterWithReturn = @"
+using System;
+using Foundation;
+using AVFoundation;
+using ObjCBindings;
 
+namespace NS {
+
+	[BindingType<SmartEnum>]
+	public enum CustomLibraryEnum {
+		[Field<EnumValue> (""None"", ""/path/to/customlibrary.framework"")]
+		None,
+		[Field<EnumValue> (""Medium"", ""/path/to/customlibrary.framework"")]
+		Medium,
+		[Field<EnumValue> (""High"", ""/path/to/customlibrary.framework"")]
+		High,
+	}
+
+	public delegate int Callback ([BindFrom (typeof(NSString))]CustomLibraryEnum[] level);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				"someTrampolineName",
+				smartEnumArrayParameterWithReturn,
+				$"var ret = del ({Global ("Foundation.NSArray")}.ArrayFromHandleFunc<{Global ("NS.CustomLibraryEnum")}> (level, {Global ("NS.CustomLibraryEnumExtensions")}.GetValue, false)!);"
+			];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
@@ -2241,6 +2307,7 @@ namespace NS {
 		Assert.NotNull (parameter.Type.Delegate);
 		var argumentSyntax = GetTrampolineInvokeArguments (trampolineName, parameter.Type.Delegate);
 		var invocation = CallTrampolineDelegate (parameter.Type.Delegate, argumentSyntax);
+		var x = invocation.ToFullString ();
 		Assert.Equal (expectedExpression, invocation.ToFullString ());
 	}
 


### PR DESCRIPTION
This change will allow to add delegates in the following forms:

1. array for nsnumber to int[]
2. array for nsvalue to struct[]
3. arrya for nsstring to smart enum.

The generated code looks like:

NSNumber:
```csharp
var ret = del (Foundation.NSArray.ArrayFromHandleFunc<int> (pointerParameter, Foundation.NSNumber.ToInt32, false)!);
```

NSValue:
```csharp
var ret = del (Foundation.NSArray.ArrayFromHandleFunc<CoreGraphics.CGSize> (size, Foundation.NSValue.ToCGSize, false)!);

```

NSString
```csharp
var ret = del (Foundation.NSArray.ArrayFromHandleFunc<NS.CustomLibraryEnum> (level, NS.CustomLibraryEnumExtensions.GetValue, false)!);

```