### PR TITLE
[RGen] Allow to generate a 'new' syntax using a known type.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.KnownTypes.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.KnownTypes.cs
@@ -7,6 +7,15 @@ using Microsoft.Macios.Generator.Extensions;
 namespace Microsoft.Macios.Generator.Emitters;
 
 static partial class BindingSyntaxFactory {
+	
+	// AudioToolbox
+	
+	/// <summary>
+	/// TypeSyntax for AudioToolbox.AudioBuffers.
+	/// </summary>
+	public static readonly TypeSyntax AudioBuffers = StringExtensions.GetIdentifierName (
+		@namespace: ["AudioToolbox"],
+		@class: "AudioBuffers");
 
 	// CoreFoundation types
 
@@ -148,7 +157,13 @@ static partial class BindingSyntaxFactory {
 	public readonly static TypeSyntax CMTag = StringExtensions.GetIdentifierName (
 		@namespace: ["CoreMedia"],
 		@class: "CMTag");
-
+	
+	/// <summary>
+	/// TypeSyntax for CoreMedia.CMSampleBuffer.
+	/// </summary>
+	public readonly static TypeSyntax CMSampleBuffer = StringExtensions.GetIdentifierName (
+		@namespace: ["CoreMedia"],
+		@class: "CMSampleBuffer");
 
 	// System types
 

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.KnownTypes.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.KnownTypes.cs
@@ -7,9 +7,9 @@ using Microsoft.Macios.Generator.Extensions;
 namespace Microsoft.Macios.Generator.Emitters;
 
 static partial class BindingSyntaxFactory {
-	
+
 	// AudioToolbox
-	
+
 	/// <summary>
 	/// TypeSyntax for AudioToolbox.AudioBuffers.
 	/// </summary>
@@ -157,7 +157,7 @@ static partial class BindingSyntaxFactory {
 	public readonly static TypeSyntax CMTag = StringExtensions.GetIdentifierName (
 		@namespace: ["CoreMedia"],
 		@class: "CMTag");
-	
+
 	/// <summary>
 	/// TypeSyntax for CoreMedia.CMSampleBuffer.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.KnownTypes.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.KnownTypes.cs
@@ -161,7 +161,7 @@ static partial class BindingSyntaxFactory {
 	/// <summary>
 	/// TypeSyntax for CoreMedia.CMSampleBuffer.
 	/// </summary>
-	public readonly static TypeSyntax CMSampleBuffer = StringExtensions.GetIdentifierName (
+	public static readonly TypeSyntax CMSampleBuffer = StringExtensions.GetIdentifierName (
 		@namespace: ["CoreMedia"],
 		@class: "CMSampleBuffer");
 

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -495,7 +495,7 @@ static partial class BindingSyntaxFactory {
 	}
 
 	/// <summary>
-	/// Generate an object creation expressing for the given type info using the provided arguments.
+	/// Generate an object creation expression for the given type info using the provided arguments.
 	/// </summary>
 	/// <param name="type">The information of the type of object to be created.</param>
 	/// <param name="arguments">The argument list for the object creation expression.</param>

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -479,21 +479,29 @@ static partial class BindingSyntaxFactory {
 				IdentifierName ("GetHandle").WithTrailingTrivia (Space)
 			)
 		);
+	
+	/// <summary>
+	/// Generate an object creation expressing for the given type info using the provided arguments.
+	/// </summary>
+	/// <param name="type">The information of the type of object to be created.</param>
+	/// <param name="arguments">The argument list for the object creation expression.</param>
+	/// <returns>An object creation expression.</returns>
+	internal static ObjectCreationExpressionSyntax New (TypeSyntax type, ImmutableArray<ArgumentSyntax> arguments)
+	{
+		var argumentList = ArgumentList (
+			SeparatedList<ArgumentSyntax> (arguments.ToSyntaxNodeOrTokenArray ()));
+		return ObjectCreationExpression (type.WithLeadingTrivia (Space).WithTrailingTrivia (Space))
+			.WithArgumentList (argumentList);
+	}
 
 	/// <summary>
 	/// Generate an object creation expressing for the given type info using the provided arguments.
 	/// </summary>
 	/// <param name="type">The information of the type of object to be created.</param>
 	/// <param name="arguments">The argument list for the object creation expression.</param>
-	/// <param name="global">If the global qualifier should be used.</param>
 	/// <returns>An object creation expression.</returns>
 	internal static ObjectCreationExpressionSyntax New (in TypeInfo type, ImmutableArray<ArgumentSyntax> arguments)
-	{
-		var argumentList = ArgumentList (
-			SeparatedList<ArgumentSyntax> (arguments.ToSyntaxNodeOrTokenArray ()));
-		return ObjectCreationExpression (type.GetIdentifierSyntax ().WithLeadingTrivia (Space).WithTrailingTrivia (Space))
-			.WithArgumentList (argumentList);
-	}
+		=> New (type.GetIdentifierSyntax (), arguments);
 
 	/// <summary>
 	/// Generates a nameof(variableName) expression.

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -479,7 +479,7 @@ static partial class BindingSyntaxFactory {
 				IdentifierName ("GetHandle").WithTrailingTrivia (Space)
 			)
 		);
-	
+
 	/// <summary>
 	/// Generate an object creation expressing for the given type info using the provided arguments.
 	/// </summary>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -520,7 +520,7 @@ public class BindingSyntaxFactoryRuntimeTests {
 		var declaration = New (typeInfo, arguments);
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
 	}
-	
+
 	[Fact]
 	void NewTestsKnownType ()
 	{

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -520,6 +520,17 @@ public class BindingSyntaxFactoryRuntimeTests {
 		var declaration = New (typeInfo, arguments);
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
 	}
+	
+	[Fact]
+	void NewTestsKnownType ()
+	{
+		var expected = $"new {Global ("AudioToolbox.AudioBuffers")} (arg1, arg2)";
+		var declaration = New (AudioBuffers, [
+			Argument (IdentifierName ("arg1")),
+			Argument (IdentifierName ("arg2"))
+		]);
+		Assert.Equal (expected, declaration.ToFullString ());
+	}
 
 	class TestDataGetNSObject : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()


### PR DESCRIPTION
There are some types that are known and we want to create a new instance for using new rather than GetINativeObject/GetNSObject. Add a new
  overload of the New method that allows to pass directly a TypeSyntax.