### PR TITLE
[RGen] When a native string is created, released as part of the post invocation steps.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -221,7 +221,7 @@ static partial class BindingSyntaxFactory {
 					IdentifierName ("CreateNative").WithTrailingTrivia (Space))
 			).WithArgumentList (argumentList);
 	}
-	
+
 	/// <summary>
 	/// Generates the expression to call the CFString.ReleaseNative method.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -221,12 +221,29 @@ static partial class BindingSyntaxFactory {
 					IdentifierName ("CreateNative").WithTrailingTrivia (Space))
 			).WithArgumentList (argumentList);
 	}
-
+	
 	/// <summary>
-	/// Generates the expression to call the CFString.CreateNative method.
+	/// Generates the expression to call the CFString.ReleaseNative method.
 	/// </summary>
 	/// <param name="arguments">The argument list for the invocation.</param>
-	/// <returns>The expression to call the CFString.CreateNative method with the provided args.</returns>
+	/// <returns>The expression to call the CFString.ReleaseNative method with the provided args.</returns>
+	internal static InvocationExpressionSyntax StringReleaseNative (ImmutableArray<ArgumentSyntax> arguments)
+	{
+		var argumentList = ArgumentList (
+			SeparatedList<ArgumentSyntax> (arguments.ToSyntaxNodeOrTokenArray ()));
+		return InvocationExpression (
+			MemberAccessExpression (
+				SyntaxKind.SimpleMemberAccessExpression,
+				CFString,
+				IdentifierName ("ReleaseNative").WithTrailingTrivia (Space))
+		).WithArgumentList (argumentList);
+	}
+
+	/// <summary>
+	/// Generates the expression to call the NFString.CreateNative method.
+	/// </summary>
+	/// <param name="arguments">The argument list for the invocation.</param>
+	/// <returns>The expression to call the NFString.CreateNative method with the provided args.</returns>
 	internal static InvocationExpressionSyntax NStringCreateNative (ImmutableArray<ArgumentSyntax> arguments)
 	{
 		var argumentList = ArgumentList (

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
@@ -1101,10 +1101,12 @@ static partial class BindingSyntaxFactory {
 				))],
 
 			{ SpecialType: SpecialType.System_String } =>  [ExpressionStatement (
-				KeepAlive (
-					//  use the nomenclator to get the name for the variable type
-					Nomenclator.GetNameForVariableType (parameter.Name, Nomenclator.VariableType.NSString)!
-				))],
+					StringReleaseNative(
+						[Argument(IdentifierName(
+							//  use the nomenclator to get the name for the variable type
+							Nomenclator.GetNameForVariableType (parameter.Name, Nomenclator.VariableType.NSString)!
+						))
+						]))],
 
 			{ IsProtocol: true } => [ExpressionStatement (
 				KeepAlive (

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -4352,7 +4352,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				stringParameter,
-				$"{Global ("System.GC")}.KeepAlive (nsstringParameter);\n"
+				$"{Global ("CoreFoundation.CFString")}.ReleaseNative (nsstringParameter);\n"
 			];
 
 			var nullableStringParameter = @"
@@ -4368,7 +4368,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				nullableStringParameter,
-				$"{Global ("System.GC")}.KeepAlive (nsstringParameter);\n"
+				$"{Global ("CoreFoundation.CFString")}.ReleaseNative (nsstringParameter);\n"
 			];
 
 			var stringArrayParameter = @"


### PR DESCRIPTION
Instead than calling the GC.KeepAlive method we want to call CFString.Release native which keeps a ref to the native string and, more importantly, frees the memory of the string once we are done with it.