### PR TITLE
[Rgen] Provide a factory method to generate AsPointer calls.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.KnownTypes.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.KnownTypes.cs
@@ -188,8 +188,19 @@ static partial class BindingSyntaxFactory {
 		@namespace: ["System"],
 		@class: "EventHandler");
 
+	/// <summary>
+	/// TypeSyntax for System.GC.
+	/// </summary>
 	public readonly static TypeSyntax GC = StringExtensions.GetIdentifierName (
 		@namespace: ["System"],
 		@class: "GC");
+
+	/// <summary>
+	/// TypeSyntax for System.Runtime.CompilerServices.Unsafe.
+	/// </summary>
+	public readonly static TypeSyntax Unsafe = StringExtensions.GetIdentifierName (
+		@namespace: ["System", "Runtime", "CompilerServices"],
+		@class: "Unsafe");
+
 
 }

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
@@ -196,12 +196,26 @@ static partial class BindingSyntaxFactory {
 	/// <returns>The needed expression to call the AsRef method.</returns>
 	internal static ExpressionSyntax AsRef (TypeSyntax objectType, ImmutableArray<ArgumentSyntax> arguments)
 	{
-		var unsafeType = StringExtensions.GetIdentifierName (
-			@namespace: ["System", "Runtime", "CompilerServices"],
-			@class: "Unsafe");
 		var argsList = ArgumentList (SeparatedList<ArgumentSyntax> (arguments.ToSyntaxNodeOrTokenArray ()));
-		return StaticInvocationGenericExpression (unsafeType, "AsRef",
+		return StaticInvocationGenericExpression (Unsafe, "AsRef",
 			objectType, argsList);
+	}
+
+	/// <summary>
+	/// Create the necessary expression to call the AsPointer method from the Unsafe class and cast the result to a pointer of the objectType.
+	/// </summary>
+	/// <param name="objectType">The target type for the pointer.</param>
+	/// <param name="arguments">The arguments to pass to the AsPointer method.</param>
+	/// <returns>The needed expression to call the AsPointer method and cast to a pointer.</returns>
+	internal static ExpressionSyntax AsPointer (TypeSyntax objectType, ImmutableArray<ArgumentSyntax> arguments)
+	{
+		var argsList = ArgumentList (SeparatedList<ArgumentSyntax> (arguments.ToSyntaxNodeOrTokenArray ()));
+		var invocation = StaticInvocationGenericExpression (Unsafe, "AsPointer",
+			objectType, argsList);
+		// we have the invocation, but we need to convert it to a pointer
+		return CastExpression (PointerType (objectType),
+			invocation.WithLeadingTrivia (Space));
+
 	}
 
 	/// <summary>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -899,6 +899,38 @@ public class BindingSyntaxFactoryRuntimeTests {
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
 	}
 
+	class TestDataAsPointerTests : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			yield return [
+				IdentifierName ("int"),
+				ImmutableArray.Create (
+					Argument (IdentifierName ("arg1"))
+				),
+				$"(int*) global::System.Runtime.CompilerServices.Unsafe.AsPointer<int> (arg1)"
+			];
+
+			yield return [
+				IdentifierName ("uint"),
+				ImmutableArray.Create (
+					Argument (IdentifierName ("arg1")),
+					Argument (IdentifierName ("arg2")),
+					Argument (IdentifierName ("arg3"))),
+				$"(uint*) global::System.Runtime.CompilerServices.Unsafe.AsPointer<uint> (arg1, arg2, arg3)"
+			];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[ClassData (typeof (TestDataAsPointerTests))]
+	void AsPointerTests (TypeSyntax objectType, ImmutableArray<ArgumentSyntax> arguments, string expectedDeclaration)
+	{
+		var declaration = AsPointer (objectType, arguments);
+		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
+	}
+
 	class TestDataGetDelegateForFunctionPointer : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{


### PR DESCRIPTION
AsPointer is used to ensure that we pass a ref/in/out parameter as a pointer to the native code.