### PR TITLE
[AccessorySetupKit] Introduce a default ctor for a few classes.

### DIFF
--- a/src/accessorysetupkit.cs
+++ b/src/accessorysetupkit.cs
@@ -144,7 +144,6 @@ namespace AccessorySetupKit {
 
 	[BaseType (typeof (NSObject))]
 	[iOS (18, 0)]
-	[DisableDefaultCtor]
 	interface ASAccessorySettings {
 		[Export ("defaultSettings")]
 		[Static]
@@ -159,7 +158,6 @@ namespace AccessorySetupKit {
 
 	[BaseType (typeof (NSObject))]
 	[iOS (18, 0)]
-	[DisableDefaultCtor]
 	interface ASDiscoveryDescriptor {
 		[Export ("supportedOptions", ArgumentSemantic.Assign)]
 		ASAccessorySupportOptions SupportedOptions { get; set; }


### PR DESCRIPTION
Fixes https://github.com/dotnet/macios/issues/22352#issuecomment-2969907846.