### PR TITLE
[RGen] Add a ArgumentForParameter method to create ArgumentSyntax from the parameter info.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
@@ -244,7 +244,7 @@ static partial class BindingSyntaxFactory {
 	/// <returns>An <see cref="ArgumentSyntax"/> representing the parameter.</returns>
 	internal static ArgumentSyntax ArgumentForParameter (string argumentName, ReferenceKind referenceKind = ReferenceKind.None)
 	{
-		var arg =  Argument (IdentifierName (argumentName));
+		var arg = Argument (IdentifierName (argumentName));
 #pragma warning disable format
 		arg = referenceKind switch {
 			ReferenceKind.In => arg.WithRefOrOutKeyword (Token (SyntaxKind.InKeyword)),

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
@@ -235,4 +235,40 @@ static partial class BindingSyntaxFactory {
 		return StaticInvocationGenericExpression (marshalType, "GetDelegateForFunctionPointer",
 			delegateType, argsList);
 	}
+
+	/// <summary>
+	/// Creates an <see cref="ArgumentSyntax"/> for a given parameter name and reference kind.
+	/// </summary>
+	/// <param name="argumentName">The name of the argument.</param>
+	/// <param name="referenceKind">The <see cref="ReferenceKind"/> of the argument.</param>
+	/// <returns>An <see cref="ArgumentSyntax"/> representing the parameter.</returns>
+	internal static ArgumentSyntax ArgumentForParameter (string argumentName, ReferenceKind referenceKind = ReferenceKind.None)
+	{
+		var arg =  Argument (IdentifierName (argumentName));
+#pragma warning disable format
+		arg = referenceKind switch {
+			ReferenceKind.In => arg.WithRefOrOutKeyword (Token (SyntaxKind.InKeyword)),
+			ReferenceKind.Out => arg.WithRefOrOutKeyword (Token (SyntaxKind.OutKeyword)),
+			ReferenceKind.Ref => arg.WithRefOrOutKeyword (Token (SyntaxKind.RefKeyword)),
+			_ => arg
+		};
+#pragma warning restore format
+		return arg.NormalizeWhitespace ();
+	}
+
+	/// <summary>
+	/// Creates an <see cref="ArgumentSyntax"/> for a given <see cref="Parameter"/>.
+	/// </summary>
+	/// <param name="parameter">The <see cref="Parameter"/> to create the argument for.</param>
+	/// <returns>An <see cref="ArgumentSyntax"/> representing the parameter.</returns>
+	internal static ArgumentSyntax ArgumentForParameter (in Parameter parameter)
+		=> ArgumentForParameter (parameter.Name, parameter.ReferenceKind);
+
+	/// <summary>
+	/// Creates an <see cref="ArgumentSyntax"/> for a given <see cref="DelegateParameter"/>.
+	/// </summary>
+	/// <param name="parameter">The <see cref="DelegateParameter"/> to create the argument for.</param>
+	/// <returns>An <see cref="ArgumentSyntax"/> representing the parameter.</returns>
+	internal static ArgumentSyntax ArgumentForParameter (in DelegateParameter parameter)
+		=> ArgumentForParameter (parameter.Name, parameter.ReferenceKind);
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.DataModel;
 using Microsoft.Macios.Generator.Extensions;
 using Xunit;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -970,6 +971,27 @@ public class BindingSyntaxFactoryRuntimeTests {
 		var declaration = ThrowIfNull (variableName);
 		var expected = $"if (markers is null)\n\t{Global ("ObjCRuntime.ThrowHelper")}.ThrowArgumentNullException (nameof (markers));";
 		Assert.Equal (expected, declaration.ToFullString ());
+	}
+
+	class TestDataArgumentSyntaxForParameterTests : IEnumerable<object[]>
+	{
+		public IEnumerator<object[]> GetEnumerator()
+		{
+			yield return ["arg1", ReferenceKind.None, "arg1"];
+			yield return ["arg2", ReferenceKind.In, "in arg2"];
+			yield return ["arg3", ReferenceKind.Out, "out arg3"];
+			yield return ["arg4", ReferenceKind.Ref, "ref arg4"];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+	}
+
+	[Theory]
+	[ClassData(typeof(TestDataArgumentSyntaxForParameterTests))]
+	void ArgumentSyntaxForParameterTests(string argumentName, ReferenceKind referenceKind, string expectedSyntax)
+	{
+		var argumentSyntax = ArgumentForParameter(argumentName, referenceKind);
+		Assert.Equal(expectedSyntax, argumentSyntax.ToFullString());
 	}
 
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -973,9 +973,8 @@ public class BindingSyntaxFactoryRuntimeTests {
 		Assert.Equal (expected, declaration.ToFullString ());
 	}
 
-	class TestDataArgumentSyntaxForParameterTests : IEnumerable<object[]>
-	{
-		public IEnumerator<object[]> GetEnumerator()
+	class TestDataArgumentSyntaxForParameterTests : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
 		{
 			yield return ["arg1", ReferenceKind.None, "arg1"];
 			yield return ["arg2", ReferenceKind.In, "in arg2"];
@@ -983,15 +982,15 @@ public class BindingSyntaxFactoryRuntimeTests {
 			yield return ["arg4", ReferenceKind.Ref, "ref arg4"];
 		}
 
-		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
 
 	[Theory]
-	[ClassData(typeof(TestDataArgumentSyntaxForParameterTests))]
-	void ArgumentSyntaxForParameterTests(string argumentName, ReferenceKind referenceKind, string expectedSyntax)
+	[ClassData (typeof (TestDataArgumentSyntaxForParameterTests))]
+	void ArgumentSyntaxForParameterTests (string argumentName, ReferenceKind referenceKind, string expectedSyntax)
 	{
-		var argumentSyntax = ArgumentForParameter(argumentName, referenceKind);
-		Assert.Equal(expectedSyntax, argumentSyntax.ToFullString());
+		var argumentSyntax = ArgumentForParameter (argumentName, referenceKind);
+		Assert.Equal (expectedSyntax, argumentSyntax.ToFullString ());
 	}
 
 }


### PR DESCRIPTION
This is a helper method that knows how to handle the ref kind and will create the correct argument syntax. This can later be used to create the arguments in a more elegant way.