### PR TITLE
[RGen] Complete the native invoke implementation.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
@@ -66,7 +66,7 @@ static partial class BindingSyntaxFactory {
 		};
 #pragma warning restore format
 	}
-	
+
 	/// <summary>
 	/// Returns an expression syntax representing the conversion of a native return value to its corresponding managed type
 	/// after a native delegate (block) invocation within a trampoline.

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
@@ -595,6 +595,14 @@ static partial class BindingSyntaxFactory {
 		return argument;
 	}
 
+	/// <summary>
+	/// Generates any necessary pre-invocation statements for a by-ref trampoline argument.
+	/// This is used to handle special cases for by-ref parameters, such as creating temporary variables
+	/// for nullable or boolean types that require conversion before the trampoline is invoked.
+	/// Returns an empty array if no special handling is required.
+	/// </summary>
+	/// <param name="parameter">The delegate parameter to process for pre-invocation by-ref handling.</param>
+	/// <returns>An immutable array of syntax nodes representing the required pre-invocation statements for the by-ref argument.</returns>
 	internal static ImmutableArray<SyntaxNode> GetTrampolinePreInvokeByRefArgument (in DelegateParameter parameter)
 	{
 		// there are two cases in which we need to do something with the byref parameters:
@@ -692,6 +700,16 @@ static partial class BindingSyntaxFactory {
 		return [expr];
 	}
 
+	/// <summary>
+	/// Generates any necessary post-invocation statements for a by-ref trampoline argument.
+	/// This is used to handle special cases for by-ref parameters, such as assigning back values
+	/// from temporary variables for nullable types or converting boolean values back to their native
+	/// representation after the trampoline is invoked.
+	/// Returns an empty array if no special handling is required.
+	/// </summary>
+	/// <param name="trampolineName">The name of the trampoline. This parameter is not directly used in the current implementation but is kept for consistency with related methods.</param>
+	/// <param name="parameter">The delegate parameter to process for post-invocation by-ref handling.</param>
+	/// <returns>An immutable array of syntax nodes representing the required post-invocation statements for the by-ref argument.</returns>
 	internal static ImmutableArray<SyntaxNode> GetTrampolinePostInvokeByRefArgument (string trampolineName,
 		in DelegateParameter parameter)
 	{
@@ -1063,6 +1081,12 @@ static partial class BindingSyntaxFactory {
 		return method;
 	}
 
+	/// <summary>
+	/// Returns an array of syntax nodes representing initializations required for a 'byref' parameter before invoking the native trampoline.
+	/// This method handles the initialization of 'byref' parameters by assigning them their default value.
+	/// </summary>
+	/// <param name="parameter">The delegate parameter, which is expected to be 'byref'.</param>
+	/// <returns>An immutable array of syntax nodes representing the initialization statements for the 'byref' parameter.</returns>
 	internal static ImmutableArray<SyntaxNode> GetTrampolineNativeInitializationByRefArgument (in DelegateParameter parameter)
 	{
 		// create the pointer variable and assign it to its default value
@@ -1392,6 +1416,14 @@ static partial class BindingSyntaxFactory {
 		return bucket.ToImmutable ();
 	}
 
+	/// <summary>
+	/// Generates the statement syntax for calling the native invoker delegate.
+	/// This method constructs the invocation of the delegate using the provided arguments,
+	/// and handles whether the delegate returns a value or is void.
+	/// </summary>
+	/// <param name="delegateInfo">The information about the delegate being called.</param>
+	/// <param name="argumentSyntax">The immutable array of argument syntax for the delegate call.</param>
+	/// <returns>A <see cref="StatementSyntax"/> representing the call to the native invoker delegate.</returns>
 	internal static StatementSyntax CallNativeInvokerDelegate (in DelegateInfo delegateInfo,
 		in ImmutableArray<TrampolineArgumentSyntax> argumentSyntax)
 	{

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
@@ -66,6 +66,114 @@ static partial class BindingSyntaxFactory {
 		};
 #pragma warning restore format
 	}
+	
+	/// <summary>
+	/// Returns an expression syntax representing the conversion of a native return value to its corresponding managed type
+	/// after a native delegate (block) invocation within a trampoline.
+	/// This method handles various conversions, such as:
+	/// - Converting a native byte (0 or 1) to a C# bool.
+	/// - Converting a native integer to a C# enum (both regular and smart enums from NSString).
+	/// - Creating a C# string from a native string handle (CFStringRef).
+	/// - Creating a C# string array from a native array handle (CFArrayRef of CFStringRef).
+	/// - Creating specific managed objects like CMSampleBuffer or AudioBuffers from their native handles.
+	/// - Getting an NSObject or INativeObject instance from a native handle.
+	/// - Getting a C# array of NSObject or INativeObject from a native array handle.
+	/// If no conversion is needed, it returns an identifier for the auxiliary variable holding the native return value.
+	/// </summary>
+	/// <param name="typeInfo">The <see cref="TypeInfo"/> of the delegate, used to determine the return type and its properties.</param>
+	/// <param name="auxVariableName">The name of the auxiliary variable holding the native return value.</param>
+	/// <returns>An <see cref="ExpressionSyntax"/> for the converted managed return value, or null if the delegate returns void.</returns>
+	internal static ExpressionSyntax? GetTrampolineNativeInvokeReturnType (TypeInfo typeInfo, string auxVariableName)
+	{
+		// ignore those types that are not delegates or that are a delegate with a void return type
+		if (!typeInfo.IsDelegate || typeInfo.Delegate.ReturnType.IsVoid)
+			return null;
+
+		var auxIdentifier = IdentifierName (auxVariableName);
+#pragma warning disable format
+		// based on the return type of the delegate we build a statement that will return the expected value
+		return typeInfo.Delegate.ReturnType switch {
+			// auxVariable != 0
+			{ SpecialType: SpecialType.System_Boolean } 
+				=> CastToBool (auxVariableName, typeInfo.Delegate.ReturnType),
+			
+			// enum values
+			
+			// normal enum, cast to the enum type
+			// (EnumType) auxVariable
+			
+			{ IsEnum: true, IsNativeEnum: true } => CastNativeToEnum (auxVariableName, typeInfo.Delegate.ReturnType), 
+		
+			// smart enum, get type from string
+			{ IsEnum: true, IsSmartEnum: true, IsNativeEnum: false } 
+				=> GetSmartEnumFromNSString (typeInfo.Delegate.ReturnType, Argument (auxIdentifier)),
+			
+			// string from native handle
+			// CFString.FromHandle (auxVariable)!
+			{ SpecialType: SpecialType.System_String, IsNullable: false} 
+				=> SuppressNullableWarning (StringFromHandle ([Argument (auxIdentifier)])),
+			
+			// CFString.FromHandle (auxVariable)
+			{ SpecialType: SpecialType.System_String, IsNullable: true} 
+				=> StringFromHandle ([Argument (auxIdentifier)]),
+			
+			// string array
+			// CFArray.StringArrayFromHandle (obj)!
+			{ IsArray: true, ArrayElementType: SpecialType.System_String, IsNullable: false} 
+				=> SuppressNullableWarning (StringArrayFromHandle ([Argument (auxIdentifier)])),
+			
+			// CFArray.StringArrayFromHandle (obj)
+			{ IsArray: true, ArrayElementType: SpecialType.System_String, IsNullable: true} 
+				=> StringArrayFromHandle ([Argument (auxIdentifier)]),
+			
+			{ FullyQualifiedName: "CoreMedia.CMSampleBuffer" } => 
+				New (CMSampleBuffer, [Argument (auxIdentifier), BoolArgument (false)]), 
+			
+			// AudioToolbox.AudioBuffers
+			// new global::AudioToolbox.AudioBuffers ({0})
+			{ FullyQualifiedName: "AudioToolbox.AudioBuffers" } =>
+				New (AudioBuffers, [Argument (auxIdentifier), BoolArgument (false)]),
+			
+			// INativeObject from a native handle
+			// Runtime.GetINativeObject<NSString> (auxVariable, false)!;
+			{ IsINativeObject: true, IsNSObject: false }
+				=> GetINativeObject (
+					nsObjectType: typeInfo.Delegate.ReturnType.ToNonNullable ().GetIdentifierSyntax (), 
+					args: [
+						Argument (auxIdentifier),
+						BoolArgument (false)
+					], 
+					suppressNullableWarning: !typeInfo.Delegate.ReturnType.IsNullable),
+			
+			// NSObject from a native handle
+			// Runtime.GetNSObject<NSString> (auxVariable, false)!;
+			{ IsNSObject: true } 
+				=> GetNSObject (
+					nsObjectType: typeInfo.Delegate.ReturnType.ToNonNullable ().GetIdentifierSyntax (), 
+					args: [
+						Argument (auxIdentifier),
+						BoolArgument (false)
+					],
+					suppressNullableWarning: !typeInfo.Delegate.ReturnType.IsNullable), 
+			
+			// CFArray.ArrayFromHandle<global::Foundation.NSMetadataItem>  
+			{ IsArray: true, ArrayElementTypeIsWrapped: true }
+				=> GetCFArrayFromHandle (typeInfo.Delegate.ReturnType.ToArrayElementType ().ToNonNullable ().GetIdentifierSyntax (), [
+					Argument (auxIdentifier)
+				], suppressNullableWarning: !typeInfo.Delegate.ReturnType.IsNullable), 
+			
+			// CFArray.ArrayFromHandle<global::Foundation.NSMetadataItem>  
+			{ IsArray: true, ArrayElementIsINativeObject: true }
+				=> GetCFArrayFromHandle (typeInfo.Delegate.ReturnType.ToArrayElementType ().ToNonNullable ().GetIdentifierSyntax (), [
+					Argument (auxIdentifier)
+				], suppressNullableWarning: !typeInfo.Delegate.ReturnType.IsNullable), 
+			
+			// default case, return the value as is
+			_ => auxIdentifier,
+
+		};
+#pragma warning restore format
+	}
 
 	/// <summary>
 	/// Returns the expression for the creation of the NativeInvocationClass for a given trampoline.
@@ -1112,44 +1220,24 @@ static partial class BindingSyntaxFactory {
 						))
 						]))],
 
-			{ IsProtocol: true } => [ExpressionStatement (
-				KeepAlive (
-					//  use the nomenclator to get the name for the variable type
-					Nomenclator.GetNameForVariableType (parameter.Name, Nomenclator.VariableType.Handle)!
-				))],
+			{ IsProtocol: true } => [ExpressionStatement (KeepAlive (parameter.Name))],
 
 			// special types
 
 			// CoreMedia.CMSampleBuffer
-			{ FullyQualifiedName: "CoreMedia.CMSampleBuffer" } => [ExpressionStatement (
-				KeepAlive (
-					//  use the nomenclator to get the name for the variable type
-					Nomenclator.GetNameForVariableType (parameter.Name, Nomenclator.VariableType.Handle)!
-				))],
+			{ FullyQualifiedName: "CoreMedia.CMSampleBuffer" } => [ExpressionStatement (KeepAlive (parameter.Name))],
 
 			// AudioToolbox.AudioBuffers
-			{ FullyQualifiedName: "AudioToolbox.AudioBuffers" } => [ExpressionStatement (
-				KeepAlive (
-					//  use the nomenclator to get the name for the variable type
-					Nomenclator.GetNameForVariableType (parameter.Name, Nomenclator.VariableType.Handle)!
-				))],
+			{ FullyQualifiedName: "AudioToolbox.AudioBuffers" } => [ExpressionStatement (KeepAlive (parameter.Name))],
 
 			// general NSObject/INativeObject, has to be after the special types otherwise the special types will
 			// fall into the NSObject/INativeObject case
 
 			// same name, native handle
-			{ IsNSObject: true } => [ExpressionStatement (
-				KeepAlive (
-					//  use the nomenclator to get the name for the variable type
-					Nomenclator.GetNameForVariableType (parameter.Name, Nomenclator.VariableType.Handle)!
-				))],
+			{ IsNSObject: true } => [ExpressionStatement (KeepAlive (parameter.Name))],
 
 			// same name, native handle
-			{ IsINativeObject: true } => [ExpressionStatement (
-				KeepAlive (
-					//  use the nomenclator to get the name for the variable type
-					Nomenclator.GetNameForVariableType (parameter.Name, Nomenclator.VariableType.Handle)!
-				))],
+			{ IsINativeObject: true } => [ExpressionStatement (KeepAlive (parameter.Name))],
 			
 			// by default, we will use the parameter name as is and the type of the parameter
 			_ => [],
@@ -1296,8 +1384,8 @@ static partial class BindingSyntaxFactory {
 		foreach (var parameter in delegateInfo.Parameters) {
 			var argument = new TrampolineArgumentSyntax (GetTrampolineNativeInvokeArgument (trampolineName, parameter)) {
 				Initializers = GetTrampolineInvokeArgumentInitializations (trampolineName, parameter),
-				PreDelegateCallConversion = GetTrampolinePreInvokeArgumentConversions (trampolineName, parameter),
-				PostDelegateCallConversion = GetTrampolinePostInvokeArgumentConversions (trampolineName, parameter),
+				PreDelegateCallConversion = GetTrampolinePreNativeInvokeArgumentConversions (trampolineName, parameter),
+				PostDelegateCallConversion = GetTrampolinePostNativeInvokeArgumentConversions (trampolineName, parameter),
 			};
 			bucket.Add (argument);
 		}

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/TrampolineEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/TrampolineEmitter.cs
@@ -145,15 +145,15 @@ public unsafe static {delegateIdentifier}? Create (IntPtr block)
 				foreach (var argument in argumentSyntax) {
 					invokeBlock.Write (argument.PreDelegateCallConversion, verifyTrivia: false);
 				}
-				
+
 				// execute the native invoker delegate
 				invokeBlock.WriteLine ($"{CallNativeInvokerDelegate (typeInfo.Delegate!, argumentSyntax)}");
-				
+
 				// build any needed post conversion operations after calling the delegate
 				foreach (var argument in argumentSyntax) {
 					invokeBlock.Write (argument.PostDelegateCallConversion, verifyTrivia: false);
 				}
-				
+
 				// perform any return conversions needed
 				if (typeInfo.Delegate!.ReturnType.SpecialType != SpecialType.System_Void)
 					invokeBlock.WriteLine ($"return {GetTrampolineNativeInvokeReturnType (typeInfo, Nomenclator.GetReturnVariableName ())};");

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/TrampolineEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/TrampolineEmitter.cs
@@ -111,7 +111,7 @@ return CreateBlock (callback);
 		var delegateIdentifier = Nomenclator.GetTrampolineClassName (trampolineName, Nomenclator.TrampolineClassType.DelegateType);
 
 		using (var classBlock = classBuilder.CreateBlock ($"internal sealed class {className} : TrampolineBlockBase", true)) {
-			classBlock.WriteLine ($"{delegateName} invoker;");
+			classBlock.WriteLine ($"{delegateName} {Nomenclator.GetNativeInvokerVariableName ()};");
 			classBlock.WriteLine (); // empty line for readability
 									 // constructor
 			classBlock.WriteRaw (
@@ -139,7 +139,24 @@ public unsafe static {delegateIdentifier}? Create (IntPtr block)
 			classBlock.WriteLine (); // empty line for readability
 									 // invoke method
 			using (var invokeBlock = classBlock.CreateBlock (GetTrampolineNativeInvokeSignature (typeInfo).ToString (), true)) {
-				invokeBlock.WriteLine ("// TODO: generate invoke method.");
+				// retrieve the arguments for the invoker execution. 
+				var argumentSyntax = GetTrampolineNativeInvokeArguments (trampolineName, typeInfo.Delegate!);
+				// write the conversion code for the arguments
+				foreach (var argument in argumentSyntax) {
+					invokeBlock.Write (argument.PreDelegateCallConversion, verifyTrivia: false);
+				}
+				
+				// execute the native invoker delegate
+				invokeBlock.WriteLine ($"{CallNativeInvokerDelegate (typeInfo.Delegate!, argumentSyntax)}");
+				
+				// build any needed post conversion operations after calling the delegate
+				foreach (var argument in argumentSyntax) {
+					invokeBlock.Write (argument.PostDelegateCallConversion, verifyTrivia: false);
+				}
+				
+				// perform any return conversions needed
+				if (typeInfo.Delegate!.ReturnType.SpecialType != SpecialType.System_Void)
+					invokeBlock.WriteLine ($"return {GetTrampolineNativeInvokeReturnType (typeInfo, Nomenclator.GetReturnVariableName ())};");
 			}
 		}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/ClassGenerationTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/ClassGenerationTests.cs
@@ -36,7 +36,7 @@ public class ClassGenerationTests : BaseGeneratorTestClass {
 			(ApplePlatform.MacCatalyst, "ThreadSafeUIKitPropertyTests", "ThreadSafeUIKitPropertyTests.cs", "ExpectedThreadSafeUIKitPropertyTests.cs", null, null),
 			(ApplePlatform.MacOSX, "AppKitPropertyTests", "AppKitPropertyTests.cs", "ExpectedAppKitPropertyTests.cs", null, null),
 			(ApplePlatform.MacOSX, "ThreadSafeAppKitPropertyTests", "ThreadSafeAppKitPropertyTests.cs", "ExpectedThreadSafeAppKitPropertyTests.cs", null, null),
-			
+
 			(ApplePlatform.iOS, "NSUserDefaults", "NSUserDefaults.cs", "ExpectedNSUserDefaults.cs", null, null),
 			(ApplePlatform.TVOS, "NSUserDefaults", "NSUserDefaults.cs", "ExpectedNSUserDefaults.cs", null, null),
 			(ApplePlatform.MacCatalyst, "NSUserDefaults", "NSUserDefaults.cs", "ExpectedNSUserDefaults.cs", null, null),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/ClassGenerationTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/ClassGenerationTests.cs
@@ -36,7 +36,7 @@ public class ClassGenerationTests : BaseGeneratorTestClass {
 			(ApplePlatform.MacCatalyst, "ThreadSafeUIKitPropertyTests", "ThreadSafeUIKitPropertyTests.cs", "ExpectedThreadSafeUIKitPropertyTests.cs", null, null),
 			(ApplePlatform.MacOSX, "AppKitPropertyTests", "AppKitPropertyTests.cs", "ExpectedAppKitPropertyTests.cs", null, null),
 			(ApplePlatform.MacOSX, "ThreadSafeAppKitPropertyTests", "ThreadSafeAppKitPropertyTests.cs", "ExpectedThreadSafeAppKitPropertyTests.cs", null, null),
-
+			
 			(ApplePlatform.iOS, "NSUserDefaults", "NSUserDefaults.cs", "ExpectedNSUserDefaults.cs", null, null),
 			(ApplePlatform.TVOS, "NSUserDefaults", "NSUserDefaults.cs", "ExpectedNSUserDefaults.cs", null, null),
 			(ApplePlatform.MacCatalyst, "NSUserDefaults", "NSUserDefaults.cs", "ExpectedNSUserDefaults.cs", null, null),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedTrampolinePropertyTestsTrampolines.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedTrampolinePropertyTestsTrampolines.cs
@@ -70,7 +70,12 @@ static partial class Trampolines
 
 		unsafe global::Foundation.NSObject Invoke (global::Foundation.NSObject obj)
 		{
-			// TODO: generate invoke method.
+			if (obj is null)
+				global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (obj));
+			var obj__handle__ = obj.GetHandle ();
+			var ret = invoker (BlockLiteral, obj__handle__);
+			global::System.GC.KeepAlive (obj);
+			return global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSObject> (ret, false)!;
 		}
 	}
 
@@ -128,7 +133,7 @@ static partial class Trampolines
 
 		unsafe void Invoke ()
 		{
-			// TODO: generate invoke method.
+			invoker (BlockLiteral);
 		}
 	}
 
@@ -187,7 +192,8 @@ static partial class Trampolines
 
 		unsafe global::CoreGraphics.CGRect Invoke (int index, global::CoreGraphics.CGRect rect)
 		{
-			// TODO: generate invoke method.
+			var ret = invoker (BlockLiteral, index, rect);
+			return ret;
 		}
 	}
 
@@ -245,7 +251,11 @@ static partial class Trampolines
 
 		unsafe void Invoke (string obj)
 		{
-			// TODO: generate invoke method.
+			if (obj is null)
+				global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (obj));
+			var nsobj = global::CoreFoundation.CFString.CreateNative (obj);
+			invoker (BlockLiteral, nsobj);
+			global::CoreFoundation.CFString.ReleaseNative (nsobj);
 		}
 	}
 
@@ -303,7 +313,7 @@ static partial class Trampolines
 
 		unsafe void Invoke (int obj)
 		{
-			// TODO: generate invoke method.
+			invoker (BlockLiteral, obj);
 		}
 	}
 
@@ -361,7 +371,7 @@ static partial class Trampolines
 
 		unsafe void Invoke (bool obj)
 		{
-			// TODO: generate invoke method.
+			invoker (BlockLiteral, obj ? (byte) 1 : (byte) 0);
 		}
 	}
 
@@ -419,7 +429,15 @@ static partial class Trampolines
 
 		unsafe void Invoke (global::CoreGraphics.CGImage imageRef, global::CoreMedia.CMTime actualTime, global::Foundation.NSError error)
 		{
-			// TODO: generate invoke method.
+			if (imageRef is null)
+				global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (imageRef));
+			var imageRef__handle__ = imageRef.GetHandle ();
+			if (error is null)
+				global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (error));
+			var error__handle__ = error.GetHandle ();
+			invoker (BlockLiteral, imageRef__handle__, actualTime, error__handle__);
+			global::System.GC.KeepAlive (imageRef);
+			global::System.GC.KeepAlive (error);
 		}
 	}
 
@@ -479,7 +497,12 @@ static partial class Trampolines
 
 		unsafe global::AVFoundation.AVAudioEngineManualRenderingStatus Invoke (uint numberOfFrames, global::AudioToolbox.AudioBuffers outBuffer, ref int outError)
 		{
-			// TODO: generate invoke method.
+			if (outBuffer is null)
+				global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (outBuffer));
+			var outBuffer__handle__ = outBuffer.GetHandle ();
+			var ret = invoker (BlockLiteral, numberOfFrames, outBuffer__handle__, (int*) global::System.Runtime.CompilerServices.Unsafe.AsPointer<int> (ref outError));
+			global::System.GC.KeepAlive (outBuffer);
+			return (global::AVFoundation.AVAudioEngineManualRenderingStatus) (long) ret;
 		}
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -385,7 +385,7 @@ namespace NS {
 		var expression = GetTrampolineInvokeReturnType (parameter.Type, auxVariableName);
 		Assert.Equal (expectedExpression, expression?.ToString ());
 	}
-	
+
 	class TestDataGetTrampolineNativeInvokeReturnType : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -406,7 +406,7 @@ namespace NS {
 				arrayNSObjectResult,
 				$"{Global ("CoreFoundation.CFArray")}.ArrayFromHandle<{Global ("Foundation.NSString")}> (auxVariable)!"
 			];
-			
+
 			const string nullableArrayNSObjectResult = @"
 using System;
 using Foundation;
@@ -424,7 +424,7 @@ namespace NS {
 				nullableArrayNSObjectResult,
 				$"{Global ("CoreFoundation.CFArray")}.ArrayFromHandle<{Global ("Foundation.NSString")}> (auxVariable)"
 			];
-			
+
 			const string arrayINativeResult = @"
 using System;
 using Foundation;
@@ -443,7 +443,7 @@ namespace NS {
 				arrayINativeResult,
 				$"{Global ("CoreFoundation.CFArray")}.ArrayFromHandle<{Global ("Security.SecKeyChain")}> (auxVariable)!"
 			];
-			
+
 			const string nullableArrayINativeResult = @"
 using System;
 using Foundation;
@@ -480,7 +480,7 @@ namespace NS {
 				nsObjectResult,
 				$"{Global ("ObjCRuntime.Runtime")}.GetNSObject<{Global ("Foundation.NSString")}> (auxVariable, false)!"
 			];
-			
+
 			const string nullableNSObjectResult = @"
 using System;
 using Foundation;
@@ -517,7 +517,7 @@ namespace NS {
 				nativeObjectResult,
 				$"{Global ("ObjCRuntime.Runtime")}.GetINativeObject<{Global ("Security.SecKeyChain")}> (auxVariable, false)!"
 			];
-			
+
 			const string nullableNativeObjectResult = @"
 using System;
 using Foundation;
@@ -555,7 +555,7 @@ namespace NS {
 				protocolResult,
 				$"{Global ("ObjCRuntime.Runtime")}.GetINativeObject<{Global ("Metal.IMTLTexture")}> (auxVariable, false)!"
 			];
-			
+
 			const string nullableProtocolResult = @"
 using System;
 using Foundation;
@@ -651,7 +651,7 @@ namespace NS {
 				nativeEnum,
 				"(global::NS.NativeSampleEnum) (long) auxVariable",
 			];
-			
+
 			const string smartEnum = @"
 using System;
 using ObjCBindings;
@@ -769,7 +769,7 @@ namespace NS {
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
-	
+
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataGetTrampolineNativeInvokeReturnType>]
 	void GetTrampolineNativeInvokeReturnTypeTests (ApplePlatform platform, string inputText, string? expectedExpression)

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -385,6 +385,411 @@ namespace NS {
 		var expression = GetTrampolineInvokeReturnType (parameter.Type, auxVariableName);
 		Assert.Equal (expectedExpression, expression?.ToString ());
 	}
+	
+	class TestDataGetTrampolineNativeInvokeReturnType : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			const string arrayNSObjectResult = @"
+using System;
+using Foundation;
+
+namespace NS {
+
+	public delegate NSString [] Callback ();
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				arrayNSObjectResult,
+				$"{Global ("CoreFoundation.CFArray")}.ArrayFromHandle<{Global ("Foundation.NSString")}> (auxVariable)!"
+			];
+			
+			const string nullableArrayNSObjectResult = @"
+using System;
+using Foundation;
+
+namespace NS {
+
+	public delegate NSString []? Callback ();
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				nullableArrayNSObjectResult,
+				$"{Global ("CoreFoundation.CFArray")}.ArrayFromHandle<{Global ("Foundation.NSString")}> (auxVariable)"
+			];
+			
+			const string arrayINativeResult = @"
+using System;
+using Foundation;
+using Security;
+
+namespace NS {
+
+	public delegate SecKeyChain [] Callback ();
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				arrayINativeResult,
+				$"{Global ("CoreFoundation.CFArray")}.ArrayFromHandle<{Global ("Security.SecKeyChain")}> (auxVariable)!"
+			];
+			
+			const string nullableArrayINativeResult = @"
+using System;
+using Foundation;
+using Security;
+
+namespace NS {
+
+	public delegate SecKeyChain []? Callback ();
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				nullableArrayINativeResult,
+				$"{Global ("CoreFoundation.CFArray")}.ArrayFromHandle<{Global ("Security.SecKeyChain")}> (auxVariable)"
+			];
+
+			const string nsObjectResult = @"
+using System;
+using Foundation;
+
+namespace NS {
+
+	public delegate NSString Callback ();
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				nsObjectResult,
+				$"{Global ("ObjCRuntime.Runtime")}.GetNSObject<{Global ("Foundation.NSString")}> (auxVariable, false)!"
+			];
+			
+			const string nullableNSObjectResult = @"
+using System;
+using Foundation;
+
+namespace NS {
+
+	public delegate NSString? Callback ();
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				nullableNSObjectResult,
+				$"{Global ("ObjCRuntime.Runtime")}.GetNSObject<{Global ("Foundation.NSString")}> (auxVariable, false)"
+			];
+
+			const string nativeObjectResult = @"
+using System;
+using Foundation;
+using Security;
+
+namespace NS {
+
+	public delegate SecKeyChain Callback ();
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				nativeObjectResult,
+				$"{Global ("ObjCRuntime.Runtime")}.GetINativeObject<{Global ("Security.SecKeyChain")}> (auxVariable, false)!"
+			];
+			
+			const string nullableNativeObjectResult = @"
+using System;
+using Foundation;
+using Security;
+
+namespace NS {
+
+	public delegate SecKeyChain? Callback ();
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				nullableNativeObjectResult,
+				$"{Global ("ObjCRuntime.Runtime")}.GetINativeObject<{Global ("Security.SecKeyChain")}> (auxVariable, false)"
+			];
+
+			const string protocolResult = @"
+using System;
+using Foundation;
+using Metal;
+
+namespace NS {
+
+	public delegate IMTLTexture Callback ();
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				protocolResult,
+				$"{Global ("ObjCRuntime.Runtime")}.GetINativeObject<{Global ("Metal.IMTLTexture")}> (auxVariable, false)!"
+			];
+			
+			const string nullableProtocolResult = @"
+using System;
+using Foundation;
+using Metal;
+
+namespace NS {
+
+	public delegate IMTLTexture? Callback ();
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				nullableProtocolResult,
+				$"{Global ("ObjCRuntime.Runtime")}.GetINativeObject<{Global ("Metal.IMTLTexture")}> (auxVariable, false)"
+			];
+
+			const string systemStringResult = @"
+using System;
+
+namespace NS {
+
+	public delegate string Callback ();
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				systemStringResult,
+				$"{Global ("CoreFoundation.CFString")}.FromHandle (auxVariable)!"
+			];
+
+			const string nullableSystemStringResult = @"
+using System;
+
+namespace NS {
+
+	public delegate string? Callback ();
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				nullableSystemStringResult,
+				$"{Global ("CoreFoundation.CFString")}.FromHandle (auxVariable)"
+			];
+
+			const string boolReturnType = @"
+using System;
+
+namespace NS {
+
+	public delegate bool Callback ();
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				boolReturnType,
+				"auxVariable != 0"
+			];
+
+			const string nativeEnum = @"
+using System;
+using ObjCBindings;
+using ObjCRuntime;
+
+namespace NS {
+
+	[Native (""GKErrorCode"")]
+	[BindingType<SmartEnum> (Flags = SmartEnum.ErrorCode, ErrorDomain = ""GKErrorDomain"")]
+	public enum NativeSampleEnum : long {
+		None = 0,
+		Unknown = 1,
+	}
+
+	public delegate NativeSampleEnum Callback()
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				nativeEnum,
+				"(global::NS.NativeSampleEnum) (long) auxVariable",
+			];
+			
+			const string smartEnum = @"
+using System;
+using ObjCBindings;
+using ObjCRuntime;
+
+namespace NS {
+
+	[BindingType<SmartEnum>]
+	public enum MySmartEnum {
+
+		[Field<EnumValue> (""AVCaptureDeviceTypeBuiltInMicrophone"")]
+		BuiltInMicrophone,
+
+		[Field<EnumValue> (""AVCaptureDeviceTypeBuiltInWideAngleCamera"")]
+		BuiltInWideAngleCamera,
+
+		[Field<EnumValue> (""AVCaptureDeviceTypeBuiltInTelephotoCamera"")]
+		BuiltInTelephotoCamera,
+
+		[Field<EnumValue> (""AVCaptureDeviceTypeBuiltInDuoCamera"")]
+		BuiltInDuoCamera,
+
+		[Field<EnumValue> (""AVCaptureDeviceTypeBuiltInDualCamera"")]
+		BuiltInDualCamera,
+
+		[Field<EnumValue> (""AVCaptureDeviceTypeBuiltInTrueDepthCamera"")]
+		BuiltInTrueDepthCamera,
+
+		[Field<EnumValue> (""AVCaptureDeviceTypeBuiltInUltraWideCamera"")]
+		BuiltInUltraWideCamera,
+
+		[Field<EnumValue> (""AVCaptureDeviceTypeBuiltInTripleCamera"")]
+		BuiltInTripleCamera,
+
+		[Field<EnumValue> (""AVCaptureDeviceTypeBuiltInDualWideCamera"")]
+		BuiltInDualWideCamera,
+
+		[Field<EnumValue> (""AVCaptureDeviceTypeExternalUnknown"")]
+		ExternalUnknown,
+
+		[Field<EnumValue> (""AVCaptureDeviceTypeBuiltInLiDARDepthCamera"")]
+		BuiltInLiDarDepthCamera,
+	}
+
+	public delegate MySmartEnum Callback()
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				smartEnum,
+				$"{Global ("NS.MySmartEnumExtensions")}.GetValue (auxVariable)",
+			];
+
+			const string unsignedNativeEnum = @"
+using System;
+using ObjCBindings;
+using ObjCRuntime;
+
+namespace NS {
+
+	[Native (""GKErrorCode"")]
+	[BindingType<SmartEnum> (Flags = SmartEnum.ErrorCode, ErrorDomain = ""GKErrorDomain"")]
+	public enum NativeSampleEnum : ulong {
+		None = 0,
+		Unknown = 1,
+	}
+
+	public delegate NativeSampleEnum Callback()
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				unsignedNativeEnum,
+				"(global::NS.NativeSampleEnum) (ulong) auxVariable",
+			];
+
+			const string intReturnType = @"
+using System;
+
+namespace NS {
+	public delegate int Callback()
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				intReturnType,
+				"auxVariable"
+			];
+
+			const string voidReturnType = @"
+using System;
+
+namespace NS {
+	public delegate void Callback()
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				voidReturnType,
+				null!
+			];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataGetTrampolineNativeInvokeReturnType>]
+	void GetTrampolineNativeInvokeReturnTypeTests (ApplePlatform platform, string inputText, string? expectedExpression)
+	{
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
+		Assert.Single (syntaxTrees);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ().OfType<MethodDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		Assert.True (Method.TryCreate (declaration, semanticModel, out var changes));
+		Assert.NotNull (changes);
+		// we know the first parameter of the method is the delegate
+		Assert.Single (changes.Value.Parameters);
+		var parameter = changes.Value.Parameters [0];
+		var auxVariableName = "auxVariable";
+		var expression = GetTrampolineNativeInvokeReturnType (parameter.Type, auxVariableName);
+		Assert.Equal (expectedExpression, expression?.ToString ());
+	}
 
 	class TestDataCreateNativeClass : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
@@ -4647,7 +5052,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				nsObjectParameter,
-				$"{Global ("System.GC")}.KeepAlive (nsObjectParameter__handle__);\n"
+				$"{Global ("System.GC")}.KeepAlive (nsObjectParameter);\n"
 			];
 
 			// nullable NSObject parameter
@@ -4668,7 +5073,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				nullableNSObjectParameter,
-				$"{Global ("System.GC")}.KeepAlive (nsObjectParameter__handle__);\n"
+				$"{Global ("System.GC")}.KeepAlive (nsObjectParameter);\n"
 			];
 
 			// NSObject array parameter
@@ -4732,7 +5137,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				iNativeParameter,
-				$"{Global ("System.GC")}.KeepAlive (inative__handle__);\n"
+				$"{Global ("System.GC")}.KeepAlive (inative);\n"
 			];
 
 			// nullable INativeObject parameter
@@ -4754,7 +5159,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				nullableINativeParameter,
-				$"{Global ("System.GC")}.KeepAlive (inative__handle__);\n"
+				$"{Global ("System.GC")}.KeepAlive (inative);\n"
 			];
 
 			// INativeObject array parameter


### PR DESCRIPTION
We achieve the following:

1. Create a method that will do any needed conversion of the return type.
2. Fix a bug in which we were keeping alive the handle, when it should the managed object.
3. Complete the generation of the invoke. Call the conversions, call the invoker, call the post conversions and return the valid value.

This completes all the code that needs to be generated by trampoline. We will add tests with known frameworks in coming commits to ensure that we are generating equivalent code.