### PR TITLE
[RGen] Add code to generate a aux variable for a NativeHandle.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -359,7 +359,7 @@ static partial class BindingSyntaxFactory {
 	/// <returns>A <see cref="LocalDeclarationStatementSyntax"/> for the auxiliary handle variable, or null if the input is not an NSObject or INativeObject, or if a variable name cannot be generated.</returns>
 	internal static LocalDeclarationStatementSyntax? GetHandleAuxVariable (in DelegateParameter parameter)
 		=> GetHandleAuxVariable (parameter.Name, parameter.Type);
-	
+
 	/// <summary>
 	/// Generates a local variable declaration for an auxiliary handle (IntPtr) initialized to IntPtr.Zero.
 	/// This is typically used to declare a default handle variable before assigning it a valid native handle.
@@ -368,19 +368,19 @@ static partial class BindingSyntaxFactory {
 	/// <returns>A <see cref="LocalDeclarationStatementSyntax"/> representing the declaration of the handle variable initialized to IntPtr.Zero.</returns>
 	internal static LocalDeclarationStatementSyntax? GetHandleDefaultVariable (string variableName)
 	{
-			// generates: var handle = IntPtr.Zero;
-			var declarator = VariableDeclarator (Identifier (variableName))
-				.WithInitializer (EqualsValueClause (
-						MemberAccessExpression (
-							SyntaxKind.SimpleMemberAccessExpression,
-							IntPtr,
-							IdentifierName ("Zero")))
-					.WithLeadingTrivia (Space).WithTrailingTrivia (Space));
+		// generates: var handle = IntPtr.Zero;
+		var declarator = VariableDeclarator (Identifier (variableName))
+			.WithInitializer (EqualsValueClause (
+					MemberAccessExpression (
+						SyntaxKind.SimpleMemberAccessExpression,
+						IntPtr,
+						IdentifierName ("Zero")))
+				.WithLeadingTrivia (Space).WithTrailingTrivia (Space));
 
-			var variableDeclaration = VariableDeclaration (NativeHandle)
-				.WithVariables (SingletonSeparatedList (declarator));
-			return LocalDeclarationStatement (variableDeclaration).NormalizeWhitespace ();
-		}
+		var variableDeclaration = VariableDeclaration (NativeHandle)
+			.WithVariables (SingletonSeparatedList (declarator));
+		return LocalDeclarationStatement (variableDeclaration).NormalizeWhitespace ();
+	}
 
 	/// <summary>
 	/// Generates a local variable declaration for an auxiliary NSString.

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -359,6 +359,28 @@ static partial class BindingSyntaxFactory {
 	/// <returns>A <see cref="LocalDeclarationStatementSyntax"/> for the auxiliary handle variable, or null if the input is not an NSObject or INativeObject, or if a variable name cannot be generated.</returns>
 	internal static LocalDeclarationStatementSyntax? GetHandleAuxVariable (in DelegateParameter parameter)
 		=> GetHandleAuxVariable (parameter.Name, parameter.Type);
+	
+	/// <summary>
+	/// Generates a local variable declaration for an auxiliary handle (IntPtr) initialized to IntPtr.Zero.
+	/// This is typically used to declare a default handle variable before assigning it a valid native handle.
+	/// </summary>
+	/// <param name="variableName">The name of the handle variable to declare.</param>
+	/// <returns>A <see cref="LocalDeclarationStatementSyntax"/> representing the declaration of the handle variable initialized to IntPtr.Zero.</returns>
+	internal static LocalDeclarationStatementSyntax? GetHandleDefaultVariable (string variableName)
+	{
+			// generates: var handle = IntPtr.Zero;
+			var declarator = VariableDeclarator (Identifier (variableName))
+				.WithInitializer (EqualsValueClause (
+						MemberAccessExpression (
+							SyntaxKind.SimpleMemberAccessExpression,
+							IntPtr,
+							IdentifierName ("Zero")))
+					.WithLeadingTrivia (Space).WithTrailingTrivia (Space));
+
+			var variableDeclaration = VariableDeclaration (NativeHandle)
+				.WithVariables (SingletonSeparatedList (declarator));
+			return LocalDeclarationStatement (variableDeclaration).NormalizeWhitespace ();
+		}
 
 	/// <summary>
 	/// Generates a local variable declaration for an auxiliary NSString.

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
@@ -984,9 +984,9 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 	void GetHandleDefaultVariableTest ()
 	{
 		var variableName = "myParam__handle__";
-		var expectedDeclaration = $"{BaseGeneratorTestClass.Global ("ObjCRuntime.NativeHandle")} {variableName} = {BaseGeneratorTestClass.Global ("System.IntPtr")}.Zero;";	
+		var expectedDeclaration = $"{BaseGeneratorTestClass.Global ("ObjCRuntime.NativeHandle")} {variableName} = {BaseGeneratorTestClass.Global ("System.IntPtr")}.Zero;";
 		var declaration = GetHandleDefaultVariable (variableName);
 		Assert.Equal (expectedDeclaration, declaration?.ToString ());
-	} 
+	}
 
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
@@ -980,4 +980,13 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 		Assert.Equal (expectedExpression, GetSmartEnumFromNSString (smartEnumType, Argument (auxVariable)).ToString ());
 	}
 
+	[Fact]
+	void GetHandleDefaultVariableTest ()
+	{
+		var variableName = "myParam__handle__";
+		var expectedDeclaration = $"{BaseGeneratorTestClass.Global ("ObjCRuntime.NativeHandle")} {variableName} = {BaseGeneratorTestClass.Global ("System.IntPtr")}.Zero;";	
+		var declaration = GetHandleDefaultVariable (variableName);
+		Assert.Equal (expectedDeclaration, declaration?.ToString ());
+	} 
+
 }


### PR DESCRIPTION
This later is required to be able to generate out NSObject parameters in trampolines.