### PR TITLE
[RGen] Fix nullable NSObject GetHandle calls.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -302,8 +302,15 @@ static partial class BindingSyntaxFactory {
 		if (variableName is null)
 			return null;
 		// decide about the factory based on the need of a null check 
-		InvocationExpressionSyntax factoryInvocation;
+		ExpressionSyntax factoryInvocation;
 		if (parameterType.IsNullable) {
+			// generates: zone?.GetHandle ();
+			factoryInvocation = ConditionalAccessExpression (
+					IdentifierName (parameterName),
+					InvocationExpression (
+						MemberBindingExpression (
+							IdentifierName ("GetHandle").WithTrailingTrivia (Space))));
+		} else {
 			// generates: zone!.GetNonNullHandle (nameof (zone));
 			factoryInvocation = InvocationExpression (
 					MemberAccessExpression (SyntaxKind.SimpleMemberAccessExpression,
@@ -313,12 +320,6 @@ static partial class BindingSyntaxFactory {
 						IdentifierName ("GetNonNullHandle").WithTrailingTrivia (Space)))
 				.WithArgumentList (ArgumentList (
 					SingletonSeparatedList (Argument (NameOf (parameterName)))));
-		} else {
-			// generates: zone.GetHandle ();
-			factoryInvocation = InvocationExpression (
-				MemberAccessExpression (SyntaxKind.SimpleMemberAccessExpression,
-					IdentifierName (parameterName),
-					IdentifierName ("GetHandle").WithTrailingTrivia (Space)));
 		}
 
 		// generates: variable = {FactoryCall}

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
@@ -1137,8 +1137,9 @@ static partial class BindingSyntaxFactory {
 	{
 		var builder = ImmutableArray.CreateBuilder<SyntaxNode> ();
 		// if the parameter does not allow the object to be null and it is a reference type, we need to add the null check
-		// otherwise ignore it
-		if (parameter.Type is { IsReferenceType: true, IsNullable: false }) {
+		// otherwise ignore it. We do not want this check for INativeObjects (includes NSObject) because the GetNonNullableHandle
+		// will throw an exception if the object is null.
+		if (parameter.Type is { IsReferenceType: true, IsINativeObject: false, IsNullable: false }) {
 			builder.Add (ThrowIfNull (parameter.Name));
 		}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedTrampolinePropertyTestsTrampolines.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedTrampolinePropertyTestsTrampolines.cs
@@ -70,9 +70,7 @@ static partial class Trampolines
 
 		unsafe global::Foundation.NSObject Invoke (global::Foundation.NSObject obj)
 		{
-			if (obj is null)
-				global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (obj));
-			var obj__handle__ = obj.GetHandle ();
+			var obj__handle__ = obj!.GetNonNullHandle (nameof (obj));
 			var ret = invoker (BlockLiteral, obj__handle__);
 			global::System.GC.KeepAlive (obj);
 			return global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSObject> (ret, false)!;
@@ -429,12 +427,8 @@ static partial class Trampolines
 
 		unsafe void Invoke (global::CoreGraphics.CGImage imageRef, global::CoreMedia.CMTime actualTime, global::Foundation.NSError error)
 		{
-			if (imageRef is null)
-				global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (imageRef));
-			var imageRef__handle__ = imageRef.GetHandle ();
-			if (error is null)
-				global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (error));
-			var error__handle__ = error.GetHandle ();
+			var imageRef__handle__ = imageRef!.GetNonNullHandle (nameof (imageRef));
+			var error__handle__ = error!.GetNonNullHandle (nameof (error));
 			invoker (BlockLiteral, imageRef__handle__, actualTime, error__handle__);
 			global::System.GC.KeepAlive (imageRef);
 			global::System.GC.KeepAlive (error);
@@ -497,9 +491,7 @@ static partial class Trampolines
 
 		unsafe global::AVFoundation.AVAudioEngineManualRenderingStatus Invoke (uint numberOfFrames, global::AudioToolbox.AudioBuffers outBuffer, ref int outError)
 		{
-			if (outBuffer is null)
-				global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (outBuffer));
-			var outBuffer__handle__ = outBuffer.GetHandle ();
+			var outBuffer__handle__ = outBuffer!.GetNonNullHandle (nameof (outBuffer));
 			var ret = invoker (BlockLiteral, numberOfFrames, outBuffer__handle__, (int*) global::System.Runtime.CompilerServices.Unsafe.AsPointer<int> (ref outError));
 			global::System.GC.KeepAlive (outBuffer);
 			return (global::AVFoundation.AVAudioEngineManualRenderingStatus) (long) ret;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
@@ -302,23 +302,23 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 			// nsobject type
 			yield return [
 				new Parameter (0, ReturnTypeForNSObject ("MyNSObject"), "myParam"),
-				"var myParam__handle__ = myParam.GetHandle ();",
+				"var myParam__handle__ = myParam!.GetNonNullHandle (nameof (myParam));",
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForNSObject ("MyNSObject", isNullable: true), "myParam"),
-				"var myParam__handle__ = myParam!.GetNonNullHandle (nameof (myParam));",
+				"var myParam__handle__ = myParam?.GetHandle ();",
 			];
 
 			// interface type
 			yield return [
 				new Parameter (0, ReturnTypeForINativeObject ("MyNativeObject"), "myParam"),
-				"var myParam__handle__ = myParam.GetHandle ();",
+				"var myParam__handle__ = myParam!.GetNonNullHandle (nameof (myParam));",
 			];
 
 			yield return [
 				new Parameter (0, ReturnTypeForINativeObject ("MyNativeObject", isNullable: true), "myParam"),
-				"var myParam__handle__ = myParam!.GetNonNullHandle (nameof (myParam));",
+				"var myParam__handle__ = myParam?.GetHandle ();",
 			];
 
 			// value type

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -4638,10 +4638,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				nsObjectParameter,
-				@"if (nsObjectParameter is null)
-	global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (nsObjectParameter));
-var nsObjectParameter__handle__ = nsObjectParameter.GetHandle ();
-",
+				"var nsObjectParameter__handle__ = nsObjectParameter!.GetNonNullHandle (nameof (nsObjectParameter));\n",
 			];
 
 			// nullable NSObject parameter
@@ -4662,7 +4659,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				nullableNSObjectParameter,
-				"var nsObjectParameter__handle__ = nsObjectParameter!.GetNonNullHandle (nameof (nsObjectParameter));\n",
+				"var nsObjectParameter__handle__ = nsObjectParameter?.GetHandle ();\n",
 			];
 
 			// NSObject array parameter
@@ -4729,10 +4726,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				iNativeParameter,
-				@"if (inative is null)
-	global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (inative));
-var inative__handle__ = inative.GetHandle ();
-"
+				"var inative__handle__ = inative!.GetNonNullHandle (nameof (inative));\n"
 			];
 
 			// nullable INativeObject parameter
@@ -4754,7 +4748,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				nullableINativeParameter,
-				"var inative__handle__ = inative!.GetNonNullHandle (nameof (inative));\n",
+				"var inative__handle__ = inative?.GetHandle ();\n",
 			];
 
 			// INativeObject array parameter
@@ -4821,10 +4815,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				audioBuffer,
-				@"if (audioBuffer is null)
-	global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (audioBuffer));
-var audioBuffer__handle__ = audioBuffer.GetHandle ();
-",
+				"var audioBuffer__handle__ = audioBuffer!.GetNonNullHandle (nameof (audioBuffer));\n",
 			];
 
 			var cmSampleBuffer = @"
@@ -4844,10 +4835,7 @@ namespace NS {
 			yield return [
 				"someTrampolineName",
 				cmSampleBuffer,
-				@"if (cmSampleBuffer is null)
-	global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (cmSampleBuffer));
-var cmSampleBuffer__handle__ = cmSampleBuffer.GetHandle ();
-",
+				"var cmSampleBuffer__handle__ = cmSampleBuffer!.GetNonNullHandle (nameof (cmSampleBuffer));\n",
 			];
 		}
 


### PR DESCRIPTION
The logic was reversed and the GetNonNullableHandle throws an exception. This change fixes the logic and makes the generated code smaller (not need for the extra throw).