### PR TITLE
[RGen] Correctly cast enum results from the native invocation.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
@@ -108,6 +108,12 @@ static partial class BindingSyntaxFactory {
 			{ IsEnum: true, IsSmartEnum: true, IsNativeEnum: false } 
 				=> GetSmartEnumFromNSString (typeInfo.Delegate.ReturnType, Argument (auxIdentifier)),
 			
+			// normal enum casting
+			{ IsEnum: true, IsSmartEnum: false, IsNativeEnum: false } 
+				=> CastExpression (
+					typeInfo.Delegate.ReturnType.GetIdentifierSyntax (), 
+					auxIdentifier.WithLeadingTrivia (Space)),
+			
 			// string from native handle
 			// CFString.FromHandle (auxVariable)!
 			{ SpecialType: SpecialType.System_String, IsNullable: false} 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedTrampolinePropertyTestsTrampolines.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedTrampolinePropertyTestsTrampolines.cs
@@ -556,17 +556,13 @@ static partial class Trampolines
 
 		unsafe global::AudioUnit.AudioUnitStatus Invoke (ref global::AudioUnit.AudioUnitRenderActionFlags actionFlags, ref global::AudioToolbox.AudioTimeStamp timestamp, uint frameCount, global::System.IntPtr outputBusNumber, global::AudioToolbox.AudioBuffers outputData, global::AudioUnit.AURenderEventEnumerator realtimeEventListHead, global::AudioUnit.AURenderPullInputBlock? pullInputBlock)
 		{
-			if (outputData is null)
-				global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (outputData));
-			var outputData__handle__ = outputData.GetHandle ();
-			if (realtimeEventListHead is null)
-				global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (realtimeEventListHead));
-			var realtimeEventListHead__handle__ = realtimeEventListHead.GetHandle ();
+			var outputData__handle__ = outputData!.GetNonNullHandle (nameof (outputData));
+			var realtimeEventListHead__handle__ = realtimeEventListHead!.GetNonNullHandle (nameof (realtimeEventListHead));
 			var block_pullInputBlock = global::ObjCRuntime.Trampolines.SDAUInternalRenderBlock.CreateNullableBlock (pullInputBlock);
 			var ret = invoker (BlockLiteral, (global::AudioUnit.AudioUnitRenderActionFlags*) global::System.Runtime.CompilerServices.Unsafe.AsPointer<global::AudioUnit.AudioUnitRenderActionFlags> (ref actionFlags), (global::AudioToolbox.AudioTimeStamp*) global::System.Runtime.CompilerServices.Unsafe.AsPointer<global::AudioToolbox.AudioTimeStamp> (ref timestamp), frameCount, outputBusNumber, outputData__handle__, realtimeEventListHead__handle__, NIDAUInternalRenderBlock.Create (pullInputBlock)!);
 			global::System.GC.KeepAlive (outputData);
 			global::System.GC.KeepAlive (realtimeEventListHead);
-			return ret;
+			return (global::AudioUnit.AudioUnitStatus) ret;
 		}
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -749,6 +749,28 @@ namespace NS {
 				intReturnType,
 				"auxVariable"
 			];
+			
+			const string enumReturnType = @"
+using System;
+
+namespace NS {
+
+	public enum TestEnum {
+		First,
+		Last
+	}
+
+	public delegate TestEnum Callback()
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				enumReturnType,
+				"(global::NS.TestEnum) auxVariable",
+			];
 
 			const string voidReturnType = @"
 using System;


### PR DESCRIPTION
Generate a simple cast when the result is a non-native non-smart enum.