### PR TITLE
[release/9.0.1xx] [src/runtime] Don't allow native code to resolve a weak reference for an object in the finalizer queue.

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -121,6 +121,7 @@ struct Trampolines {
 	void* set_gchandle_tramp;
 	void* get_flags_tramp;
 	void* set_flags_tramp;
+	void* retainWeakReference_tramp;
 };
 
 enum InitializationFlags : int {
@@ -180,6 +181,7 @@ static struct Trampolines trampolines = {
 	(void *) &xamarin_set_gchandle_trampoline,
 	(void *) &xamarin_get_flags_trampoline,
 	(void *) &xamarin_set_flags_trampoline,
+	(void *) &xamarin_retainWeakReference_trampoline,
 };
 
 static struct InitializationOptions options = { 0 };

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -654,6 +654,15 @@ xamarin_invoke_objc_method_implementation (id self, SEL sel, IMP xamarin_impl)
 	return ((func_objc_msgSendSuper) objc_msgSendSuper) (&sup, sel);
 }
 
+BOOL
+xamarin_invoke_objc_method_implementation_BOOL (id self, SEL sel, IMP xamarin_impl)
+{
+	struct objc_super sup;
+	find_objc_method_implementation (&sup, self, sel, xamarin_impl);
+	typedef BOOL (*func_objc_msgSendSuper) (struct objc_super *sup, SEL sel);
+	return ((func_objc_msgSendSuper) objc_msgSendSuper) (&sup, sel);
+}
+
 #if MONOMAC
 id
 xamarin_copyWithZone_trampoline1 (id self, SEL sel, NSZone *zone)
@@ -804,6 +813,35 @@ xamarin_retain_trampoline (id self, SEL sel)
 	return self;
 }
 
+BOOL
+xamarin_retainWeakReference_trampoline (id self, SEL sel)
+{
+	GCHandle gchandle = xamarin_get_gchandle (self);
+	uint32_t flags = 0;
+	MonoObject *mobj = NULL;
+	bool isInFinalizerQueue = false;
+
+	if (gchandle != INVALID_GCHANDLE) {
+		mobj = xamarin_gchandle_get_target (gchandle);
+		if (mobj != NULL) {
+			flags = xamarin_get_nsobject_flags (mobj);
+			isInFinalizerQueue = (flags & NSObjectFlagsInFinalizerQueue) == NSObjectFlagsInFinalizerQueue;
+		}
+	}
+
+#if defined(DEBUG_REF_COUNTING)
+	PRINT ("xamarin_retainWeakReference_trampoline (%s Handle=%p) gchandle: %i flags: %x mobj: %p isInFinalizerQueue: %i\n",
+		class_getName ([self class]), self, gchandle, flags, mobj, isInFinalizerQueue);
+#endif
+
+	// Do not allow any weak references to be resolved if the managed wrapper has been scheduled for finalization,
+	// all kinds of bad things happen when native code tries to use such an object.
+	if (isInFinalizerQueue)
+		return FALSE;
+
+	/* Invoke the real release method */
+	return xamarin_invoke_objc_method_implementation_BOOL (self, sel, (IMP) xamarin_retainWeakReference_trampoline);
+}
 
 // We try to use the associated object API as little as possible, because the API does
 // not like recursion (see bug #35017), and it calls retain/release, which we might

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -822,11 +822,13 @@ xamarin_retainWeakReference_trampoline (id self, SEL sel)
 	bool isInFinalizerQueue = false;
 
 	if (gchandle != INVALID_GCHANDLE) {
+		MONO_THREAD_ATTACH;
 		mobj = xamarin_gchandle_get_target (gchandle);
 		if (mobj != NULL) {
 			flags = xamarin_get_nsobject_flags (mobj);
 			isInFinalizerQueue = (flags & NSObjectFlagsInFinalizerQueue) == NSObjectFlagsInFinalizerQueue;
 		}
+		MONO_THREAD_DETACH;
 	}
 
 #if defined(DEBUG_REF_COUNTING)

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -274,6 +274,7 @@ void			xamarin_log_managed_exception (MonoObject *exception, MarshalManagedExcep
 void			xamarin_log_objectivec_exception (NSException *exception, MarshalObjectiveCExceptionMode mode);
 
 id				xamarin_invoke_objc_method_implementation (id self, SEL sel, IMP xamarin_impl);
+BOOL			xamarin_invoke_objc_method_implementation_BOOL (id self, SEL sel, IMP xamarin_impl);
 MonoType *		xamarin_get_nsnumber_type ();
 MonoType *		xamarin_get_nsvalue_type ();
 MonoClass *		xamarin_get_inativeobject_class ();

--- a/runtime/xamarin/trampolines.h
+++ b/runtime/xamarin/trampolines.h
@@ -26,6 +26,7 @@ void		xamarin_stret_trampoline (void *buffer, id self, SEL sel, ...);
 float		xamarin_fpret_single_trampoline (id self, SEL sel, ...);
 double		xamarin_fpret_double_trampoline (id self, SEL sel, ...);
 void		xamarin_release_trampoline (id self, SEL sel);
+BOOL		xamarin_retainWeakReference_trampoline (id self, SEL sel);
 void		xamarin_calayer_release_trampoline (id self, SEL sel);
 id			xamarin_retain_trampoline (id self, SEL sel);
 void		xamarin_dealloc_trampoline (id self, SEL sel);

--- a/src/ObjCRuntime/DynamicRegistrar.cs
+++ b/src/ObjCRuntime/DynamicRegistrar.cs
@@ -1131,6 +1131,9 @@ namespace Registrar {
 			case Trampoline.SetFlags:
 				tramp = Method.SetFlagsTrampoline;
 				break;
+			case Trampoline.RetainWeakReference:
+				tramp = Method.RetainWeakReferenceTrampoline;
+				break;
 			default:
 				throw ErrorHelper.CreateError (4144, "Cannot register the method '{0}.{1}' since it does not have an associated trampoline. Please file a bug report at https://github.com/dotnet/macios/issues/new", method.DeclaringType.Type.FullName, method.Name);
 			}

--- a/src/ObjCRuntime/Method.cs
+++ b/src/ObjCRuntime/Method.cs
@@ -108,6 +108,10 @@ namespace ObjCRuntime {
 		internal unsafe static IntPtr SetFlagsTrampoline {
 			get { return Runtime.options->Trampolines->set_flags_tramp; }
 		}
+
+		internal unsafe static IntPtr RetainWeakReferenceTrampoline {
+			get{ return Runtime.options->Trampolines->retainWeakReference_tramp; }
+		}
 #endif // !COREBUILD
 	}
 }

--- a/src/ObjCRuntime/Method.cs
+++ b/src/ObjCRuntime/Method.cs
@@ -110,7 +110,7 @@ namespace ObjCRuntime {
 		}
 
 		internal unsafe static IntPtr RetainWeakReferenceTrampoline {
-			get{ return Runtime.options->Trampolines->retainWeakReference_tramp; }
+			get { return Runtime.options->Trampolines->retainWeakReference_tramp; }
 		}
 #endif // !COREBUILD
 	}

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -164,6 +164,7 @@ namespace ObjCRuntime {
 			public IntPtr set_gchandle_tramp;
 			public IntPtr get_flags_tramp;
 			public IntPtr set_flags_tramp;
+			public IntPtr retainWeakReference_tramp;
 		}
 #pragma warning restore 649
 

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -2661,6 +2661,8 @@ namespace Registrar {
 				return "-(bool) xamarinSetGCHandle: (GCHandle) gchandle flags: (enum XamarinGCHandleFlags) flags";
 			else if (method.CurrentTrampoline == Trampoline.CopyWithZone1 || method.CurrentTrampoline == Trampoline.CopyWithZone2)
 				return "-(id) copyWithZone: (NSZone *)zone";
+			else if (method.CurrentTrampoline == Trampoline.RetainWeakReference)
+				return "-(BOOL) retainWeakReference";
 
 			var sb = new StringBuilder ();
 			var isCtor = method.CurrentTrampoline == Trampoline.Constructor;
@@ -3477,6 +3479,13 @@ namespace Registrar {
 				sb.AppendLine ("return xamarin_copyWithZone_trampoline2 (self, _cmd, zone);");
 				sb.AppendLine ("}");
 				return true;
+			case Trampoline.RetainWeakReference:
+				sb.WriteLine ("-(BOOL) retainWeakReference");
+				sb.WriteLine ("{");
+				sb.WriteLine ("\treturn xamarin_retainWeakReference_trampoline (self, _cmd);");
+				sb.WriteLine ("}");
+				sb.WriteLine ();
+				return true;
 			}
 
 			var customConformsToProtocol = method.Selector == "conformsToProtocol:" && method.Method.DeclaringType.Is ("Foundation", "NSObject") && method.Method.Name == "InvokeConformsToProtocol" && method.Parameters.Length == 1;
@@ -3536,6 +3545,10 @@ namespace Registrar {
 					rettype = ToSimpleObjCParameterType (method.NativeReturnType, descriptiveMethodName, exceptions, method.Method);
 					return true;
 				}
+			case Trampoline.RetainWeakReference:
+				rettype = "BOOL";
+				isCtor = false;
+				return true;
 			case Trampoline.Constructor:
 				rettype = "id";
 				isCtor = true;


### PR DESCRIPTION
The following happens:

1. An instance of a custom NSObject subclass is created, with both a native instance
   and the corresponding managed wrapper.

2. Native code creates a weak reference to the native instance.

3. No other managed code references the managed instance, and there's no non-weak
   native reference to the native instance, so the GC schedules the managed instance
   for finalization.

4. Native code fetches the native instance from the weak reference.

5. Native code thinks it can do whatever it wants with the native instance, because
   it got a perfectly valid (and retained) native instance. Unfortunately, there's no way
   to stop the managed instance from being finalized (which happens on a background
   thread anyway, so there's no thread-safe way to do it), which means havoc ensues.

The most frequent manifestation of this problem has been like this:

    ObjCRuntime.RuntimeException: Failed to marshal the Objective-C object 0x13d566800 (type: Microsoft_Maui_Platform_MauiTextField). Could not find an existing managed instance for this object, nor was it possible to create a new managed instance (because the type 'Microsoft.Maui.Platform.MauiTextField' does not have a constructor that takes one NativeHandle argument).
       at ObjCRuntime.Runtime.MissingCtor(IntPtr , IntPtr , Type , MissingCtorResolution , IntPtr , RuntimeMethodHandle )
       at ObjCRuntime.Runtime.ConstructNSObject[NSObject](IntPtr , Type , MissingCtorResolution , IntPtr , RuntimeMethodHandle )
       at ObjCRuntime.Runtime.ConstructNSObject[NSObject](IntPtr , Type , MissingCtorResolution )
       at ObjCRuntime.Runtime.ConstructNSObject(IntPtr , IntPtr , MissingCtorResolution )
       at ObjCRuntime.Runtime.GetNSObject(IntPtr , MissingCtorResolution , Boolean )
       at ObjCRuntime.Runtime.GetNSObject(IntPtr )
       at ObjCRuntime.Runtime.InvokeConformsToProtocol(IntPtr , IntPtr )
       at ObjCRuntime.Runtime.invoke_conforms_to_protocol(IntPtr obj, IntPtr protocol, IntPtr* exception_gchandle)
       Exception_EndOfInnerExceptionStack

but other problems can also occur.

This is a rather complicated issue to fix, because:

* There's no way to be notified when native code creates a weak reference to a
  native instance.
* There's not even a way to know if anybody has a weak reference to a native
  instance.
* I also looked into manually clearing the weak references for a native
  instance, but that's not possible either.

However, it is possible to basically say \"nope!\" when native code tries to
fetch a native instance from a weak reference:

We override the '[NSObject retainWeakReference]' method for all custom
NSObject subclasses, and return FALSE if the corresponding managed object has
been scheduled for finalization (otherwise call the base class implementation).

The ['[NSObject retainWeakReference]'][1] method is public, but it's not
documented how it's supposed to behave. Fortunately, the corresponding [source
code][2] is public, so we can figure out the semantics ourselves: return
`TRUE` if the object can be / was retained, `FALSE` otherwise.

* Fixes https://github.com/dotnet/macios/issues/21648.
* Fixes https://github.com/dotnet/maui/issues/28261.
* Fixes https://github.com/dotnet/macios/issues/19076.

Might also fix the following issues:

* https://github.com/dotnet/macios/issues/22867
* https://github.com/dotnet/macios/issues/19579
* https://github.com/dotnet/macios/issues/4207
* https://bugzilla.xamarin.com/show_bug.cgi?id=34242 (https://web.archive.org/web/20170630214134/https://bugzilla.xamarin.com/show_bug.cgi?id=34242)

[1]: https://developer.apple.com/documentation/foundation/nsproxy/retainweakreference
[2]: https://github.com/apple-oss-distributions/objc4/blob/f126469408dc82bd3f327217ae678fd0e6e3b37c/runtime/NSObject.mm#L539-L541

Backport of #23072.