### PR TITLE
[release/9.0.1xx] Update Xamarin.Messaging and renamed Xamarin paths

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
 		<DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
 		<MonoCecilPackageVersion>0.11.5</MonoCecilPackageVersion>
 		<MSBuildStructuredLoggerPackageVersion>2.2.158</MSBuildStructuredLoggerPackageVersion>
-		<MicrosoftBuildPackageVersion>16.10.0</MicrosoftBuildPackageVersion>
+		<MicrosoftBuildPackageVersion>17.13.1</MicrosoftBuildPackageVersion>
 		<MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
 		<MicrosoftBuildTasksCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCorePackageVersion>
 		<MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>
@@ -12,7 +12,7 @@
 		<!-- Fix transient dependency issue found by component governance 4.7.0 -> 4.7.2 brought by Microsoft.Build package -->
 		<SystemDrawingCommonPackageVersion>4.7.2</SystemDrawingCommonPackageVersion>
 		<!-- Fix transient dependency issue found by component governance 4.7.0 -> 4.7.1 brought by Microsoft.Build.Tasks.Core package -->
-		<SystemSecurityCryptographyXmlPackageVersion>4.7.1</SystemSecurityCryptographyXmlPackageVersion>
+		<SystemSecurityCryptographyXmlPackageVersion>8.0.0</SystemSecurityCryptographyXmlPackageVersion>
 	</PropertyGroup>
 	<Import Project="Build.props" Condition="Exists('Build.props')" />
 </Project>

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1314,9 +1314,16 @@
 		</ItemGroup>
 	</Target>
 
+	<Target Name="_ComputeDotNetRoot">
+		<PropertyGroup>
+			<_DotNetRoot Condition="'$(IsMacEnabled)' == 'true'">$(_DotNetRootRemoteDirectory)</_DotNetRoot>
+		</PropertyGroup>
+	</Target>
+
 	<PropertyGroup>
 		<_AOTCompileDependsOn>
 			$(_AOTCompileDependsOn);
+			_ComputeDotNetRoot;
 			_ComputeVariables;
 			_FindAotCompiler;
 			_DetectAppManifest;
@@ -1409,6 +1416,7 @@
 			SdkIsSimulator="$(_SdkIsSimulator)"
 			SdkRoot="$(_SdkRoot)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
+			DotNetRoot="$(_DotNetRoot)"
 		>
 		</CompileNativeCode>
 
@@ -1550,6 +1558,7 @@
 	<PropertyGroup>
 		<_CompileNativeExecutableDependsOn>
 			$(_CompileNativeExecutableDependsOn);
+			_ComputeDotNetRoot;
 			_DetectSdkLocations;
 			_ComputeTargetArchitectures;
 			_GenerateBundleName;
@@ -1583,6 +1592,7 @@
 			SdkIsSimulator="$(_SdkIsSimulator)"
 			SdkRoot="$(_SdkRoot)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
+			DotNetRoot="$(_DotNetRoot)"
 		>
 		</CompileNativeCode>
 

--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -15,7 +15,7 @@
 			https://dev.azure.com/azure-public/vside/_artifacts/feed/xamarin-impl/NuGet/Xamarin.Messaging.Client/
 
 		-->
-		<MessagingVersion Condition="'$(MessagingVersion)' == ''">[18.0.108-gaffa6c07e5]</MessagingVersion>
+		<MessagingVersion Condition="'$(MessagingVersion)' == ''">[18.0.136-g9e200fbc6d]</MessagingVersion>
 		<HotRestartVersion>[17.14.133-g001ce2ac7a]</HotRestartVersion>
 	</PropertyGroup>
 	<Import Project="$(MSBuildThisFileDirectory)../Directory.Build.props" />

--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -15,7 +15,7 @@
 			https://dev.azure.com/azure-public/vside/_artifacts/feed/xamarin-impl/NuGet/Xamarin.Messaging.Client/
 
 		-->
-		<MessagingVersion Condition="'$(MessagingVersion)' == ''">[3.0.13]</MessagingVersion>
+		<MessagingVersion Condition="'$(MessagingVersion)' == ''">[18.0.108-gaffa6c07e5]</MessagingVersion>
 		<HotRestartVersion>[17.14.133-g001ce2ac7a]</HotRestartVersion>
 	</PropertyGroup>
 	<Import Project="$(MSBuildThisFileDirectory)../Directory.Build.props" />

--- a/msbuild/ILMerge.targets
+++ b/msbuild/ILMerge.targets
@@ -34,6 +34,7 @@
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'ILStrip'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Newtonsoft.Json'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Renci.SshNet'" />
+      <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'BouncyCastle.Cryptography'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Merq'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Merq.Core'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'SshNet.Security.Cryptography'" />

--- a/msbuild/Messaging/Xamarin.Messaging.Build/BuildAgent.cs
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/BuildAgent.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Xamarin.Messaging.Build.Contracts;
 using Xamarin.Messaging.Client;
@@ -39,7 +40,7 @@ namespace Xamarin.Messaging.Build {
 			return Task.FromResult (true);
 		}
 
-		protected override async Task RegisterCustomHandlersAsync (MessageHandlerManager manager)
+		protected override async Task RegisterCustomHandlersAsync (MessageHandlerManager manager, CancellationToken cancellationToken)
 		{
 			await TryRegisterHandlerAsync (new ExecuteTaskMessageHandler ())
 				.ConfigureAwait (continueOnCapturedContext: false);

--- a/msbuild/Messaging/Xamarin.Messaging.Build/Handlers/CompareFilesMessageHandler.cs
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/Handlers/CompareFilesMessageHandler.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Messaging.Build {
 		protected override async Task<CompareItemsResult> ExecuteAsync (CompareItemsMessage message)
 		{
 			return await Task.Run (() => {
-				var buildPath = Path.Combine (MessagingContext.GetBuildPath (), message.AppName, message.SessionId);
+				var buildPath = Path.Combine (MessagingContext.BuildsPath, message.AppName, message.SessionId);
 				var files = new List<string> ();
 
 				using (var hashAlgorithm = Hash.GetAlgorithm ()) {

--- a/msbuild/Messaging/Xamarin.Messaging.Build/Handlers/CopyItemMessageHandler.cs
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/Handlers/CopyItemMessageHandler.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Messaging.Build {
 		{
 			await Task.Run (async () => {
 				var targetPath = Path.GetFullPath (Path.Combine (
-					MessagingContext.GetBuildPath (),
+					MessagingContext.BuildsPath,
 					message.AppName,
 					message.SessionId,
 					PlatformPath.GetPathForCurrentPlatform (message.ItemSpec)));

--- a/msbuild/Messaging/Xamarin.Messaging.Build/Handlers/ExecuteTaskMessageHandler.cs
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/Handlers/ExecuteTaskMessageHandler.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Messaging.Build {
 					var currentDirectory = Directory.GetCurrentDirectory ();
 
 					try {
-						var buildDirectory = Path.Combine (MessagingContext.GetBuildPath (), message.AppName, message.SessionId);
+						var buildDirectory = Path.Combine (MessagingContext.BuildsPath, message.AppName, message.SessionId);
 
 						Directory.CreateDirectory (buildDirectory);
 

--- a/msbuild/Messaging/Xamarin.Messaging.Build/Handlers/GetItemMessageHandler.cs
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/Handlers/GetItemMessageHandler.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Messaging.Build {
 		{
 			return await Task.Run<GetItemResult> (() => {
 				var targetPath = Path.GetFullPath (Path.Combine (
-					MessagingContext.GetBuildPath (),
+					MessagingContext.BuildsPath,
 					message.AppName,
 					message.SessionId,
 					PlatformPath.GetPathForCurrentPlatform (message.ItemSpec)));

--- a/msbuild/Messaging/Xamarin.Messaging.Build/Program.cs
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/Program.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Xamarin.Messaging.Client;
 
@@ -10,7 +11,7 @@ namespace Xamarin.Messaging.Build {
 			var agent = new BuildAgent (topicGenerator, arguments.Version, arguments.VersionInfo);
 			var runner = new AgentConsoleRunner<BuildAgent> (agent, arguments);
 
-			await runner.RunAsync ().ConfigureAwait (continueOnCapturedContext: false);
+			await runner.RunAsync (CancellationToken.None).ConfigureAwait (continueOnCapturedContext: false);
 		}
 	}
 }

--- a/msbuild/Messaging/Xamarin.Messaging.Build/Program.cs
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/Program.cs
@@ -1,6 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Xamarin.Messaging.Client;
+using System.IO;
 
 namespace Xamarin.Messaging.Build {
 	class Program {
@@ -10,6 +11,13 @@ namespace Xamarin.Messaging.Build {
 			var arguments = new AgentArgumentsParser ().ParseArguments (args);
 			var agent = new BuildAgent (topicGenerator, arguments.Version, arguments.VersionInfo);
 			var runner = new AgentConsoleRunner<BuildAgent> (agent, arguments);
+
+			//Hack to support legacy paths from Windows (likely Dev17 versions)
+			if (MessagingContext.BasePath.Contains ("Xamarin")) {
+				var xamarinPath = MessagingContext.BasePath.Substring (0, MessagingContext.BasePath.IndexOf ("Xamarin") + "Xamarin".Length);
+
+				MessagingContext.BuildsPath = Path.Combine (xamarinPath, "mtbs", "builds");
+			}
 
 			await runner.RunAsync (CancellationToken.None).ConfigureAwait (continueOnCapturedContext: false);
 		}

--- a/msbuild/Messaging/Xamarin.Messaging.Build/Program.cs
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Xamarin.Messaging.Client;
@@ -13,8 +14,10 @@ namespace Xamarin.Messaging.Build {
 			var runner = new AgentConsoleRunner<BuildAgent> (agent, arguments);
 
 			//Hack to support legacy paths from Windows (likely Dev17 versions)
-			if (MessagingContext.BasePath.Contains ("Xamarin")) {
-				var xamarinPath = MessagingContext.BasePath.Substring (0, MessagingContext.BasePath.IndexOf ("Xamarin") + "Xamarin".Length);
+			var index = MessagingContext.BasePath.IndexOf ("Xamarin", StringComparison.Ordinal);
+
+			if (index >= 0) {
+				var xamarinPath = MessagingContext.BasePath.Substring (0, index + "Xamarin".Length);
 
 				MessagingContext.BuildsPath = Path.Combine (xamarinPath, "mtbs", "builds");
 			}

--- a/msbuild/Messaging/Xamarin.Messaging.Build/TaskRunner.cs
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/TaskRunner.cs
@@ -55,7 +55,7 @@ namespace Xamarin.Messaging.Build {
 
 		void SetDotNetVariables ()
 		{
-			var xmaSdkRootPath = Path.Combine (MessagingContext.GetXmaPath (), "SDKs");
+			var xmaSdkRootPath = MessagingContext.SdksPath;
 			var xmaDotNetRootPath = Path.Combine (xmaSdkRootPath, "dotnet");
 			var xmaDotNetPath = default (string);
 

--- a/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/Xamarin.Messaging.Build.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <AssemblyName>Build</AssemblyName>
     <NoWarn>$(NoWarn);NU1603</NoWarn> <!-- Xamarin.Messaging.Build.Common 1.6.24 depends on Merq (>= 1.1.0) but Merq 1.1.0 was not found. An approximate best match of Merq 1.1.4 was resolved. -->

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -799,6 +799,11 @@
         </value>
     </data>
     
+    <data name="M0169" xml:space="preserve">
+        <value>Adjusted path from '{0}' to '{1}'
+        </value>
+    </data>
+
     <data name="E0169" xml:space="preserve">
         <value>Unknown target framework identifier: {0}.
         </value>

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ACTool.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ACTool.cs
@@ -436,7 +436,7 @@ namespace Xamarin.MacDev.Tasks {
 
 					foreach (var tag in resourceTags.EnumerateArray ()) {
 						if (tag.ValueKind == JsonValueKind.String)
-							tags.Add (tag.GetString ());
+							tags.Add (tag.GetString ()!);
 					}
 
 					var tagList = tags.ToList ();

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileNativeCode.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileNativeCode.cs
@@ -163,14 +163,14 @@ namespace Xamarin.MacDev.Tasks {
 				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 
-		string GetIncludeDirectory(ITaskItem item)
+		string GetIncludeDirectory (ITaskItem item)
 		{
 			var path = Path.GetFullPath (item.ItemSpec);
 
 			if (string.IsNullOrEmpty (DotNetRoot)) {
 				return path;
 			}
-				
+
 			var packsIdentifier = "packs";
 			var dotnetPacksIdentifier = Path.Combine ("dotnet", packsIdentifier);
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileNativeCode.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileNativeCode.cs
@@ -33,6 +33,8 @@ namespace Xamarin.MacDev.Tasks {
 
 		[Required]
 		public bool SdkIsSimulator { get; set; }
+
+		public string DotNetRoot { get; set; }
 		#endregion
 
 		public override bool Execute ()
@@ -107,8 +109,11 @@ namespace Xamarin.MacDev.Tasks {
 				arguments.Add (SdkRoot);
 
 				if (IncludeDirectories is not null) {
-					foreach (var inc in IncludeDirectories)
-						arguments.Add ("-I" + Path.GetFullPath (inc.ItemSpec));
+					foreach (var inc in IncludeDirectories) {
+						var incPath = GetIncludeDirectory (inc);
+
+						arguments.Add ("-I" + incPath);
+					}
 				}
 
 				var args = info.GetMetadata ("Arguments");
@@ -156,6 +161,31 @@ namespace Xamarin.MacDev.Tasks {
 		{
 			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (BuildEngine4).Wait ();
+		}
+
+		string GetIncludeDirectory(ITaskItem item)
+		{
+			var path = Path.GetFullPath (item.ItemSpec);
+
+			if (string.IsNullOrEmpty (DotNetRoot)) {
+				return path;
+			}
+				
+			var packsIdentifier = "packs";
+			var dotnetPacksIdentifier = Path.Combine ("dotnet", packsIdentifier);
+
+			//If the directory points to a dotnet pack, we want to ensure the full path 
+			//is actually pointing to a sub-folder in the dotnet SDK
+			if (path.Contains (dotnetPacksIdentifier) && !path.StartsWith (DotNetRoot)) {
+				var relativePath = path.Substring (path.IndexOf (packsIdentifier));
+				//We combine the relative pack dir (starting from "packs") with the dotnet root to get the full path
+				var newPath = Path.Combine (DotNetRoot, relativePath);
+
+				Log.LogMessage (MessageImportance.Low, MSBStrings.M0169, path, newPath);
+				path = newPath;
+			}
+
+			return path;
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileNativeCode.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileNativeCode.cs
@@ -176,7 +176,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			//If the directory points to a dotnet pack, we want to ensure the full path 
 			//is actually pointing to a sub-folder in the dotnet SDK
-			if (path.IndexOf(dotnetPacksIdentifier, StringComparison.Ordinal) >= 0 && !path.StartsWith (DotNetRoot, StringComparison.Ordinal)) {
+			if (path.IndexOf (dotnetPacksIdentifier, StringComparison.Ordinal) >= 0 && !path.StartsWith (DotNetRoot, StringComparison.Ordinal)) {
 				var relativePath = path.Substring (path.IndexOf (packsIdentifier, StringComparison.Ordinal));
 				//We combine the relative pack dir (starting from "packs") with the dotnet root to get the full path
 				var newPath = Path.Combine (DotNetRoot, relativePath);

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileNativeCode.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileNativeCode.cs
@@ -34,7 +34,7 @@ namespace Xamarin.MacDev.Tasks {
 		[Required]
 		public bool SdkIsSimulator { get; set; }
 
-		public string DotNetRoot { get; set; }
+		public string DotNetRoot { get; set; } = "";
 		#endregion
 
 		public override bool Execute ()

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileNativeCode.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileNativeCode.cs
@@ -176,8 +176,8 @@ namespace Xamarin.MacDev.Tasks {
 
 			//If the directory points to a dotnet pack, we want to ensure the full path 
 			//is actually pointing to a sub-folder in the dotnet SDK
-			if (path.Contains (dotnetPacksIdentifier) && !path.StartsWith (DotNetRoot)) {
-				var relativePath = path.Substring (path.IndexOf (packsIdentifier));
+			if (path.IndexOf(dotnetPacksIdentifier, StringComparison.Ordinal) >= 0 && !path.StartsWith (DotNetRoot, StringComparison.Ordinal)) {
+				var relativePath = path.Substring (path.IndexOf (packsIdentifier, StringComparison.Ordinal));
 				//We combine the relative pack dir (starting from "packs") with the dotnet root to get the full path
 				var newPath = Path.Combine (DotNetRoot, relativePath);
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CopyArchiveFiles.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CopyArchiveFiles.cs
@@ -69,8 +69,7 @@ namespace Xamarin.MacDev.Tasks {
 
 		async System.Threading.Tasks.Task CopyArchiveAsync (ISshCommands sshCommands)
 		{
-			var serverHomeDirectory = await sshCommands.GetHomeDirectoryAsync ().ConfigureAwait (continueOnCapturedContext: false);
-			var buildPath = PlatformPath.GetServerBuildPath (serverHomeDirectory, AppName, SessionId, TargetPath);
+			var buildPath = PlatformPath.GetServerBuildPath (AppName, SessionId, TargetPath);
 
 			if (!Directory.Exists (buildPath)) {
 				await sshCommands.CreateDirectoryAsync (buildPath).ConfigureAwait (continueOnCapturedContext: false);

--- a/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />
-    <PackageReference Include="System.Text.Json" Version="4.7.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="Mono.Cecil" Version="$(MonoCecilPackageVersion)" />
     <!-- Compile against Microsoft.Build* NuGet refs, but do not copy to OutputDir if IncludeMSBuildAssets was not set. -->
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" IncludeAssets="$(IncludeMSBuildAssets)" />

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
@@ -28,6 +28,16 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 		DependsOnTargets="_SayHello" 
 		BeforeTargets="_CleanDebugSymbols;_CleanAppBundle;_DetectAppManifest;_DetectSdkLocations;_GenerateBundleName" />
 	
+	<!-- Default context path values for remote builds -->
+	<!-- When building from VS, these values will be passed directly from the IDE -->
+	<Target Name="EnsureMessagingContext" BeforeTargets="_SayHello">
+		<PropertyGroup>
+			<BasePath Condition="'$(BasePath)' == ''">~/Library/Caches/maui/PairToMac</BasePath>
+			<LogsPath Condition="'$(LogsPath)' == ''">~/Library/Logs</LogsPath>
+			<LocalBasePath Condition="'$(LocalBasePath)' == ''">%LOCALAPPDATA%\maui\iOS\PairToMac</LocalBasePath>
+		</PropertyGroup>
+	</Target>
+
 	<PropertyGroup>
 		<CreateAppBundleDependsOn>
 			GetBundleResourceWithLogicalNameItems;

--- a/tests/dotnet/Windows/collect-binlogs.sh
+++ b/tests/dotnet/Windows/collect-binlogs.sh
@@ -25,8 +25,8 @@ fi
 rm -f ~/remote_build_testing/windows-remote-logs.zip
 zip -9r ~/remote_build_testing/windows-remote-logs.zip ~/remote_build_testing/binlogs
 
-if test -d ~/Library/Caches/Xamarin/XMA/Agents/Build; then
-	find ~/Library/Caches/Xamarin/XMA/Agents/Build -type f -print0 | xargs -0 shasum -a 256 > ~/remote_build_testing/Agents_Build_Checksums.txt
+if test -d ~/Library/Caches/maui/PairToMac/Agents/Build; then
+	find ~/Library/Caches/maui/PairToMac/Agents/Build -type f -print0 | xargs -0 shasum -a 256 > ~/remote_build_testing/Agents_Build_Checksums.txt
 	zip -9r ~/remote_build_testing/windows-remote-logs.zip ~/remote_build_testing/Agents_Build_Checksums.txt
 fi
 
@@ -49,6 +49,6 @@ ps auxww > ~/remote_build_testing/processes.txt || true
 # Collect any crash reports.
 zip -9r ~/remote_build_testing/windows-remote-logs.zip ~/Library/Logs/DiagnosticReports || true
 
-ls -la ~/Library/Caches/Xamarin/XMA/SDKs/dotnet/ >> ~/remote_build_testing/dotnet-debug.txt 2>&1 || true
-cat ~/Library/Caches/Xamarin/XMA/SDKs/dotnet/NuGet.config >> ~/remote_build_testing/dotnet-debug.txt 2>&1 || true
-cat ~/Library/Caches/Xamarin/XMA/SDKs/.home/.nuget/NuGet/NuGet.Config >> ~/remote_build_testing/dotnet-debug.txt 2>&1  || true
+ls -la ~/Library/Caches/maui/PairToMac/Sdks/dotnet/ >> ~/remote_build_testing/dotnet-debug.txt 2>&1 || true
+cat ~/Library/Caches/maui/PairToMac/Sdks/dotnet/NuGet.config >> ~/remote_build_testing/dotnet-debug.txt 2>&1 || true
+cat ~/Library/Caches/maui/PairToMac/Sdks/.home/.nuget/NuGet/NuGet.Config >> ~/remote_build_testing/dotnet-debug.txt 2>&1  || true

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ValidateNoStaticLibraresTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ValidateNoStaticLibraresTests.cs
@@ -112,7 +112,7 @@ namespace Xamarin.MacDev.Tasks {
 			var task = CreateTask (skipStaticLibraryValidation, "/does/not/exist");
 			ExecuteTask (task, expectedErrorCount: 1);
 			Assert.AreEqual (0, Engine.Logger.WarningsEvents.Count, "Warning Count");
-			Assert.AreEqual ($"The file '/does/not/exist' does not exist.", Engine.Logger.ErrorEvents [0].Message.TrimEnd (), "Error Message");
+			Assert.AreEqual ($"The file '/does/not/exist' does not exist.", Engine.Logger.ErrorEvents [0].Message?.TrimEnd (), "Error Message");
 		}
 
 		[Test]
@@ -122,7 +122,7 @@ namespace Xamarin.MacDev.Tasks {
 			var task = CreateTask (skipStaticLibraryValidation, "/does/not/exist");
 			ExecuteTask (task, expectedErrorCount: 0);
 			Assert.AreEqual (1, Engine.Logger.WarningsEvents.Count, "Warning Count");
-			Assert.AreEqual ($"The file '/does/not/exist' does not exist.", Engine.Logger.WarningsEvents [0].Message.TrimEnd (), "Error Message");
+			Assert.AreEqual ($"The file '/does/not/exist' does not exist.", Engine.Logger.WarningsEvents [0].Message?.TrimEnd (), "Error Message");
 		}
 	}
 }

--- a/tools/devops/automation/scripts/clean-for-remote-tests.sh
+++ b/tools/devops/automation/scripts/clean-for-remote-tests.sh
@@ -10,6 +10,11 @@ if du -hs ~/Library/Caches/Xamarin; then
 	rm -rf ~/Library/Caches/Xamarin
 fi
 
+# Make sure we don't have any old stuff installed
+if du -hs ~/Library/Caches/maui; then
+	rm -rf ~/Library/Caches/maui
+fi
+
 # Clean up temporary logs
 rm -rf /tmp/com.xamarin.*
 

--- a/tools/devops/automation/scripts/prepare-for-remote-tests.sh
+++ b/tools/devops/automation/scripts/prepare-for-remote-tests.sh
@@ -4,14 +4,14 @@ cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
 
 # Install the local .NET we're using into XMA's directory
 # (we can't point XMA to our local directory)
-mkdir -p ~/Library/Caches/Xamarin/XMA/SDKs
-cp -cRH ./builds/downloads/dotnet ~/Library/Caches/Xamarin/XMA/SDKs
-sed '/local-tests-feed/d' ./NuGet.config > ~/Library/Caches/Xamarin/XMA/SDKs/dotnet/NuGet.config
+mkdir -p ~/Library/Caches/maui/PairToMac/Sdks
+cp -cRH ./builds/downloads/dotnet ~/Library/Caches/maui/PairToMac/Sdks
+sed '/local-tests-feed/d' ./NuGet.config > ~/Library/Caches/maui/PairToMac/Sdks/dotnet/NuGet.config
 
-mkdir -p ~/Library/Caches/Xamarin/XMA/SDKs/.home/.nuget/NuGet/
-cp ~/Library/Caches/Xamarin/XMA/SDKs/dotnet/NuGet.config ~/Library/Caches/Xamarin/XMA/SDKs/.home/.nuget/NuGet/NuGet.Config
+mkdir -p ~/Library/Caches/maui/PairToMac/Sdks/.home/.nuget/NuGet/
+cp ~/Library/Caches/maui/PairToMac/Sdks/dotnet/NuGet.config ~/Library/Caches/maui/PairToMac/Sdks/.home/.nuget/NuGet/NuGet.Config
 
 # some diagnostics
-cat ~/Library/Caches/Xamarin/XMA/SDKs/dotnet/NuGet.config
-cd ~/Library/Caches/Xamarin/XMA/SDKs/dotnet/
+cat ~/Library/Caches/maui/PairToMac/Sdks/dotnet/NuGet.config
+cd ~/Library/Caches/maui/PairToMac/Sdks/dotnet/
 ./dotnet --info || true

--- a/tools/devops/automation/scripts/run-remote-windows-tests.ps1
+++ b/tools/devops/automation/scripts/run-remote-windows-tests.ps1
@@ -9,7 +9,7 @@ if ("$Env:DOTNET" -eq "") {
 $Env:ServerAddress = $Env:MAC_AGENT_IP
 $Env:ServerUser = $Env:MAC_AGENT_USER
 $Env:ServerPassword = $Env:XMA_PASSWORD
-$Env:_DotNetRootRemoteDirectory = "/Users/$Env:MAC_AGENT_USER/Library/Caches/Xamarin/XMA/SDKs/dotnet/"
+$Env:_DotNetRootRemoteDirectory = "/Users/$Env:MAC_AGENT_USER/Library/Caches/maui/PairToMac/Sdks/dotnet/"
 
 & $Env:DOTNET `
     test `


### PR DESCRIPTION
Brings important changes around Xamarin deprecation and Mac paths:

- Updated Xamarin.Messaging to 18.0.136-g9e200fbc6d
- Added target before SayHello to set default Messaging context path values
- Adapted code to Messaging API changes
- IL merge BouncyCastle.Cryptography (new SSH.NET dependency)
- Updated from old Xamarin path to new maui path in test scripts
- Fixed CompileNativeCode to correctly resolve dotnet packs paths

Backport of #22803.