### PR TITLE
[msbuild] Bump some package versions from 17.13.1 to 17.13.9.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
 		<DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
 		<MonoCecilPackageVersion>0.11.5</MonoCecilPackageVersion>
 		<MSBuildStructuredLoggerPackageVersion>2.2.158</MSBuildStructuredLoggerPackageVersion>
-		<MicrosoftBuildPackageVersion>17.13.1</MicrosoftBuildPackageVersion>
+		<MicrosoftBuildPackageVersion>17.13.9</MicrosoftBuildPackageVersion>
 		<MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
 		<MicrosoftBuildTasksCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCorePackageVersion>
 		<MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>


### PR DESCRIPTION
There's apparently no version 17.13.1 of these packages, so use one that exists instead.

Fixes these warnings:

```
tests/msbuild/Xamarin.MacDev.Tasks.Tests/Xamarin.MacDev.Tasks.Tests.csproj : warning NU1603: Xamarin.MacDev.Tasks.Tests depends on Microsoft.Build (>= 17.13.1) but Microsoft.Build 17.13.1 was not found. Microsoft.Build 17.13.9 was resolved instead.
tests/msbuild/Xamarin.MacDev.Tasks.Tests/Xamarin.MacDev.Tasks.Tests.csproj : warning NU1603: Xamarin.MacDev.Tasks.Tests depends on Microsoft.Build.Framework (>= 17.13.1) but Microsoft.Build.Framework 17.13.1 was not found. Microsoft.Build.Framework 17.13.9 was resolved instead.
tests/msbuild/Xamarin.MacDev.Tasks.Tests/Xamarin.MacDev.Tasks.Tests.csproj : warning NU1603: Xamarin.MacDev.Tasks.Tests depends on Microsoft.Build.Tasks.Core (>= 17.13.1) but Microsoft.Build.Tasks.Core 17.13.1 was not found. Microsoft.Build.Tasks.Core 17.13.9 was resolved instead.
tests/msbuild/Xamarin.MacDev.Tasks.Tests/Xamarin.MacDev.Tasks.Tests.csproj : warning NU1603: Xamarin.MacDev.Tasks.Tests depends on Microsoft.Build.Utilities.Core (>= 17.13.1) but Microsoft.Build.Utilities.Core 17.13.1 was not found. Microsoft.Build.Utilities.Core 17.13.9 was resolved instead.
```