### PR TITLE
[RGen] Add support for the use of Callbacks/Trampolines in properties.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Property.cs
@@ -96,6 +96,11 @@ static partial class BindingSyntaxFactory {
 				{ BindAs.Type.FullyQualifiedName: "Foundation.NSString", ReturnType.IsSmartEnum: true} =>
 					SmartEnumGetValue (property.ReturnType, [Argument (objMsgSend)]),
 				
+				// block callback
+				// global::ObjCRuntime.Trampolines.{TrampolineNativeClass}.Create (ret)!;
+				{ ReturnType.IsDelegate: true } 
+					=> TrampolineNativeInvocationClassCreate (property.ReturnType, [Argument (objMsgSend)]), 
+				
 				// string[]? => CFArray.StringArrayFromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (class_ptr, Selector.GetHandle ("selector")), false);
 				{ ReturnType.IsArray: true, ReturnType.Name: "string", ReturnType.IsNullable: true } =>
 					StringArrayFromHandle ([Argument (objMsgSend), BoolArgument (false)]),

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
@@ -1469,7 +1469,7 @@ static partial class BindingSyntaxFactory {
 							EqualsValueClause (invocation.WithLeadingTrivia (Space)).WithLeadingTrivia (Space))));
 		return LocalDeclarationStatement (declaration);
 	}
-	
+
 	/// <summary>
 	/// Generates an expression to create an instance of a native invocation class for a given trampoline type.
 	/// This is used to create a native block from a C# delegate. The generated expression calls the static `Create`
@@ -1485,7 +1485,7 @@ static partial class BindingSyntaxFactory {
 		// get the name of the native class to be used to call the create method
 		var className =
 			Nomenclator.GetTrampolineClassName (trampolineType, Nomenclator.TrampolineClassType.NativeInvocationClass);
-		
+
 		// generate the needed invocation expression for the Create method with the passed arguments
 		var invocation = InvocationExpression (
 				MemberAccessExpression (
@@ -1496,7 +1496,7 @@ static partial class BindingSyntaxFactory {
 						IdentifierName (className)),
 					IdentifierName ("Create").WithTrailingTrivia (Space))).
 			WithArgumentList (argumentList);
-		
+
 		// null ignore
 		return PostfixUnaryExpression (
 			SyntaxKind.SuppressNullableWarningExpression,

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
@@ -1469,5 +1469,37 @@ static partial class BindingSyntaxFactory {
 							EqualsValueClause (invocation.WithLeadingTrivia (Space)).WithLeadingTrivia (Space))));
 		return LocalDeclarationStatement (declaration);
 	}
-
+	
+	/// <summary>
+	/// Generates an expression to create an instance of a native invocation class for a given trampoline type.
+	/// This is used to create a native block from a C# delegate. The generated expression calls the static `Create`
+	/// method on the appropriate `NativeInvocationClass` within the `ObjCRuntime.Trampolines` namespace.
+	/// </summary>
+	/// <param name="trampolineType">The <see cref="TypeInfo"/> of the delegate for which to create the native invocation class.</param>
+	/// <param name="arguments">The arguments to pass to the `Create` method.</param>
+	/// <returns>An <see cref="ExpressionSyntax"/> representing the call to create the native invocation class instance.</returns>
+	internal static ExpressionSyntax TrampolineNativeInvocationClassCreate (in TypeInfo trampolineType, ImmutableArray<ArgumentSyntax> arguments)
+	{
+		var argumentList = ArgumentList (
+			SeparatedList<ArgumentSyntax> (arguments.ToSyntaxNodeOrTokenArray ()));
+		// get the name of the native class to be used to call the create method
+		var className =
+			Nomenclator.GetTrampolineClassName (trampolineType, Nomenclator.TrampolineClassType.NativeInvocationClass);
+		
+		// generate the needed invocation expression for the Create method with the passed arguments
+		var invocation = InvocationExpression (
+				MemberAccessExpression (
+					SyntaxKind.SimpleMemberAccessExpression,
+					MemberAccessExpression (
+						SyntaxKind.SimpleMemberAccessExpression,
+						Trampolines,
+						IdentifierName (className)),
+					IdentifierName ("Create").WithTrailingTrivia (Space))).
+			WithArgumentList (argumentList);
+		
+		// null ignore
+		return PostfixUnaryExpression (
+			SyntaxKind.SuppressNullableWarningExpression,
+			invocation);
+	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
@@ -173,6 +173,10 @@ return {backingField};
 			using (var propertyBlock = classBlock.CreateBlock (property.ToDeclaration ().ToString (), block: true)) {
 				// be very verbose with the availability, makes the life easier to the dotnet analyzer
 				propertyBlock.AppendMemberAvailability (getter.Value.SymbolAvailability);
+				// if we deal with a delegate, include the attr:
+				// [return: DelegateProxy (typeof ({staticBridge}))]
+				if (property.ReturnType.IsDelegate)
+					propertyBlock.AppendDelegateProxyReturn (property.ReturnType);
 				using (var getterBlock = propertyBlock.CreateBlock ("get", block: true)) {
 					if (uiThreadCheck is not null) {
 						getterBlock.WriteLine (uiThreadCheck.ToString ());
@@ -200,6 +204,10 @@ return {tempVar};
 
 				propertyBlock.WriteLine (); // add space between getter and setter since we have the attrs
 				propertyBlock.AppendMemberAvailability (setter.Value.SymbolAvailability);
+				// if we deal with a delegate, include the attr:
+				// [param: BlockProxy (typeof ({nativeInvoker}))]
+				if (property.ReturnType.IsDelegate)
+					propertyBlock.AppendDelegateParameter (property.ReturnType);
 				using (var setterBlock = propertyBlock.CreateBlock ("set", block: true)) {
 					if (uiThreadCheck is not null) {
 						setterBlock.WriteLine (uiThreadCheck.ToString ());

--- a/src/rgen/Microsoft.Macios.Generator/IO/TabbedStringBuilderExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/IO/TabbedStringBuilderExtensions.cs
@@ -3,6 +3,8 @@
 
 using System.ComponentModel;
 using System.IO;
+using Microsoft.Macios.Generator.DataModel;
+using static Microsoft.Macios.Generator.Emitters.BindingSyntaxFactory;
 
 namespace Microsoft.Macios.Generator.IO;
 
@@ -79,6 +81,40 @@ static class TabbedStringBuilderExtensions {
 		self.WriteLine ();
 		self.WriteLine ("#nullable enable");
 		self.WriteLine ();
+		return self;
+	}
+	
+	/// <summary>
+	/// Appends a `[return: DelegateProxy]` attribute to the current writer.
+	/// This attribute is used for properties that return a delegate, and it points to the static bridge class
+	/// generated for the specified delegate type.
+	/// </summary>
+	/// <param name="self">A tabbed string writer.</param>
+	/// <param name="typeInfo">The <see cref="TypeInfo"/> of the delegate.</param>
+	/// <returns>The current writer.</returns>
+	public static TabbedWriter<StringWriter> AppendDelegateProxyReturn (this TabbedWriter<StringWriter> self,
+		in TypeInfo typeInfo)
+	{
+		var staticBridge =
+			Nomenclator.GetTrampolineClassName (typeInfo, Nomenclator.TrampolineClassType.StaticBridgeClass);
+		self.WriteLine ($"[return: DelegateProxy (typeof ({Trampolines}.{staticBridge}))]");
+		return self;
+	}
+
+	/// <summary>
+	/// Appends a `[param: BlockProxy]` attribute to the current writer.
+	/// This attribute is used for parameters that are delegates (blocks), and it points to the native invocation class
+	/// generated for the specified delegate type.
+	/// </summary>
+	/// <param name="self">A tabbed string writer.</param>
+	/// <param name="typeInfo">The <see cref="TypeInfo"/> of the delegate.</param>
+	/// <returns>The current writer.</returns>
+	public static TabbedWriter<StringWriter> AppendDelegateParameter (this TabbedWriter<StringWriter> self, 
+		in TypeInfo typeInfo)
+	{
+		var nativeInvoker =
+			Nomenclator.GetTrampolineClassName (typeInfo, Nomenclator.TrampolineClassType.NativeInvocationClass);
+		self.WriteLine ($"[param: BlockProxy (typeof ({Trampolines}.{nativeInvoker}))]");
 		return self;
 	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/IO/TabbedStringBuilderExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/IO/TabbedStringBuilderExtensions.cs
@@ -83,7 +83,7 @@ static class TabbedStringBuilderExtensions {
 		self.WriteLine ();
 		return self;
 	}
-	
+
 	/// <summary>
 	/// Appends a `[return: DelegateProxy]` attribute to the current writer.
 	/// This attribute is used for properties that return a delegate, and it points to the static bridge class
@@ -109,7 +109,7 @@ static class TabbedStringBuilderExtensions {
 	/// <param name="self">A tabbed string writer.</param>
 	/// <param name="typeInfo">The <see cref="TypeInfo"/> of the delegate.</param>
 	/// <returns>The current writer.</returns>
-	public static TabbedWriter<StringWriter> AppendDelegateParameter (this TabbedWriter<StringWriter> self, 
+	public static TabbedWriter<StringWriter> AppendDelegateParameter (this TabbedWriter<StringWriter> self,
 		in TypeInfo typeInfo)
 	{
 		var nativeInvoker =

--- a/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
@@ -111,7 +111,7 @@ static class Nomenclator {
 			_ => throw new ArgumentOutOfRangeException (nameof (trampolineClassType), trampolineClassType, null)
 		};
 	}
-	
+
 	/// <summary>
 	/// Return the name of the trampoline class to be used for the given type info.
 	/// This is a convenience overload for <see cref="GetTrampolineClassName(string, TrampolineClassType)"/>.

--- a/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
@@ -111,6 +111,16 @@ static class Nomenclator {
 			_ => throw new ArgumentOutOfRangeException (nameof (trampolineClassType), trampolineClassType, null)
 		};
 	}
+	
+	/// <summary>
+	/// Return the name of the trampoline class to be used for the given type info.
+	/// This is a convenience overload for <see cref="GetTrampolineClassName(string, TrampolineClassType)"/>.
+	/// </summary>
+	/// <param name="typeInfo">The type info for which to get the trampoline class name.</param>
+	/// <param name="trampolineClassType">The type of class to be generated.</param>
+	/// <returns>The name to be used by the generated class.</returns>
+	public static string GetTrampolineClassName (in TypeInfo typeInfo, TrampolineClassType trampolineClassType)
+		=> GetTrampolineClassName (GetTrampolineName (typeInfo), trampolineClassType);
 
 	/// <summary>
 	/// Returns the name of the aux variable that would have needed for the given parameter. Use the

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedTrampolinePropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedTrampolinePropertyTests.cs
@@ -191,18 +191,20 @@ public partial class TrampolinePropertyTests
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	public partial global::System.Action<bool> BoolActionHandler
 	{
+		[return: DelegateProxy (typeof (global::ObjCRuntime.Trampolines.SDActionArity1bool))]
 		get
 		{
 			global::System.Action<bool> ret;
 			if (IsDirectBinding) {
-				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("boolActionHandler"));
+				ret = global::ObjCRuntime.Trampolines.NIDActionArity1bool.Create (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("boolActionHandler")))!;
 			} else {
-				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("boolActionHandler"));
+				ret = global::ObjCRuntime.Trampolines.NIDActionArity1bool.Create (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("boolActionHandler")))!;
 			}
 			global::System.GC.KeepAlive (this);
 			return ret;
 		}
 
+		[param: BlockProxy (typeof (global::ObjCRuntime.Trampolines.NIDActionArity1bool))]
 		set
 		{
 			throw new NotImplementedException();
@@ -212,18 +214,20 @@ public partial class TrampolinePropertyTests
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	public partial global::System.Action CompletionHandler
 	{
+		[return: DelegateProxy (typeof (global::ObjCRuntime.Trampolines.SDAction))]
 		get
 		{
 			global::System.Action ret;
 			if (IsDirectBinding) {
-				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completionHandler"));
+				ret = global::ObjCRuntime.Trampolines.NIDAction.Create (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completionHandler")))!;
 			} else {
-				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completionHandler"));
+				ret = global::ObjCRuntime.Trampolines.NIDAction.Create (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completionHandler")))!;
 			}
 			global::System.GC.KeepAlive (this);
 			return ret;
 		}
 
+		[param: BlockProxy (typeof (global::ObjCRuntime.Trampolines.NIDAction))]
 		set
 		{
 			throw new NotImplementedException();
@@ -233,18 +237,20 @@ public partial class TrampolinePropertyTests
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	public partial global::Microsoft.Macios.Generator.Tests.Classes.Data.TestNamespace.TrampolinePropertyTests.CreateObject CreateObjectHandler
 	{
+		[return: DelegateProxy (typeof (global::ObjCRuntime.Trampolines.SDTrampolinePropertyTests_CreateObject))]
 		get
 		{
 			global::Microsoft.Macios.Generator.Tests.Classes.Data.TestNamespace.TrampolinePropertyTests.CreateObject ret;
 			if (IsDirectBinding) {
-				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("createObjectHandler"));
+				ret = global::ObjCRuntime.Trampolines.NIDTrampolinePropertyTests_CreateObject.Create (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("createObjectHandler")))!;
 			} else {
-				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("createObjectHandler"));
+				ret = global::ObjCRuntime.Trampolines.NIDTrampolinePropertyTests_CreateObject.Create (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("createObjectHandler")))!;
 			}
 			global::System.GC.KeepAlive (this);
 			return ret;
 		}
 
+		[param: BlockProxy (typeof (global::ObjCRuntime.Trampolines.NIDTrampolinePropertyTests_CreateObject))]
 		set
 		{
 			throw new NotImplementedException();
@@ -254,18 +260,20 @@ public partial class TrampolinePropertyTests
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	public partial global::System.Action DuplicateCompletionHandler
 	{
+		[return: DelegateProxy (typeof (global::ObjCRuntime.Trampolines.SDAction))]
 		get
 		{
 			global::System.Action ret;
 			if (IsDirectBinding) {
-				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("duplicateCompletionHandler"));
+				ret = global::ObjCRuntime.Trampolines.NIDAction.Create (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("duplicateCompletionHandler")))!;
 			} else {
-				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("duplicateCompletionHandler"));
+				ret = global::ObjCRuntime.Trampolines.NIDAction.Create (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("duplicateCompletionHandler")))!;
 			}
 			global::System.GC.KeepAlive (this);
 			return ret;
 		}
 
+		[param: BlockProxy (typeof (global::ObjCRuntime.Trampolines.NIDAction))]
 		set
 		{
 			throw new NotImplementedException();
@@ -296,18 +304,20 @@ public partial class TrampolinePropertyTests
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	public partial global::AVFoundation.AVAssetImageGenerateAsynchronouslyForTimeCompletionHandler ImageGeneratorCompletionHandler
 	{
+		[return: DelegateProxy (typeof (global::ObjCRuntime.Trampolines.SDAVAssetImageGenerateAsynchronouslyForTimeCompletionHandler))]
 		get
 		{
 			global::AVFoundation.AVAssetImageGenerateAsynchronouslyForTimeCompletionHandler ret;
 			if (IsDirectBinding) {
-				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("imageGeneratorCompletionHandler"));
+				ret = global::ObjCRuntime.Trampolines.NIDAVAssetImageGenerateAsynchronouslyForTimeCompletionHandler.Create (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("imageGeneratorCompletionHandler")))!;
 			} else {
-				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("imageGeneratorCompletionHandler"));
+				ret = global::ObjCRuntime.Trampolines.NIDAVAssetImageGenerateAsynchronouslyForTimeCompletionHandler.Create (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("imageGeneratorCompletionHandler")))!;
 			}
 			global::System.GC.KeepAlive (this);
 			return ret;
 		}
 
+		[param: BlockProxy (typeof (global::ObjCRuntime.Trampolines.NIDAVAssetImageGenerateAsynchronouslyForTimeCompletionHandler))]
 		set
 		{
 			throw new NotImplementedException();
@@ -317,18 +327,20 @@ public partial class TrampolinePropertyTests
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	public partial global::System.Action<int> IntActionHandler
 	{
+		[return: DelegateProxy (typeof (global::ObjCRuntime.Trampolines.SDActionArity1int))]
 		get
 		{
 			global::System.Action<int> ret;
 			if (IsDirectBinding) {
-				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("intActionHandler"));
+				ret = global::ObjCRuntime.Trampolines.NIDActionArity1int.Create (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("intActionHandler")))!;
 			} else {
-				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("intActionHandler"));
+				ret = global::ObjCRuntime.Trampolines.NIDActionArity1int.Create (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("intActionHandler")))!;
 			}
 			global::System.GC.KeepAlive (this);
 			return ret;
 		}
 
+		[param: BlockProxy (typeof (global::ObjCRuntime.Trampolines.NIDActionArity1int))]
 		set
 		{
 			throw new NotImplementedException();
@@ -338,18 +350,20 @@ public partial class TrampolinePropertyTests
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	public partial global::AudioUnit.AUInternalRenderBlock InternalRenderBlockHandler
 	{
+		[return: DelegateProxy (typeof (global::ObjCRuntime.Trampolines.SDAUInternalRenderBlock))]
 		get
 		{
 			global::AudioUnit.AUInternalRenderBlock ret;
 			if (IsDirectBinding) {
-				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("internalRenderBlockHandler"));
+				ret = global::ObjCRuntime.Trampolines.NIDAUInternalRenderBlock.Create (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("internalRenderBlockHandler")))!;
 			} else {
-				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("internalRenderBlockHandler"));
+				ret = global::ObjCRuntime.Trampolines.NIDAUInternalRenderBlock.Create (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("internalRenderBlockHandler")))!;
 			}
 			global::System.GC.KeepAlive (this);
 			return ret;
 		}
 
+		[param: BlockProxy (typeof (global::ObjCRuntime.Trampolines.NIDAUInternalRenderBlock))]
 		set
 		{
 			throw new NotImplementedException();
@@ -359,18 +373,20 @@ public partial class TrampolinePropertyTests
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	public partial global::CoreImage.CIKernelRoiCallback KernelRoiCallback
 	{
+		[return: DelegateProxy (typeof (global::ObjCRuntime.Trampolines.SDCIKernelRoiCallback))]
 		get
 		{
 			global::CoreImage.CIKernelRoiCallback ret;
 			if (IsDirectBinding) {
-				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("kernelRoiCallback"));
+				ret = global::ObjCRuntime.Trampolines.NIDCIKernelRoiCallback.Create (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("kernelRoiCallback")))!;
 			} else {
-				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("kernelRoiCallback"));
+				ret = global::ObjCRuntime.Trampolines.NIDCIKernelRoiCallback.Create (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("kernelRoiCallback")))!;
 			}
 			global::System.GC.KeepAlive (this);
 			return ret;
 		}
 
+		[param: BlockProxy (typeof (global::ObjCRuntime.Trampolines.NIDCIKernelRoiCallback))]
 		set
 		{
 			throw new NotImplementedException();
@@ -380,18 +396,20 @@ public partial class TrampolinePropertyTests
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	public partial global::CoreImage.CIKernelRoiCallback KernelRoiCallback
 	{
+		[return: DelegateProxy (typeof (global::ObjCRuntime.Trampolines.SDCIKernelRoiCallback))]
 		get
 		{
 			global::CoreImage.CIKernelRoiCallback ret;
 			if (IsDirectBinding) {
-				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("kernelRoiCallback"));
+				ret = global::ObjCRuntime.Trampolines.NIDCIKernelRoiCallback.Create (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("kernelRoiCallback")))!;
 			} else {
-				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("kernelRoiCallback"));
+				ret = global::ObjCRuntime.Trampolines.NIDCIKernelRoiCallback.Create (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("kernelRoiCallback")))!;
 			}
 			global::System.GC.KeepAlive (this);
 			return ret;
 		}
 
+		[param: BlockProxy (typeof (global::ObjCRuntime.Trampolines.NIDCIKernelRoiCallback))]
 		set
 		{
 			throw new NotImplementedException();
@@ -401,18 +419,20 @@ public partial class TrampolinePropertyTests
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	public partial global::AVFoundation.AVAudioEngineManualRenderingBlock ManualRendering
 	{
+		[return: DelegateProxy (typeof (global::ObjCRuntime.Trampolines.SDAVAudioEngineManualRenderingBlock))]
 		get
 		{
 			global::AVFoundation.AVAudioEngineManualRenderingBlock ret;
 			if (IsDirectBinding) {
-				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("manualRenderingCallback"));
+				ret = global::ObjCRuntime.Trampolines.NIDAVAudioEngineManualRenderingBlock.Create (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("manualRenderingCallback")))!;
 			} else {
-				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("manualRenderingCallback"));
+				ret = global::ObjCRuntime.Trampolines.NIDAVAudioEngineManualRenderingBlock.Create (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("manualRenderingCallback")))!;
 			}
 			global::System.GC.KeepAlive (this);
 			return ret;
 		}
 
+		[param: BlockProxy (typeof (global::ObjCRuntime.Trampolines.NIDAVAudioEngineManualRenderingBlock))]
 		set
 		{
 			throw new NotImplementedException();
@@ -422,18 +442,20 @@ public partial class TrampolinePropertyTests
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	public partial global::System.Action<string> StringActionHandler
 	{
+		[return: DelegateProxy (typeof (global::ObjCRuntime.Trampolines.SDActionArity1string))]
 		get
 		{
 			global::System.Action<string> ret;
 			if (IsDirectBinding) {
-				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("stringActionHandler"));
+				ret = global::ObjCRuntime.Trampolines.NIDActionArity1string.Create (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("stringActionHandler")))!;
 			} else {
-				ret = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("stringActionHandler"));
+				ret = global::ObjCRuntime.Trampolines.NIDActionArity1string.Create (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("stringActionHandler")))!;
 			}
 			global::System.GC.KeepAlive (this);
 			return ret;
 		}
 
+		[param: BlockProxy (typeof (global::ObjCRuntime.Trampolines.NIDActionArity1string))]
 		set
 		{
 			throw new NotImplementedException();

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -5528,5 +5528,114 @@ namespace NS {
 		var x = invocation.ToFullString ();
 		Assert.Equal (expectedExpression, invocation.ToFullString ());
 	}
+	
+	class TestDataTrampolioneNativeNativeInvocationClassCreate : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			var refParameter = @"
+using System;
+
+namespace NS {
+	public delegate int Callback (ref int pointerParameter);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				refParameter,
+				ImmutableArray.Create(
+					Argument (IdentifierName ("arg1")),
+					Argument (IdentifierName ("arg2"))
+				),
+				$"{Global ("ObjCRuntime.Trampolines")}.NIDCallback.Create (arg1, arg2)!",
+			];
+
+			var refEnumParameter = @"
+using System;
+using AVFoundation;
+
+namespace NS {
+	public class MyClass {
+		public void MyMethod (AVAudioConverterInputHandler cb) {}
+	}
+}
+";
+
+			yield return [
+				refEnumParameter,
+				ImmutableArray.Create(
+					Argument (IdentifierName ("arg1")),
+					Argument (IdentifierName ("arg2"))
+				),
+				$"{Global ("ObjCRuntime.Trampolines")}.NIDAVAudioConverterInputHandler.Create (arg1, arg2)!",
+			];
+
+			var boolReferenceParameter = @"
+using System;
+using AVFoundation;
+
+namespace NS {
+	public class MyClass {
+		public void MyMethod (AVAudioUnitComponentFilter cb) {}
+	}
+}
+";
+
+			yield return [
+				boolReferenceParameter,
+				ImmutableArray.Create(
+					Argument (IdentifierName ("arg1")),
+					Argument (IdentifierName ("arg2"))
+				),
+				$"{Global ("ObjCRuntime.Trampolines")}.NIDAVAudioUnitComponentFilter.Create (arg1, arg2)!",
+			];
+
+			var doubleReferenceParameter = @"
+using System;
+using AVFoundation;
+
+namespace NS {
+	public class MyClass {
+		public void MyMethod (AVMusicEventEnumerationBlock cb) {}
+	}
+}
+";
+
+			yield return [
+				doubleReferenceParameter,
+				ImmutableArray.Create(
+					Argument (IdentifierName ("arg1")),
+					Argument (IdentifierName ("arg2"))
+				),
+				$"{Global ("ObjCRuntime.Trampolines")}.NIDAVMusicEventEnumerationBlock.Create (arg1, arg2)!",
+			];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataTrampolioneNativeNativeInvocationClassCreate>]
+	void TrampolioneNativeNativeInvocationClassCreateTests (ApplePlatform platform, string inputText, ImmutableArray<ArgumentSyntax> argumnets, string expectedExpression)
+	{
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
+		Assert.Single (syntaxTrees);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ().OfType<MethodDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		Assert.True (Method.TryCreate (declaration, semanticModel, out var changes));
+		Assert.NotNull (changes);
+		// we know the first parameter of the method is the delegate
+		Assert.Single (changes.Value.Parameters);
+		var parameter = changes.Value.Parameters [0];
+		// assert it is indeed a delegate
+		Assert.NotNull (parameter.Type.Delegate);
+		var invocation = TrampolineNativeInvocationClassCreate (parameter.Type, argumnets);
+		var x = invocation.ToFullString ();
+		Assert.Equal (expectedExpression, invocation.ToFullString ());
+	}
 
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -5528,7 +5528,7 @@ namespace NS {
 		var x = invocation.ToFullString ();
 		Assert.Equal (expectedExpression, invocation.ToFullString ());
 	}
-	
+
 	class TestDataTrampolioneNativeNativeInvocationClassCreate : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -5544,7 +5544,7 @@ namespace NS {
 ";
 			yield return [
 				refParameter,
-				ImmutableArray.Create(
+				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1")),
 					Argument (IdentifierName ("arg2"))
 				),
@@ -5564,7 +5564,7 @@ namespace NS {
 
 			yield return [
 				refEnumParameter,
-				ImmutableArray.Create(
+				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1")),
 					Argument (IdentifierName ("arg2"))
 				),
@@ -5584,7 +5584,7 @@ namespace NS {
 
 			yield return [
 				boolReferenceParameter,
-				ImmutableArray.Create(
+				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1")),
 					Argument (IdentifierName ("arg2"))
 				),
@@ -5604,7 +5604,7 @@ namespace NS {
 
 			yield return [
 				doubleReferenceParameter,
-				ImmutableArray.Create(
+				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1")),
 					Argument (IdentifierName ("arg2"))
 				),
@@ -5614,7 +5614,7 @@ namespace NS {
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
-	
+
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataTrampolioneNativeNativeInvocationClassCreate>]
 	void TrampolioneNativeNativeInvocationClassCreateTests (ApplePlatform platform, string inputText, ImmutableArray<ArgumentSyntax> argumnets, string expectedExpression)


### PR DESCRIPTION
Complete the property getter implementation by:

1. Including the return and the param attributes.
2. Convert the return type to the correct delegate.

This was done after completing the Trampolines.g.cs so that we could reuse a number of methods needed to generate that file. This should mean that we finally completed all possible properyt getters.