### PR TITLE
[RGen] Unifier the code that convers a native type to a managed one.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Arguments.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Arguments.cs
@@ -250,7 +250,7 @@ static partial class BindingSyntaxFactory {
 			
 			// native enum, return the conversion expression to the native type
 			{ Type.IsNativeEnum: true} 
-				=> CastNativeToEnum (argumentInfo.Name, argumentInfo.Type)!,
+				=> CastNativeToEnum (IdentifierName (argumentInfo.Name), argumentInfo.Type)!,
 			
 			// boolean, convert it to byte
 			{ Type.SpecialType: SpecialType.System_Boolean } 

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Property.cs
@@ -58,8 +58,8 @@ static partial class BindingSyntaxFactory {
 			return (ThrowNotImplementedException (), ThrowNotImplementedException ());
 		}
 
-		var getterSend = GetterInvocation (MessagingInvocation (sendMethod, selector, []), property);
-		var getterSuperSend = GetterInvocation (MessagingInvocation (superSendMethod, selector, []), property);
+		var getterSend = ConvertToManaged (property, MessagingInvocation (sendMethod, selector, []));
+		var getterSuperSend = ConvertToManaged (property, MessagingInvocation (superSendMethod, selector, []));
 		// if we cannot get the methods, throw a runtime exception 
 		if (getterSend is null || getterSuperSend is null) {
 			return (ThrowNotImplementedException (), ThrowNotImplementedException ());
@@ -70,71 +70,6 @@ static partial class BindingSyntaxFactory {
 			Send: AssignVariable (Nomenclator.GetReturnVariableName (), getterSend),
 			SendSuper: AssignVariable (Nomenclator.GetReturnVariableName (), getterSuperSend)
 		);
-
-#pragma warning disable format
-		// helper internal function that returns the expression based on the property return type and uses the passed
-		// message send expression
-		ExpressionSyntax? GetterInvocation (InvocationExpressionSyntax objMsgSend, in Property property)
-			=> property switch {
-				// bind from NSNumber: NSNumber.ToInt32 (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (class_ptr, Selector.GetHandle ("selector"));
-				{ BindAs.Type.FullyQualifiedName: "Foundation.NSNumber", ReturnType.IsArray: false } => 
-					NSNumberFromHandle (property.ReturnType, [Argument (objMsgSend)]),
-				
-				// bind from NSNumber array: NSArray.ArrayFromHandleFunc <int> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (class_ptr, Selector.GetHandle ("selector"), NSNumber.ToInt32, false))
-				{ BindAs.Type.FullyQualifiedName: "Foundation.NSNumber", ReturnType.IsArray: true } => 
-					NSArrayFromHandleFunc (property.ReturnType.ToArrayElementType ().GetIdentifierSyntax (), [Argument (objMsgSend), Argument(NSNumberFromHandle (property.ReturnType)!), BoolArgument (false)]),
-				
-				// bind from NSValue: NSValue.ToCGPoint (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, Selector.GetHandle (\"myProperty\")))
-				{ BindAs.Type.FullyQualifiedName: "Foundation.NSValue", ReturnType.IsArray: false } => 
-					NSValueFromHandle (property.ReturnType, [Argument (objMsgSend)]),
-				
-				// bind from NSValue array: NSArray.ArrayFromHandleFunc<CoreGraphics.CGPoint> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, Selector.GetHandle (\"myProperty\")), NSValue.ToCGPoint, false)
-				{ BindAs.Type.FullyQualifiedName: "Foundation.NSValue", ReturnType.IsArray: true } => 
-					NSArrayFromHandleFunc (property.ReturnType.ToArrayElementType ().GetIdentifierSyntax (), [Argument (objMsgSend), Argument(NSValueFromHandle (property.ReturnType)!), BoolArgument (false)]),
-
-				// bind from NSString to a SmartEnum: "global::AVFoundation.AVCaptureSystemPressureLevelExtensions.GetNullableValue (arg1)
-				{ BindAs.Type.FullyQualifiedName: "Foundation.NSString", ReturnType.IsSmartEnum: true} =>
-					SmartEnumGetValue (property.ReturnType, [Argument (objMsgSend)]),
-				
-				// block callback
-				// global::ObjCRuntime.Trampolines.{TrampolineNativeClass}.Create (ret)!;
-				{ ReturnType.IsDelegate: true } 
-					=> TrampolineNativeInvocationClassCreate (property.ReturnType, [Argument (objMsgSend)]), 
-				
-				// string[]? => CFArray.StringArrayFromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (class_ptr, Selector.GetHandle ("selector")), false);
-				{ ReturnType.IsArray: true, ReturnType.Name: "string", ReturnType.IsNullable: true } =>
-					StringArrayFromHandle ([Argument (objMsgSend), BoolArgument (false)]),
-
-				// string[] => CFArray.StringArrayFromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (class_ptr, Selector.GetHandle ("selector")), false)!;
-				{ ReturnType.IsArray: true, ReturnType.Name: "string", ReturnType.IsNullable: false } =>
-					SuppressNullableWarning (StringArrayFromHandle ([Argument (objMsgSend), BoolArgument (false)])),
-				
-				// NSObject[] => CFArray.ArrayFromHandle<Foundation.NSMetadataItem> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, Selector.GetHandle ("results")))!;
-				{ ReturnType.IsArray: true, ReturnType.ArrayElementTypeIsWrapped: true } => 
-					GetCFArrayFromHandle (property.ReturnType.ToArrayElementType ().GetIdentifierSyntax (), [Argument (objMsgSend)], suppressNullableWarning: !property.ReturnType.IsNullable),
-				
-				// Runtime.GetNSObject<Foundation.NSObject> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, Selector.GetHandle ("delegate")));
-				{ ReturnType.IsArray: false, ReturnType.IsNSObject: true, ReturnType.IsNullable: true} => 
-					GetNSObject (property.ReturnType.ToNonNullable ().GetIdentifierSyntax (), [Argument (objMsgSend)], suppressNullableWarning: false),
-				
-				{ ReturnType.IsArray: false, ReturnType.IsNSObject: true, ReturnType.IsNullable: false} => 
-					GetNSObject (property.ReturnType.GetIdentifierSyntax (), [Argument (objMsgSend)], suppressNullableWarning: true),
-
-				// string => CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, Selector.GetHandle ("tunnelRemoteAddress")), false);
-				{ ReturnType.SpecialType: SpecialType.System_String, ReturnType.IsNullable: true } =>
-					StringFromHandle ([Argument (objMsgSend), BoolArgument (false)]),
-
-				// string => CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, Selector.GetHandle ("tunnelRemoteAddress")), false)!;
-				{ ReturnType.SpecialType: SpecialType.System_String, ReturnType.IsNullable: false } =>
-					SuppressNullableWarning (StringFromHandle ([Argument (objMsgSend), BoolArgument (false)])),
-
-				// bool => global::ObjCRuntime.Messaging.bool_objc_msgSend (this.Handle, Selector.GetHandle ("canDraw")) != 0;
-				{ ReturnType.SpecialType: SpecialType.System_Boolean } => ByteToBool (objMsgSend),
-				
-				// general case, just return the result of the send message
-				_ => objMsgSend,
-			}; 
-#pragma warning restore format
 	}
 
 	internal static PropertyInvocations GetInvocations (in Property property)

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ReturnInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ReturnInfo.cs
@@ -18,11 +18,11 @@ readonly record struct ReturnInfo {
 	/// The [BindAs] attribute data, if any.
 	/// </summary>
 	public BindFromData? BindAs { get; init; }
-	
+
 	/// <summary>
 	/// True if the returned handle should be released after use.
 	/// </summary>
-	public bool? ReleaseHandle {get; init; } = null;
+	public bool? ReleaseHandle { get; init; } = null;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="ReturnInfo"/> struct from a <see cref="Property"/>.
@@ -44,14 +44,14 @@ readonly record struct ReturnInfo {
 		BindAs = null;
 		ReleaseHandle = false;
 	}
-	
+
 	/// <summary>
 	/// Implicitly converts a <see cref="Property"/> to a <see cref="ReturnInfo"/>.
 	/// </summary>
 	/// <param name="property">The property to convert.</param>
 	public static implicit operator ReturnInfo (in Property property)
 		=> new (property);
-	
+
 	/// <summary>
 	/// Implicitly converts a <see cref="DelegateInfo"/> to a <see cref="ReturnInfo"/>.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ReturnInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ReturnInfo.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Macios.Generator.Attributes;
+using Microsoft.Macios.Generator.DataModel;
+
+namespace Microsoft.Macios.Generator.Emitters;
+
+/// <summary>
+/// Represents information about a return value from a native invocation.
+/// </summary>
+readonly record struct ReturnInfo {
+	/// <summary>
+	/// The type information of the return value.
+	/// </summary>
+	public TypeInfo Type { get; init; }
+	/// <summary>
+	/// The [BindAs] attribute data, if any.
+	/// </summary>
+	public BindFromData? BindAs { get; init; }
+	
+	/// <summary>
+	/// True if the returned handle should be released after use.
+	/// </summary>
+	public bool? ReleaseHandle {get; init; } = null;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ReturnInfo"/> struct from a <see cref="Property"/>.
+	/// </summary>
+	/// <param name="property">The property to create the return info from.</param>
+	public ReturnInfo (in Property property)
+	{
+		Type = property.ReturnType;
+		BindAs = property.BindAs;
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ReturnInfo"/> struct from a <see cref="DelegateInfo"/>.
+	/// </summary>
+	/// <param name="delegateInfo">The delegate info to create the return info from.</param>
+	public ReturnInfo (in DelegateInfo delegateInfo)
+	{
+		Type = delegateInfo.ReturnType;
+		BindAs = null;
+		ReleaseHandle = false;
+	}
+	
+	/// <summary>
+	/// Implicitly converts a <see cref="Property"/> to a <see cref="ReturnInfo"/>.
+	/// </summary>
+	/// <param name="property">The property to convert.</param>
+	public static implicit operator ReturnInfo (in Property property)
+		=> new (property);
+	
+	/// <summary>
+	/// Implicitly converts a <see cref="DelegateInfo"/> to a <see cref="ReturnInfo"/>.
+	/// </summary>
+	/// <param name="delegateInfo">The delegate info to convert.</param>
+	public static implicit operator ReturnInfo (in DelegateInfo delegateInfo)
+		=> new (delegateInfo);
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
@@ -195,9 +195,9 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 
 	[Theory]
 	[ClassData (typeof (TestDataByteToBoolTests))]
-	void ByteToBoolTests (InvocationExpressionSyntax invocationExpressionSyntax, string expectedDeclaration)
+	void CastToBoolTests (InvocationExpressionSyntax invocationExpressionSyntax, string expectedDeclaration)
 	{
-		var declaration = ByteToBool (invocationExpressionSyntax);
+		var declaration = CastToBool (invocationExpressionSyntax);
 		Assert.Equal (expectedDeclaration, declaration.ToString ());
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryPropertyTests.cs
@@ -72,7 +72,7 @@ public class BindingSyntaxFactoryPropertyTests {
 
 			property = new Property (
 				name: "MyProperty",
-				returnType: ReturnTypeForArray ("string"),
+				returnType: ReturnTypeForArray ("string", underlyingType: SpecialType.System_String),
 				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [],
@@ -97,7 +97,7 @@ public class BindingSyntaxFactoryPropertyTests {
 
 			property = new Property (
 				name: "MyProperty",
-				returnType: ReturnTypeForArray ("string", isNullable: true),
+				returnType: ReturnTypeForArray ("string", isNullable: true, underlyingType: SpecialType.System_String),
 				symbolAvailability: new (),
 				attributes: [],
 				modifiers: [],

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -589,7 +589,7 @@ namespace NS {
 
 			yield return [
 				systemStringResult,
-				$"{Global ("CoreFoundation.CFString")}.FromHandle (auxVariable)!"
+				$"{Global ("CoreFoundation.CFString")}.FromHandle (auxVariable, false)!"
 			];
 
 			const string nullableSystemStringResult = @"
@@ -606,7 +606,7 @@ namespace NS {
 
 			yield return [
 				nullableSystemStringResult,
-				$"{Global ("CoreFoundation.CFString")}.FromHandle (auxVariable)"
+				$"{Global ("CoreFoundation.CFString")}.FromHandle (auxVariable, false)"
 			];
 
 			const string boolReturnType = @"


### PR DESCRIPTION
The code is the same for properties, trampolines and methods. We add a intermediate readonly struct to customize the conversion and that way we can share the logic.