### PR TITLE
[Rgen] Fix an error from PR #23115

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ArgumentInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ArgumentInfo.cs
@@ -33,6 +33,11 @@ readonly record struct ArgumentInfo {
 	public bool IsByRef { get; init; }
 
 	/// <summary>
+	/// The reference kind of the argument.
+	/// </summary>
+	public ReferenceKind ReferenceKind { get; init; } = ReferenceKind.None;
+
+	/// <summary>
 	/// True if the argument is a C-style function pointer callback.
 	/// </summary>
 	public bool IsCCallback { get; init; }
@@ -52,6 +57,7 @@ readonly record struct ArgumentInfo {
 		Type = parameter.Type;
 		BindAs = parameter.BindAs;
 		IsByRef = parameter.IsByRef;
+		ReferenceKind = parameter.ReferenceKind;
 		IsCCallback = false;
 		IsBlockCallback = false;
 	}
@@ -66,6 +72,7 @@ readonly record struct ArgumentInfo {
 		Type = parameter.Type;
 		BindAs = parameter.BindAs;
 		IsByRef = parameter.IsByRef;
+		ReferenceKind = parameter.ReferenceKind;
 		IsCCallback = parameter.IsCCallback;
 		IsBlockCallback = parameter.IsBlockCallback;
 	}

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Arguments.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Arguments.cs
@@ -27,9 +27,7 @@ static partial class BindingSyntaxFactory {
 		var expr = ExpressionStatement (
 			AssignmentExpression (
 				SyntaxKind.SimpleAssignmentExpression,
-				PrefixUnaryExpression (
-					SyntaxKind.PointerIndirectionExpression,
-					IdentifierName (parameterName)),
+				IdentifierName (parameterName),
 				LiteralExpression (
 					SyntaxKind.DefaultLiteralExpression,
 					Token (SyntaxKind.DefaultKeyword)))).NormalizeWhitespace ();
@@ -43,12 +41,12 @@ static partial class BindingSyntaxFactory {
 	/// </summary>
 	/// <param name="argumentInfo">The information about the argument for which to generate initializations.</param>
 	/// <returns>An immutable array of <see cref="SyntaxNode"/> representing the initialization statements.</returns>
-	internal static ImmutableArray<SyntaxNode> GetInvokeArgumentInitializations (in ArgumentInfo argumentInfo)
+	internal static ImmutableArray<SyntaxNode> GetNativeInvokeArgumentInitializations (in ArgumentInfo argumentInfo)
 	{
 		// decide the type of conversion we need to do based on the type of the parameter
 #pragma warning disable format
 		return argumentInfo switch { 
-			{ IsByRef: true } => GetNativeInitializationByRefArgument (argumentInfo.Name),
+			{ IsByRef: true, ReferenceKind: ReferenceKind.Out} => GetNativeInitializationByRefArgument (argumentInfo.Name),
 			_ => []
 		};
 #pragma warning restore format

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
@@ -684,6 +684,29 @@ static partial class BindingSyntaxFactory {
 	}
 
 	/// <summary>
+	/// Returns an array of syntax nodes representing initializations required for a 'byref' parameter before invoking the trampoline.
+	/// This is primarily used for handling 'byref' parameters, which may require temporary variables or conversions.
+	/// </summary>
+	/// <param name="parameter">The delegate parameter, which is expected to be 'byref'.</param>
+	/// <returns>An immutable array of syntax nodes representing the initialization statements for the 'byref' parameter.</returns>
+	internal static ImmutableArray<SyntaxNode> GetTrampolineInitializationByRefArgument (in DelegateParameter parameter)
+	{
+		// create the pointer variable and assign it to its default value
+		// generates the following:
+		// *{ParameterName} = default;
+		var expr = ExpressionStatement (
+			AssignmentExpression (
+				SyntaxKind.SimpleAssignmentExpression,
+				PrefixUnaryExpression (
+					SyntaxKind.PointerIndirectionExpression,
+					IdentifierName (parameter.Name)),
+				LiteralExpression (
+					SyntaxKind.DefaultLiteralExpression,
+					Token (SyntaxKind.DefaultKeyword)))).NormalizeWhitespace ();
+		return [expr];
+	}
+
+	/// <summary>
 	/// Generates any necessary post-invocation statements for a by-ref trampoline argument.
 	/// This is used to handle special cases for by-ref parameters, such as assigning back values
 	/// from temporary variables for nullable types or converting boolean values back to their native
@@ -789,15 +812,27 @@ static partial class BindingSyntaxFactory {
 	}
 
 	/// <summary>
+	/// Returns a list of syntax nodes representing the necessary initializations for a trampoline argument before the delegate is invoked.
+	/// This is primarily used for handling 'byref' parameters, which may require temporary variables or conversions.
+	/// </summary>
+	/// <param name="parameter">The delegate parameter for which initializations might be needed.</param>
+	/// <returns>An immutable array of syntax nodes for the initializations. Returns an empty array if no special initialization is required.</returns>
+	internal static ImmutableArray<SyntaxNode> GetTrampolineInvokeArgumentInitializations (in DelegateParameter parameter)
+	{
+		// decide the type of conversion we need to do based on the type of the parameter
+		return parameter switch { { IsByRef: true } => GetTrampolineInitializationByRefArgument (parameter),
+			_ => []
+		};
+	}
+
+	/// <summary>
 	/// Returns the list of expressions that need to be executed before the trampoline is invoked. This allows to
 	/// help the trampoline to convert the parameters to the expected types.
 	/// </summary>
-	/// <param name="trampolineName">The trampoline name to which the conversion is needed.</param>
 	/// <param name="parameter">The parameters whose conversions we need.</param>
 	/// <returns>An immutable array with the needed conversion expressions. Empty is return if no conversion
 	/// is needed.</returns>
-	internal static ImmutableArray<SyntaxNode> GetTrampolinePreInvokeArgumentConversions (string trampolineName,
-		in DelegateParameter parameter)
+	internal static ImmutableArray<SyntaxNode> GetTrampolinePreInvokeArgumentConversions (in DelegateParameter parameter)
 	{
 		// decide the type of conversion we need to do based on the type of the parameter
 		return parameter switch { { IsByRef: true } => GetTrampolinePreInvokeByRefArgument (parameter),
@@ -835,8 +870,8 @@ static partial class BindingSyntaxFactory {
 		var bucket = ImmutableArray.CreateBuilder<TrampolineArgumentSyntax> (delegateInfo.Parameters.Length);
 		foreach (var parameter in delegateInfo.Parameters) {
 			var argument = new TrampolineArgumentSyntax (GetTrampolineInvokeArgument (trampolineName, parameter)) {
-				Initializers = GetInvokeArgumentInitializations (parameter),
-				PreDelegateCallConversion = GetTrampolinePreInvokeArgumentConversions (trampolineName, parameter),
+				Initializers = GetTrampolineInvokeArgumentInitializations (parameter),
+				PreDelegateCallConversion = GetTrampolinePreInvokeArgumentConversions (parameter),
 				PostDelegateCallConversion = GetTrampolinePostInvokeArgumentConversions (trampolineName, parameter),
 			};
 			bucket.Add (argument);
@@ -1049,43 +1084,6 @@ static partial class BindingSyntaxFactory {
 	}
 
 	/// <summary>
-	/// Returns an array of syntax nodes representing initializations required for a 'byref' parameter before invoking the native trampoline.
-	/// This method handles the initialization of 'byref' parameters by assigning them their default value.
-	/// </summary>
-	/// <param name="parameter">The delegate parameter, which is expected to be 'byref'.</param>
-	/// <returns>An immutable array of syntax nodes representing the initialization statements for the 'byref' parameter.</returns>
-	internal static ImmutableArray<SyntaxNode> GetTrampolineNativeInitializationByRefArgument (in DelegateParameter parameter)
-	{
-		// create the pointer variable and assign it to its default value
-		// generates the following:
-		// *{ParameterName} = default;
-		var expr = ExpressionStatement (
-			AssignmentExpression (
-				SyntaxKind.SimpleAssignmentExpression,
-					IdentifierName (parameter.Name),
-				LiteralExpression (
-					SyntaxKind.DefaultLiteralExpression,
-					Token (SyntaxKind.DefaultKeyword)))).NormalizeWhitespace ();
-		return [expr];
-	}
-
-	/// <summary>
-	/// Returns a list of syntax nodes representing the necessary initializations for a trampoline argument before the native delegate (block) is invoked.
-	/// This is primarily used for handling 'out' parameters, which must be initialized to their default value before the native call.
-	/// </summary>
-	/// <param name="trampolineName">The name of the trampoline. Although not directly used in this specific method's logic for 'out' parameter handling, it's kept for consistency with related methods.</param>
-	/// <param name="parameter">The delegate parameter for which initializations might be needed.</param>
-	/// <returns>An immutable array of syntax nodes for the initializations. Returns an empty array if no special initialization (e.g., for 'out' parameters) is required.</returns>
-	internal static ImmutableArray<SyntaxNode> GetTrampolineNativeInvokeArgumentInitializations (string trampolineName,
-		in DelegateParameter parameter)
-	{
-		// decide the type of conversion we need to do based on the type of the parameter
-		return parameter switch { { IsByRef: true, ReferenceKind: ReferenceKind.Out } => GetTrampolineNativeInitializationByRefArgument (parameter),
-			_ => []
-		};
-	}
-
-	/// <summary>
 	/// Generates a list of <see cref="TrampolineArgumentSyntax"/> objects for invoking a native delegate (block) from a trampoline.
 	/// Each <see cref="TrampolineArgumentSyntax"/> encapsulates the argument itself, along with any necessary
 	/// pre-invocation initializations, pre-invocation conversions (managed to native), and post-invocation
@@ -1106,7 +1104,7 @@ static partial class BindingSyntaxFactory {
 		// add all the mising parameters to the bucket.
 		foreach (var parameter in delegateInfo.Parameters) {
 			var argument = new TrampolineArgumentSyntax (GetNativeInvokeArgument (parameter)) {
-				Initializers = GetInvokeArgumentInitializations (parameter),
+				Initializers = GetNativeInvokeArgumentInitializations (parameter),
 				PreDelegateCallConversion = GetPreNativeInvokeArgumentConversions (parameter),
 				PostDelegateCallConversion = GetPostNativeInvokeArgumentConversions (parameter),
 			};

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
@@ -194,92 +194,6 @@ static partial class BindingSyntaxFactory {
 		return StaticInvocationExpression (staticClassName, "Create", arguments, suppressNullableWarning: true);
 	}
 
-
-	/// <summary>
-	/// Returns the needed data to build the parameter syntax for the native trampoline delegate.
-	/// </summary>
-	/// <param name="trampolineName">The trampoline name of the parameter we want to generate.</param>
-	/// <param name="parameter">The parameter we want to generate for the lower invoke method.</param>
-	/// <returns>The parameter syntax needed for the parameter.</returns>
-	internal static ParameterSyntax GetTrampolineInvokeParameter (string trampolineName, in DelegateParameter parameter)
-	{
-		var parameterIdentifier = Identifier (parameter.Name);
-#pragma warning disable format
-		(SyntaxToken ParameterName, TypeSyntax? ParameterType) parameterInfo = parameter switch {
-			// pointer parameter 
-			{ Type.IsPointer: true } 
-				=> (parameterIdentifier, 
-					parameter.Type.GetIdentifierSyntax ()),
-			
-			// parameters that are passed by reference, depend on the type that is referenced
-			{ IsByRef: true, Type.IsReferenceType: false, Type.IsNullable: true} 
-				=> (parameterIdentifier, 
-					PointerType (parameter.Type.GetIdentifierSyntax ())),
-			
-			{ IsByRef: true, Type.SpecialType: SpecialType.System_Boolean} 
-				=> (parameterIdentifier,
-					PointerType (PredefinedType (Token(SyntaxKind.ByteKeyword)))),
-			
-			{ IsByRef: true, Type.IsReferenceType: true, Type.IsNullable: false} 
-				=> (parameterIdentifier,
-					PointerType (NativeHandle)),
-			
-			// delegate parameter is a NativeHandle
-			{ Type.IsDelegate: true } => (parameterIdentifier, IntPtr),
-			
-			// native enum, return the conversion expression to the native type
-			{ Type.IsNativeEnum: true}
-				=> (parameterIdentifier, IdentifierName(parameter.Type.EnumUnderlyingType!.Value.GetKeyword ())),
-
-			// boolean, convert it to byte
-			{ Type.SpecialType: SpecialType.System_Boolean }
-				=> (parameterIdentifier, 
-					PredefinedType (Token(SyntaxKind.ByteKeyword))),
-
-			// same name, native handle
-			{ Type.IsArray: true }
-				=> (parameterIdentifier, NativeHandle),
-
-			// string
-			// same name, native handle
-			{ Type.SpecialType: SpecialType.System_String }
-				=> (parameterIdentifier, NativeHandle),
-
-			// same name, NativeHandle
-			{ Type.IsProtocol: true } => (parameterIdentifier, NativeHandle),
-
-			// same name, NativeHandle
-			{ ForcedType: not null } => (parameterIdentifier, NativeHandle),
-
-			// special types
-
-			// CoreMedia.CMSampleBuffer
-			// same name, native handle
-			{ Type.FullyQualifiedName: "CoreMedia.CMSampleBuffer" } => (parameterIdentifier, NativeHandle),
-
-			// AudioToolbox.AudioBuffers
-			// same name, native handle
-			{ Type.FullyQualifiedName: "AudioToolbox.AudioBuffers" } => (parameterIdentifier, NativeHandle),
-
-			// general NSObject/INativeObject, has to be after the special types otherwise the special types will
-			// fall into the NSObject/INativeObject case
-
-			// same name, native handle
-			{ Type.IsNSObject: true } => (parameterIdentifier, NativeHandle),
-
-			// same name, native handle
-			{ Type.IsINativeObject: true } => (parameterIdentifier, NativeHandle),
-			
-			// by default, we will use the parameter name as is and the type of the parameter
-			_ => (parameterIdentifier, parameter.Type.GetIdentifierSyntax ()),
-		};
-#pragma warning restore format
-		
-		return Parameter (parameterInfo.ParameterName)
-			.WithType (parameterInfo.ParameterType)
-			.NormalizeWhitespace ();
-	}
-
 	/// <summary>
 	/// Gets the low-level native type syntax for a given native enum type.
 	/// This is used when generating code that interacts with native representations of enums.
@@ -449,7 +363,7 @@ static partial class BindingSyntaxFactory {
 			
 			// boolean, convert it to byte
 			{ Type.SpecialType: SpecialType.System_Boolean } 
-				=> CastToBool (parameter.Name, parameterType)!,
+				=> CastToBool (parameter.Name, parameterType),
 			
 			// array types
 			
@@ -1089,11 +1003,9 @@ static partial class BindingSyntaxFactory {
 	/// pre-invocation initializations, pre-invocation conversions (managed to native), and post-invocation
 	/// conversions or cleanup actions (e.g., GC.KeepAlive).
 	/// </summary>
-	/// <param name="trampolineName">The name of the trampoline. This is passed to helper methods to generate unique variable names if needed.</param>
 	/// <param name="delegateInfo">The <see cref="DelegateInfo"/> describing the delegate whose arguments are being generated.</param>
 	/// <returns>An immutable array of <see cref="TrampolineArgumentSyntax"/> for the native delegate invocation.</returns>
-	internal static ImmutableArray<TrampolineArgumentSyntax> GetTrampolineNativeInvokeArguments (string trampolineName,
-		in DelegateInfo delegateInfo)
+	internal static ImmutableArray<TrampolineArgumentSyntax> GetTrampolineNativeInvokeArguments (in DelegateInfo delegateInfo)
 	{
 		// create the builder for the arguments, we already know the size of the array
 		var bucket = ImmutableArray.CreateBuilder<TrampolineArgumentSyntax> (delegateInfo.Parameters.Length);

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/TrampolineEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/TrampolineEmitter.cs
@@ -140,7 +140,7 @@ public unsafe static {delegateIdentifier}? Create (IntPtr block)
 									 // invoke method
 			using (var invokeBlock = classBlock.CreateBlock (GetTrampolineNativeInvokeSignature (typeInfo).ToString (), true)) {
 				// retrieve the arguments for the invoker execution. 
-				var argumentSyntax = GetTrampolineNativeInvokeArguments (trampolineName, typeInfo.Delegate!);
+				var argumentSyntax = GetTrampolineNativeInvokeArguments (typeInfo.Delegate!);
 				// write the conversion code for the arguments
 				foreach (var argument in argumentSyntax) {
 					invokeBlock.Write (argument.PreDelegateCallConversion, verifyTrivia: false);

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryArgumentsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryArgumentsTests.cs
@@ -16,7 +16,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 namespace Microsoft.Macios.Generator.Tests.Emitters;
 
 public class BindingSyntaxFactoryArgumentsTests : BaseGeneratorTestClass {
-	
+
 	class TestDataGetTrampolinePostNativeInvokeArgumentConversions : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -767,7 +767,7 @@ namespace NS {
 		sb.Write (conversions, false);
 		Assert.Equal (expectedExpression, sb.ToCode ());
 	}
-	
+
 	class TestDataGetTrampolineNativeInvokeArgumentInitializations : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -872,7 +872,7 @@ namespace NS {
 		sb.Write (conversions);
 		Assert.Equal (expectedExpression, sb.ToCode ());
 	}
-	
+
 	class TestDataGetTrampolineInvokeArgumentInitializations : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryArgumentsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryArgumentsTests.cs
@@ -16,93 +16,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 namespace Microsoft.Macios.Generator.Tests.Emitters;
 
 public class BindingSyntaxFactoryArgumentsTests : BaseGeneratorTestClass {
-
-	class TestDataGetTrampolineInvokeArgumentInitializations : IEnumerable<object []> {
-		public IEnumerator<object []> GetEnumerator ()
-		{
-			var outNullableInt = @"
-using System;
-using Foundation;
-using ObjCBindings;
-
-namespace NS {
-	public delegate void Callback (out int? outNullableInt);
-	public class MyClass {
-		public void MyMethod (Callback cb) {}
-	}
-}
-";
-
-			yield return [
-				outNullableInt,
-				"*outNullableInt = default;\n",
-			];
-
-			var outBoolean = @"
-using System;
-using Foundation;
-using ObjCBindings;
-
-namespace NS {
-	public delegate void Callback (out bool outBool);
-	public class MyClass {
-		public void MyMethod (Callback cb) {}
-	}
-}
-";
-
-			yield return [
-				outBoolean,
-				"*outBool = default;\n",
-			];
-
-			var outNSObject = @"
-using System;
-using Foundation;
-using ObjCBindings;
-
-namespace NS {
-	public delegate void Callback (out NSObject outNSObject);
-	public class MyClass {
-		public void MyMethod (Callback cb) {}
-	}
-}
-";
-
-			yield return [
-				outNSObject,
-				"*outNSObject = default;\n",
-			];
-		}
-
-		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
-	}
-
-	[Theory]
-	[AllSupportedPlatformsClassData<TestDataGetTrampolineInvokeArgumentInitializations>]
-	void GetTrampolineInvokeArgumentInitializationsTests (ApplePlatform platform, string inputText, string expectedExpression)
-	{
-		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
-		Assert.Single (syntaxTrees);
-		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
-		var declaration = syntaxTrees [0].GetRoot ()
-			.DescendantNodes ().OfType<MethodDeclarationSyntax> ()
-			.FirstOrDefault ();
-		Assert.NotNull (declaration);
-		Assert.True (Method.TryCreate (declaration, semanticModel, out var changes));
-		Assert.NotNull (changes);
-		// we know the first parameter of the method is the delegate
-		Assert.Single (changes.Value.Parameters);
-		var parameter = changes.Value.Parameters [0];
-		// assert it is indeed a delegate
-		Assert.NotNull (parameter.Type.Delegate);
-		var conversions = GetInvokeArgumentInitializations (parameter.Type.Delegate!.Parameters [0]);
-		// uses a tabbeb string builder to get the conversion string and test
-		var sb = new TabbedStringBuilder (new ());
-		sb.Write (conversions);
-		Assert.Equal (expectedExpression, sb.ToCode ());
-	}
-
+	
 	class TestDataGetTrampolinePostNativeInvokeArgumentConversions : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -851,6 +765,197 @@ namespace NS {
 		// uses a tabbeb string builder to get the conversion string and test
 		var sb = new TabbedStringBuilder (new ());
 		sb.Write (conversions, false);
+		Assert.Equal (expectedExpression, sb.ToCode ());
+	}
+	
+	class TestDataGetTrampolineNativeInvokeArgumentInitializations : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			var outNullableInt = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public delegate void Callback (out int? outNullableInt);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				outNullableInt,
+				"outNullableInt = default;\n",
+			];
+
+			var outBoolean = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public delegate void Callback (out bool outBool);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				outBoolean,
+				"outBool = default;\n",
+			];
+
+			var outNSObject = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public delegate void Callback (out NSObject outNSObject);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				outNSObject,
+				"outNSObject = default;\n",
+			];
+
+			var refNSObject = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public delegate void Callback (ref NSObject outNSObject);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				refNSObject,
+				string.Empty,
+			];
+
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataGetTrampolineNativeInvokeArgumentInitializations>]
+	void GetTrampolineInvokeArgumentNativeInitializationsTests (ApplePlatform platform, string inputText, string expectedExpression)
+	{
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
+		Assert.Single (syntaxTrees);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ().OfType<MethodDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		Assert.True (Method.TryCreate (declaration, semanticModel, out var changes));
+		Assert.NotNull (changes);
+		// we know the first parameter of the method is the delegate
+		Assert.Single (changes.Value.Parameters);
+		var parameter = changes.Value.Parameters [0];
+		// assert it is indeed a delegate
+		Assert.NotNull (parameter.Type.Delegate);
+		var conversions = GetNativeInvokeArgumentInitializations (parameter.Type.Delegate!.Parameters [0]);
+		// uses a tabbeb string builder to get the conversion string and test
+		var sb = new TabbedStringBuilder (new ());
+		sb.Write (conversions);
+		Assert.Equal (expectedExpression, sb.ToCode ());
+	}
+	
+	class TestDataGetTrampolineInvokeArgumentInitializations : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			var outNullableInt = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public delegate void Callback (out int? outNullableInt);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				outNullableInt,
+				"*outNullableInt = default;\n",
+			];
+
+			var outBoolean = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public delegate void Callback (out bool outBool);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				outBoolean,
+				"*outBool = default;\n",
+			];
+
+			var outNSObject = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public delegate void Callback (out NSObject outNSObject);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+
+			yield return [
+				outNSObject,
+				"*outNSObject = default;\n",
+			];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataGetTrampolineInvokeArgumentInitializations>]
+	void GetTrampolineInvokeArgumentInitializationsTests (ApplePlatform platform, string inputText, string expectedExpression)
+	{
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
+		Assert.Single (syntaxTrees);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ().OfType<MethodDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		Assert.True (Method.TryCreate (declaration, semanticModel, out var changes));
+		Assert.NotNull (changes);
+		// we know the first parameter of the method is the delegate
+		Assert.Single (changes.Value.Parameters);
+		var parameter = changes.Value.Parameters [0];
+		// assert it is indeed a delegate
+		Assert.NotNull (parameter.Type.Delegate);
+		var conversions = GetTrampolineInvokeArgumentInitializations (parameter.Type.Delegate!.Parameters [0]);
+		// uses a tabbeb string builder to get the conversion string and test
+		var sb = new TabbedStringBuilder (new ());
+		sb.Write (conversions);
 		Assert.Equal (expectedExpression, sb.ToCode ());
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -4275,7 +4275,6 @@ namespace NS {
 }
 ";
 			yield return [
-				"someTrampolineName",
 				pointerParameter,
 				"invoker (BlockLiteral, pointerParameter);",
 			];
@@ -4291,7 +4290,6 @@ namespace NS {
 }
 ";
 			yield return [
-				"someTrampolineName",
 				pointerParameterWithReturn,
 				"var ret = invoker (BlockLiteral, pointerParameter);",
 			];
@@ -4309,7 +4307,6 @@ namespace NS {
 }
 ";
 			yield return [
-				"someTrampolineName",
 				nsNumberParameterWithReturn,
 				"var ret = invoker (BlockLiteral, pointerParameter__handle__);",
 			];
@@ -4327,7 +4324,6 @@ namespace NS {
 }
 ";
 			yield return [
-				"someTrampolineName",
 				nsNumberArrayParameterWithReturn,
 				"var ret = invoker (BlockLiteral, nsa_pointerParameter);",
 			];
@@ -4346,7 +4342,6 @@ namespace NS {
 }
 ";
 			yield return [
-				"someTrampolineName",
 				nsValueParameterWithReturn,
 				"var ret = invoker (BlockLiteral, size__handle__);"
 			];
@@ -4365,7 +4360,6 @@ namespace NS {
 }
 ";
 			yield return [
-				"someTrampolineName",
 				nsValueArrayParameterWithReturn,
 				"var ret = invoker (BlockLiteral, nsa_size);",
 			];
@@ -4395,7 +4389,6 @@ namespace NS {
 }
 ";
 			yield return [
-				"someTrampolineName",
 				smartEnumParameterWithReturn,
 				"var ret = invoker (BlockLiteral, nslevel);"
 			];
@@ -4425,7 +4418,6 @@ namespace NS {
 }
 ";
 			yield return [
-				"someTrampolineName",
 				smartEnumArrayParameterWithReturn,
 				"var ret = invoker (BlockLiteral, nsa_level);"
 			];
@@ -4441,7 +4433,6 @@ namespace NS {
 }
 ";
 			yield return [
-				"someTrampolineName",
 				refParameter,
 				$"var ret = invoker (BlockLiteral, (int*) {Global ("System.Runtime")}.CompilerServices.Unsafe.AsPointer<int> (ref pointerParameter));",
 			];
@@ -4458,7 +4449,6 @@ namespace NS {
 ";
 
 			yield return [
-				"someTrampolineName",
 				refEnumParameter,
 				$"var ret = invoker (BlockLiteral, inNumberOfPackets, ({Global ("AVFoundation.AVAudioConverterInputStatus")}*) {Global ("System.Runtime")}.CompilerServices.Unsafe.AsPointer<{Global ("AVFoundation.AVAudioConverterInputStatus")}> (ref outStatus));",
 			];
@@ -4475,7 +4465,6 @@ namespace NS {
 ";
 
 			yield return [
-				"someTrampolineName",
 				boolReferenceParameter,
 				$"var ret = invoker (BlockLiteral, comp__handle__, (byte*) {Global ("System.Runtime")}.CompilerServices.Unsafe.AsPointer<bool> (ref stop));",
 			];
@@ -4492,7 +4481,6 @@ namespace NS {
 ";
 
 			yield return [
-				"someTrampolineName",
 				doubleReferenceParameter,
 				$"invoker (BlockLiteral, event__handle__, (double*) {Global ("System.Runtime")}.CompilerServices.Unsafe.AsPointer<double> (ref timeStamp), (byte*) global::System.Runtime.CompilerServices.Unsafe.AsPointer<bool> (ref removeEvent));",
 			];
@@ -4509,7 +4497,6 @@ namespace NS {
 ";
 
 			yield return [
-				"someTrampolineName",
 				blockParameter,
 				$"invoker (BlockLiteral, ({Global ("ObjCRuntime.NativeHandle")}) block_ptr_callbackParameter);"
 			];
@@ -4520,7 +4507,7 @@ namespace NS {
 
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataGetTrampolineNativeInvokeArguments>]
-	void CallNativeInvokerDelegateTests (ApplePlatform platform, string trampolineName, string inputText, string expectedExpression)
+	void CallNativeInvokerDelegateTests (ApplePlatform platform, string inputText, string expectedExpression)
 	{
 		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
 		Assert.Single (syntaxTrees);
@@ -4536,7 +4523,7 @@ namespace NS {
 		var parameter = changes.Value.Parameters [0];
 		// assert it is indeed a delegate
 		Assert.NotNull (parameter.Type.Delegate);
-		var argumentSyntax = GetTrampolineNativeInvokeArguments (trampolineName, parameter.Type.Delegate);
+		var argumentSyntax = GetTrampolineNativeInvokeArguments (parameter.Type.Delegate);
 		var invocation = CallNativeInvokerDelegate (parameter.Type.Delegate, argumentSyntax);
 		var x = invocation.ToFullString ();
 		Assert.Equal (expectedExpression, invocation.ToFullString ());

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -4260,7 +4260,7 @@ namespace NS {
 		var delegateDeclaration = GetTrampolineNativeInvokeSignature (parameter.Type);
 		Assert.Equal (expectedExpression, delegateDeclaration.ToString ());
 	}
-	
+
 	class TestDataGetTrampolineNativeInvokeArguments : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryTrampolineTests.cs
@@ -1396,7 +1396,6 @@ namespace NS {
 }
 ";
 			yield return [
-				"someTrampolineName",
 				pointerParameter,
 				string.Empty,
 			];
@@ -1414,7 +1413,6 @@ namespace NS {
 ";
 
 			yield return [
-				"someTrampolineName",
 				ccallbackParameter,
 				string.Empty,
 			];
@@ -1432,7 +1430,6 @@ namespace NS {
 ";
 
 			yield return [
-				"someTrampolineName",
 				blockParameter,
 				string.Empty,
 			];
@@ -1459,7 +1456,6 @@ namespace NS {
 ";
 
 			yield return [
-				"someTrampolineName",
 				nativeEnumParameter,
 				string.Empty,
 			];
@@ -1477,7 +1473,6 @@ namespace NS {
 ";
 
 			yield return [
-				"someTrampolineName",
 				boolParameter,
 				string.Empty,
 			];
@@ -1496,7 +1491,6 @@ namespace NS {
 ";
 
 			yield return [
-				"someTrampolineName",
 				nsObjectArray,
 				string.Empty,
 			];
@@ -1516,7 +1510,6 @@ namespace NS {
 ";
 
 			yield return [
-				"someTrampolineName",
 				iNativeObjectArray,
 				string.Empty,
 			];
@@ -1535,7 +1528,6 @@ namespace NS {
 ";
 
 			yield return [
-				"someTrampolineName",
 				stringArray,
 				string.Empty,
 			];
@@ -1554,7 +1546,6 @@ namespace NS {
 ";
 
 			yield return [
-				"someTrampolineName",
 				stringParameter,
 				string.Empty,
 			];
@@ -1573,7 +1564,6 @@ namespace NS {
 ";
 
 			yield return [
-				"someTrampolineName",
 				protocolParameter,
 				string.Empty,
 			];
@@ -1592,7 +1582,6 @@ namespace NS {
 ";
 
 			yield return [
-				"someTrampolineName",
 				forcedParameterOwnsFalse,
 				string.Empty,
 			];
@@ -1611,7 +1600,6 @@ namespace NS {
 ";
 
 			yield return [
-				"someTrampolineName",
 				forcedParameterOwnsTrue,
 				string.Empty,
 			];
@@ -1630,7 +1618,6 @@ namespace NS {
 ";
 
 			yield return [
-				"someTrampolineName",
 				nsObjectParameter,
 				string.Empty,
 			];
@@ -1650,7 +1637,6 @@ namespace NS {
 ";
 
 			yield return [
-				"someTrampolineName",
 				iNativeParameter,
 				string.Empty,
 			];
@@ -1670,7 +1656,6 @@ namespace NS {
 ";
 
 			yield return [
-				"someTrampolineName",
 				cmSampleBuffer,
 				string.Empty,
 			];
@@ -1690,7 +1675,6 @@ namespace NS {
 ";
 
 			yield return [
-				"someTrampolineName",
 				audioBuffer,
 				string.Empty,
 			];
@@ -1709,7 +1693,6 @@ namespace NS {
 ";
 
 			yield return [
-				"someTrampolineName",
 				outNullableInt,
 				@"int? __xamarin_nullified__0 = null;
 if (outNullableInt is not null)
@@ -1731,7 +1714,6 @@ namespace NS {
 ";
 
 			yield return [
-				"someTrampolineName",
 				outBoolean,
 				"bool __xamarin_bool__0 = *outBool != 0;\n",
 			];
@@ -1750,7 +1732,6 @@ namespace NS {
 ";
 
 			yield return [
-				"someTrampolineName",
 				outNSObject,
 				string.Empty,
 			];
@@ -1769,7 +1750,6 @@ namespace NS {
 ";
 
 			yield return [
-				"someTrampolineName",
 				valueType,
 				string.Empty,
 			];
@@ -1780,7 +1760,7 @@ namespace NS {
 
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataGetTrampolinePreInvokeArgumentConversions>]
-	void GetTrampolinePreInvokeArgumentConversionsTests (ApplePlatform platform, string trampolineName, string inputText, string expectedExpression)
+	void GetTrampolinePreInvokeArgumentConversionsTests (ApplePlatform platform, string inputText, string expectedExpression)
 	{
 		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
 		Assert.Single (syntaxTrees);
@@ -1796,7 +1776,7 @@ namespace NS {
 		var parameter = changes.Value.Parameters [0];
 		// assert it is indeed a delegate
 		Assert.NotNull (parameter.Type.Delegate);
-		var conversions = GetTrampolinePreInvokeArgumentConversions (trampolineName, parameter.Type.Delegate!.Parameters [0]);
+		var conversions = GetTrampolinePreInvokeArgumentConversions (parameter.Type.Delegate!.Parameters [0]);
 		// uses a tabbeb string builder to get the conversion string and test
 		var sb = new TabbedStringBuilder (new ());
 		sb.Write (conversions);
@@ -4280,116 +4260,7 @@ namespace NS {
 		var delegateDeclaration = GetTrampolineNativeInvokeSignature (parameter.Type);
 		Assert.Equal (expectedExpression, delegateDeclaration.ToString ());
 	}
-
-	class TestDataGetTrampolineNativeInvokeArgumentInitializations : IEnumerable<object []> {
-		public IEnumerator<object []> GetEnumerator ()
-		{
-			var outNullableInt = @"
-using System;
-using Foundation;
-using ObjCBindings;
-
-namespace NS {
-	public delegate void Callback (out int? outNullableInt);
-	public class MyClass {
-		public void MyMethod (Callback cb) {}
-	}
-}
-";
-
-			yield return [
-				"someTrampolineName",
-				outNullableInt,
-				"outNullableInt = default;\n",
-			];
-
-			var outBoolean = @"
-using System;
-using Foundation;
-using ObjCBindings;
-
-namespace NS {
-	public delegate void Callback (out bool outBool);
-	public class MyClass {
-		public void MyMethod (Callback cb) {}
-	}
-}
-";
-
-			yield return [
-				"someTrampolineName",
-				outBoolean,
-				"outBool = default;\n",
-			];
-
-			var outNSObject = @"
-using System;
-using Foundation;
-using ObjCBindings;
-
-namespace NS {
-	public delegate void Callback (out NSObject outNSObject);
-	public class MyClass {
-		public void MyMethod (Callback cb) {}
-	}
-}
-";
-
-			yield return [
-				"someTrampolineName",
-				outNSObject,
-				"outNSObject = default;\n",
-			];
-
-			var refNSObject = @"
-using System;
-using Foundation;
-using ObjCBindings;
-
-namespace NS {
-	public delegate void Callback (ref NSObject outNSObject);
-	public class MyClass {
-		public void MyMethod (Callback cb) {}
-	}
-}
-";
-
-			yield return [
-				"someTrampolineName",
-				refNSObject,
-				string.Empty,
-			];
-
-		}
-
-		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
-	}
-
-	[Theory]
-	[AllSupportedPlatformsClassData<TestDataGetTrampolineNativeInvokeArgumentInitializations>]
-	void GetTrampolineInvokeArgumentNativeInitializationsTests (ApplePlatform platform, string trampolineName, string inputText, string expectedExpression)
-	{
-		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
-		Assert.Single (syntaxTrees);
-		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
-		var declaration = syntaxTrees [0].GetRoot ()
-			.DescendantNodes ().OfType<MethodDeclarationSyntax> ()
-			.FirstOrDefault ();
-		Assert.NotNull (declaration);
-		Assert.True (Method.TryCreate (declaration, semanticModel, out var changes));
-		Assert.NotNull (changes);
-		// we know the first parameter of the method is the delegate
-		Assert.Single (changes.Value.Parameters);
-		var parameter = changes.Value.Parameters [0];
-		// assert it is indeed a delegate
-		Assert.NotNull (parameter.Type.Delegate);
-		var conversions = GetTrampolineNativeInvokeArgumentInitializations (trampolineName, parameter.Type.Delegate!.Parameters [0]);
-		// uses a tabbeb string builder to get the conversion string and test
-		var sb = new TabbedStringBuilder (new ());
-		sb.Write (conversions);
-		Assert.Equal (expectedExpression, sb.ToCode ());
-	}
-
+	
 	class TestDataGetTrampolineNativeInvokeArguments : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{


### PR DESCRIPTION
The refactor was wrong and we refactored the
GetTrampolineInitializationByRefArgument whichs does native -> managed instead of GetTrampolineNativeInvokeArgumentInitializations.

This commit undoos that mistake.