### PR TITLE
[RGen] Add support for backing fields on properties.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
@@ -181,7 +181,6 @@ readonly partial struct Property {
 		ImmutableArray<Accessor> accessors)
 	{
 		Name = name;
-		BackingField = $"_{Name}";
 		ReturnType = returnType;
 		SymbolAvailability = symbolAvailability;
 		Attributes = attributes;

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
@@ -70,7 +70,7 @@ readonly partial struct Property : IEquatable<Property> {
 	/// <summary>
 	/// Returns if the property is static.
 	/// </summary>
-	public bool IsStatic => isStatic; 
+	public bool IsStatic => isStatic;
 
 	/// <summary>
 	/// The platform availability of the property.

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
@@ -4,8 +4,9 @@ using System;
 using System.Collections.Immutable;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
-using Microsoft.Macios.Generator.Attributes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Macios.Generator.Availability;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
@@ -19,10 +20,22 @@ readonly partial struct Property : IEquatable<Property> {
 	/// </summary>
 	public string Name { get; } = string.Empty;
 
+	readonly string? backingField = null;
+
 	/// <summary>
 	/// Name of the backing field.
 	/// </summary>
-	public string BackingField { get; private init; }
+	public string BackingField {
+		get {
+			if (backingField is not null)
+				return backingField;
+			// if the backing field is not set, we use the default logic.
+			return IsField ? $"_{Name}" : Nomenclator.GetPropertyBackingFieldName (Name, IsStatic);
+		}
+		init {
+			backingField = value;
+		}
+	}
 
 	readonly TypeInfo returnType;
 
@@ -52,6 +65,13 @@ readonly partial struct Property : IEquatable<Property> {
 	/// </summary>
 	public bool IsReferenceType => ReturnType.IsReferenceType;
 
+	readonly bool isStatic;
+
+	/// <summary>
+	/// Returns if the property is static.
+	/// </summary>
+	public bool IsStatic => isStatic; 
+
 	/// <summary>
 	/// The platform availability of the property.
 	/// </summary>
@@ -62,10 +82,19 @@ readonly partial struct Property : IEquatable<Property> {
 	/// </summary>
 	public ImmutableArray<AttributeCodeChange> Attributes { get; } = [];
 
+
+	readonly ImmutableArray<SyntaxToken> modifiers = [];
+
 	/// <summary>
 	/// Get the modifiers of the property.
 	/// </summary>
-	public ImmutableArray<SyntaxToken> Modifiers { get; init; } = [];
+	public ImmutableArray<SyntaxToken> Modifiers {
+		get => modifiers;
+		init {
+			modifiers = value;
+			isStatic = modifiers.Contains (Token (SyntaxKind.StaticKeyword));
+		}
+	}
 
 	/// <summary>
 	/// Get the list of accessor changes of the property.

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
@@ -202,7 +202,7 @@ if (IsDirectBinding) {{
 ");
 					if (property.RequiresDirtyCheck) {
 						getterBlock.WriteLine ("MarkDirty ();");
-						getterBlock.WriteLine ($"{property.BackingField} = ret;");
+						getterBlock.WriteLine ($"{property.BackingField} = {tempVar};");
 					}
 					getterBlock.WriteLine ($"return {tempVar};");
 				}

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
@@ -166,6 +166,12 @@ return {backingField};
 			if (getter is null)
 				continue;
 
+			// add backing variable for the property if it is needed
+			if (property.NeedsBackingField) {
+				classBlock.WriteLine ();
+				classBlock.WriteLine($"object? {property.BackingField} = null;");
+			}
+			
 			classBlock.WriteLine ();
 			classBlock.AppendMemberAvailability (property.SymbolAvailability);
 			classBlock.AppendGeneratedCodeAttribute (optimizable: true);
@@ -193,8 +199,12 @@ if (IsDirectBinding) {{
 	{ExpressionStatement (invocations.Getter.SendSuper)}
 }}
 {ExpressionStatement (KeepAlive ("this"))}
-return {tempVar};
 ");
+					if (property.RequiresDirtyCheck) {
+						getterBlock.WriteLine ("MarkDirty ();");
+						getterBlock.WriteLine ($"{property.BackingField} = ret;");
+					}
+					getterBlock.WriteLine ($"return {tempVar};");
 				}
 
 				var setter = property.GetAccessor (AccessorKind.Setter);
@@ -214,6 +224,11 @@ return {tempVar};
 						setterBlock.WriteLine ();
 					}
 					setterBlock.WriteLine ("throw new NotImplementedException();");
+					
+					if (property.RequiresDirtyCheck) {
+						setterBlock.WriteLine ("MarkDirty ();");
+						setterBlock.WriteLine ($"{property.BackingField} = value;");
+					}
 				}
 			}
 		}

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
@@ -169,9 +169,9 @@ return {backingField};
 			// add backing variable for the property if it is needed
 			if (property.NeedsBackingField) {
 				classBlock.WriteLine ();
-				classBlock.WriteLine($"object? {property.BackingField} = null;");
+				classBlock.WriteLine ($"object? {property.BackingField} = null;");
 			}
-			
+
 			classBlock.WriteLine ();
 			classBlock.AppendMemberAvailability (property.SymbolAvailability);
 			classBlock.AppendGeneratedCodeAttribute (optimizable: true);
@@ -224,7 +224,7 @@ if (IsDirectBinding) {{
 						setterBlock.WriteLine ();
 					}
 					setterBlock.WriteLine ("throw new NotImplementedException();");
-					
+
 					if (property.RequiresDirtyCheck) {
 						setterBlock.WriteLine ("MarkDirty ();");
 						setterBlock.WriteLine ($"{property.BackingField} = value;");

--- a/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
@@ -224,4 +224,13 @@ static class Nomenclator {
 	/// Returns the name used for the block literal type.
 	/// </summary>
 	public static string GetBlockLiteralName () => "BlockLiteral";
+	
+	/// <summary>
+	/// Generates the name for the backing field of a property.
+	/// </summary>
+	/// <param name="propertyName">The name of the property.</param>
+	/// <param name="isStatic">A value indicating whether the property is static.</param>
+	/// <returns>The name of the backing field for the property.</returns>
+	public static string GetPropertyBackingFieldName (string propertyName, bool isStatic)
+		=> $"__mt_{propertyName}_var{(isStatic ? "_static" : "")}";
 }

--- a/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Nomenclator.cs
@@ -224,7 +224,7 @@ static class Nomenclator {
 	/// Returns the name used for the block literal type.
 	/// </summary>
 	public static string GetBlockLiteralName () => "BlockLiteral";
-	
+
 	/// <summary>
 	/// Generates the name for the backing field of a property.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Transformer/Microsoft.Macios.Transformer.csproj
+++ b/src/rgen/Microsoft.Macios.Transformer/Microsoft.Macios.Transformer.csproj
@@ -35,6 +35,9 @@
         <Compile Include="../Microsoft.Macios.Generator/Configuration.cs" >
             <Link>Configuration.cs</Link>
         </Compile>
+        <Compile Include="../Microsoft.Macios.Generator/Nomenclator.cs" >
+            <Link>Nomenclator.cs</Link>
+        </Compile>
         <Compile Include="../Microsoft.Macios.Generator/DictionaryComparer.cs">
             <Link>DictionaryComparer.cs</Link>
         </Compile>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
@@ -206,6 +206,8 @@ public partial class PropertyTests
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
 	protected internal PropertyTests (global::ObjCRuntime.NativeHandle handle) : base (handle) {}
 
+	object? __mt_Alphanumerics_var = null;
+
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]
@@ -226,9 +228,13 @@ public partial class PropertyTests
 				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSCharacterSet> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("alphanumericCharacterSet")))!;
 			}
 			global::System.GC.KeepAlive (this);
+			MarkDirty ();
+			__mt_Alphanumerics_var = ret;
 			return ret;
 		}
 	}
+
+	object? __mt_AttributedStringByInflectingString_var = null;
 
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]
@@ -250,6 +256,8 @@ public partial class PropertyTests
 				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSAttributedString> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("attributedStringByInflectingString")))!;
 			}
 			global::System.GC.KeepAlive (this);
+			MarkDirty ();
+			__mt_AttributedStringByInflectingString_var = ret;
 			return ret;
 		}
 	}
@@ -467,6 +475,8 @@ public partial class PropertyTests
 		}
 	}
 
+	object? __mt_Locale_var = null;
+
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]
@@ -487,6 +497,8 @@ public partial class PropertyTests
 				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSLocale> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("locale")))!;
 			}
 			global::System.GC.KeepAlive (this);
+			MarkDirty ();
+			__mt_Locale_var = ret;
 			return ret;
 		}
 
@@ -497,6 +509,8 @@ public partial class PropertyTests
 		set
 		{
 			throw new NotImplementedException();
+			MarkDirty ();
+			__mt_Locale_var = value;
 		}
 	}
 
@@ -665,6 +679,8 @@ public partial class PropertyTests
 		}
 	}
 
+	object? __mt_Results_var = null;
+
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]
@@ -685,6 +701,8 @@ public partial class PropertyTests
 				ret = global::CoreFoundation.CFArray.ArrayFromHandle<global::Foundation.NSMetadataItem> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("results")))!;
 			}
 			global::System.GC.KeepAlive (this);
+			MarkDirty ();
+			__mt_Results_var = ret;
 			return ret;
 		}
 	}
@@ -736,6 +754,8 @@ public partial class PropertyTests
 			return ret;
 		}
 	}
+
+	object? __mt_WeakDelegate_var = null;
 
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
@@ -206,6 +206,8 @@ public partial class PropertyTests
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
 	protected internal PropertyTests (global::ObjCRuntime.NativeHandle handle) : base (handle) {}
 
+	object? __mt_Alphanumerics_var = null;
+
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]
@@ -226,9 +228,13 @@ public partial class PropertyTests
 				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSCharacterSet> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("alphanumericCharacterSet")))!;
 			}
 			global::System.GC.KeepAlive (this);
+			MarkDirty ();
+			__mt_Alphanumerics_var = ret;
 			return ret;
 		}
 	}
+
+	object? __mt_AttributedStringByInflectingString_var = null;
 
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]
@@ -250,6 +256,8 @@ public partial class PropertyTests
 				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSAttributedString> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("attributedStringByInflectingString")))!;
 			}
 			global::System.GC.KeepAlive (this);
+			MarkDirty ();
+			__mt_AttributedStringByInflectingString_var = ret;
 			return ret;
 		}
 	}
@@ -467,6 +475,8 @@ public partial class PropertyTests
 		}
 	}
 
+	object? __mt_Locale_var = null;
+
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]
@@ -487,6 +497,8 @@ public partial class PropertyTests
 				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSLocale> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("locale")))!;
 			}
 			global::System.GC.KeepAlive (this);
+			MarkDirty ();
+			__mt_Locale_var = ret;
 			return ret;
 		}
 
@@ -497,6 +509,8 @@ public partial class PropertyTests
 		set
 		{
 			throw new NotImplementedException();
+			MarkDirty ();
+			__mt_Locale_var = value;
 		}
 	}
 
@@ -665,6 +679,8 @@ public partial class PropertyTests
 		}
 	}
 
+	object? __mt_Results_var = null;
+
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]
@@ -685,6 +701,8 @@ public partial class PropertyTests
 				ret = global::CoreFoundation.CFArray.ArrayFromHandle<global::Foundation.NSMetadataItem> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("results")))!;
 			}
 			global::System.GC.KeepAlive (this);
+			MarkDirty ();
+			__mt_Results_var = ret;
 			return ret;
 		}
 	}
@@ -736,6 +754,8 @@ public partial class PropertyTests
 			return ret;
 		}
 	}
+
+	object? __mt_WeakDelegate_var = null;
 
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
@@ -206,6 +206,8 @@ public partial class PropertyTests
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
 	protected internal PropertyTests (global::ObjCRuntime.NativeHandle handle) : base (handle) {}
 
+	object? __mt_Alphanumerics_var = null;
+
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]
@@ -226,9 +228,13 @@ public partial class PropertyTests
 				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSCharacterSet> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("alphanumericCharacterSet")))!;
 			}
 			global::System.GC.KeepAlive (this);
+			MarkDirty ();
+			__mt_Alphanumerics_var = ret;
 			return ret;
 		}
 	}
+
+	object? __mt_AttributedStringByInflectingString_var = null;
 
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]
@@ -250,6 +256,8 @@ public partial class PropertyTests
 				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSAttributedString> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("attributedStringByInflectingString")))!;
 			}
 			global::System.GC.KeepAlive (this);
+			MarkDirty ();
+			__mt_AttributedStringByInflectingString_var = ret;
 			return ret;
 		}
 	}
@@ -467,6 +475,8 @@ public partial class PropertyTests
 		}
 	}
 
+	object? __mt_Locale_var = null;
+
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]
@@ -487,6 +497,8 @@ public partial class PropertyTests
 				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSLocale> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("locale")))!;
 			}
 			global::System.GC.KeepAlive (this);
+			MarkDirty ();
+			__mt_Locale_var = ret;
 			return ret;
 		}
 
@@ -497,6 +509,8 @@ public partial class PropertyTests
 		set
 		{
 			throw new NotImplementedException();
+			MarkDirty ();
+			__mt_Locale_var = value;
 		}
 	}
 
@@ -665,6 +679,8 @@ public partial class PropertyTests
 		}
 	}
 
+	object? __mt_Results_var = null;
+
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]
@@ -685,6 +701,8 @@ public partial class PropertyTests
 				ret = global::CoreFoundation.CFArray.ArrayFromHandle<global::Foundation.NSMetadataItem> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("results")))!;
 			}
 			global::System.GC.KeepAlive (this);
+			MarkDirty ();
+			__mt_Results_var = ret;
 			return ret;
 		}
 	}
@@ -736,6 +754,8 @@ public partial class PropertyTests
 			return ret;
 		}
 	}
+
+	object? __mt_WeakDelegate_var = null;
 
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests/GeneralPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests/GeneralPropertyTests.cs
@@ -23,12 +23,12 @@ public class GeneralPropertyTests {
 		var property = new Property (
 			name: propertyName,
 			returnType: ReturnTypeForString (),
-			symbolAvailability: new(),
+			symbolAvailability: new (),
 			attributes: [],
 			modifiers: [Token (SyntaxKind.StaticKeyword)],
 			accessors: []
 		) {
-			ExportFieldData = new()
+			ExportFieldData = new ()
 		};
 		Assert.Equal ($"_{propertyName}", property.BackingField);
 	}
@@ -42,12 +42,12 @@ public class GeneralPropertyTests {
 		var property = new Property (
 			name: propertyName,
 			returnType: ReturnTypeForString (),
-			symbolAvailability: new(),
+			symbolAvailability: new (),
 			attributes: [],
 			modifiers: isStatic ? [Token (SyntaxKind.StaticKeyword)] : [],
 			accessors: []
 		) {
-			ExportFieldData = null, 
+			ExportFieldData = null,
 		};
 		Assert.Equal (Nomenclator.GetPropertyBackingFieldName (propertyName, isStatic), property.BackingField);
 	}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests/GeneralPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests/GeneralPropertyTests.cs
@@ -8,6 +8,7 @@ using ObjCRuntime;
 using Xunit;
 using Property = Microsoft.Macios.Generator.DataModel.Property;
 using static Microsoft.Macios.Generator.Tests.TestDataFactory;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Microsoft.Macios.Generator.Tests.DataModel.PropertyTests;
 
@@ -17,17 +18,38 @@ public class GeneralPropertyTests {
 	[InlineData ("Name")]
 	[InlineData ("Surname")]
 	[InlineData ("Date")]
-	public void BackingFieldTests (string propertyName)
+	public void BackingFieldStaticFieldTests (string propertyName)
 	{
 		var property = new Property (
 			name: propertyName,
 			returnType: ReturnTypeForString (),
-			symbolAvailability: new (),
+			symbolAvailability: new(),
 			attributes: [],
-			modifiers: [],
+			modifiers: [Token (SyntaxKind.StaticKeyword)],
 			accessors: []
-		);
+		) {
+			ExportFieldData = new()
+		};
 		Assert.Equal ($"_{propertyName}", property.BackingField);
+	}
+
+	[Theory]
+	[InlineData ("Name", false)]
+	[InlineData ("Surname", false)]
+	[InlineData ("Date", true)]
+	public void BackingFieldTests (string propertyName, bool isStatic)
+	{
+		var property = new Property (
+			name: propertyName,
+			returnType: ReturnTypeForString (),
+			symbolAvailability: new(),
+			attributes: [],
+			modifiers: isStatic ? [Token (SyntaxKind.StaticKeyword)] : [],
+			accessors: []
+		) {
+			ExportFieldData = null, 
+		};
+		Assert.Equal (Nomenclator.GetPropertyBackingFieldName (propertyName, isStatic), property.BackingField);
 	}
 
 	[Fact]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/NomenclatorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/NomenclatorTests.cs
@@ -198,5 +198,10 @@ public class Example {
 	[ClassData (typeof (TestDataGetNameForTempTrampolineVariable))]
 	void GetNameForTempTrampolineVariable (DelegateParameter parameter, string expectedName)
 		=> Assert.Equal (expectedName, Nomenclator.GetNameForTempTrampolineVariable (parameter));
-}
 
+	[Theory]
+	[InlineData ("MyProperty", true, "__mt_MyProperty_var_static")]
+	[InlineData ("AnotherProperty", false, "__mt_AnotherProperty_var")]
+	public void GetPropertyBackingFieldNameTests (string propertyName, bool isStatic, string expectedName)
+		=> Assert.Equal (expectedName, Nomenclator.GetPropertyBackingFieldName (propertyName, isStatic));
+}


### PR DESCRIPTION
Ensure that those properties that require a backing field and need to be marked as dirty are correctly generated. The WeakDelegate properties are not curreclty supported since they are a special case.