### PR TITLE
[UIKit] Make sure to invoke the correct constructor. Fixes #23122.

### DIFF
--- a/src/UIKit/UIBarButtonItem.cs
+++ b/src/UIKit/UIBarButtonItem.cs
@@ -60,7 +60,7 @@ namespace UIKit {
 		/// <summary>Constructor that allows a particular <see cref="UIKit.UIBarButtonSystemItem" /> to be specified when the button is created along with an event handler.</summary>
 		/// <remarks>The event handler will be called when the button is pressed.</remarks>
 		public UIBarButtonItem (UIBarButtonSystemItem systemItem, EventHandler handler)
-		: this (systemItem, null, null)
+		: this (systemItem, target: null, action: null)
 		{
 			Clicked += handler;
 		}


### PR DESCRIPTION
There are three constructors involved here:

1. (UIBarButtonSystemItem systemItem, EventHandler handler)
2. (UIBarButtonSystemItem systemItem, NSObject target, Selector action)
3. (UIBarButtonSystemItem systemItem, UIAction primaryAction, UIMenu menu)

The first constructor is a manually written convenience constructor, and needs
to call another constructor. Either the second or the third constructor works,
but the third constructor is only available on iOS 16+, while the second is
available on all iOS version.

This means that calling the third constructor is a bad idea, because it won't
work on anything before iOS 16. Unfortunately that's exactly what we did.

So change the code to call the second constructor instead.

This is a regression that was introduced in f4315389ff2f9d777293f1356b1a9edbe358bdb2.

Fixes https://github.com/dotnet/macios/issues/23122.