### PR TITLE
[release/10.0.1xx-preview6] Update TSA Area Path to DevDiv\.NET MAUI

### DIFF
--- a/tools/devops/automation/scripts/VSTS.psm1
+++ b/tools/devops/automation/scripts/VSTS.psm1
@@ -889,7 +889,7 @@ function Find-AzureDevOpsWorkItemWithTitle {
         $WorkItemType = 'Bug',
 
         [string]
-        $AreaPath = 'DevDiv\VS Client - Runtime SDKs\iOS and Mac'
+        $AreaPath = 'DevDiv\.NET MAUI\iOS and Mac'
     )
 
     $headers = Get-AuthHeader -AccessToken $Env:ACCESSTOKEN
@@ -941,7 +941,7 @@ function New-AzureDevOpsWorkItem {
         $WorkItemType = 'Bug',
 
         [string]
-        $AreaPath = 'DevDiv\VS Client - Runtime SDKs\iOS and Mac'
+        $AreaPath = 'DevDiv\.NET MAUI\iOS and Mac'
     )
 
     $headers = Get-AuthHeader -AccessToken $Env:ACCESSTOKEN

--- a/tools/devops/governance/tsa_config.gdntsa
+++ b/tools/devops/governance/tsa_config.gdntsa
@@ -9,7 +9,7 @@
     ],
     "instanceUrl": "https://devdiv.visualstudio.com",
     "projectName": "DevDiv",
-    "areaPath": "DevDiv\\VS Client - Runtime SDKs\\iOS and Mac",
+    "areaPath": "DevDiv\\.NET MAUI\\iOS and Mac",
     "iterationPath": "DevDiv",
     "tools": [
         "ApiScan", 


### PR DESCRIPTION
Backport of #23143

by changing the area path in AzDO, I accidentally broke the integration with TSA. This PR fixes the area path to point to the correct location.