### PR TITLE
[RGen] Add a new property to mark properties as WeakDelegates.

### DIFF
--- a/src/ObjCBindings/ExportTag.cs
+++ b/src/ObjCBindings/ExportTag.cs
@@ -204,6 +204,9 @@ namespace ObjCBindings {
 		/// </summary>
 		Proxy = 1 << 14,
 
+		/// <summary>
+		/// Use this flag on a property to mark it as a weak delegate.
+		/// </summary>
+		WeakDelegate = 1 << 15,
 	}
 }
-

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
@@ -106,6 +106,11 @@ readonly partial struct Property {
 	/// </summary>
 	public bool IsProxy => IsProperty && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.Proxy);
 
+	/// <summary>
+	/// True if the property was marked as a weak delegate.
+	/// </summary>
+	public bool IsWeakDelegate => IsProperty && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.WeakDelegate);
+
 	readonly bool? needsBackingField = null;
 	/// <summary>
 	/// States if the property, when generated, needs a backing field.

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Property.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Property.Transformer.cs
@@ -66,6 +66,11 @@ readonly partial struct Property {
 	public bool IsTransient => IsProperty && HasTransientFlag;
 
 	/// <summary>
+	/// True if the property is a weak delegate.
+	/// </summary>
+	public bool IsWeakDelegate => IsProperty && Name.StartsWith ("Weak");
+
+	/// <summary>
 	/// Returns the bind from data if present in the binding.
 	/// </summary>
 	public BindAsData? BindAs => BindAsAttribute;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests/GeneralPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests/GeneralPropertyTests.cs
@@ -446,4 +446,25 @@ public class GeneralPropertyTests {
 		};
 		Assert.Equal (expectedResult, property.IsNotification);
 	}
+
+	[Theory]
+	[InlineData (ObjCBindings.Property.Default, false)]
+	[InlineData (ObjCBindings.Property.WeakDelegate, true)]
+#pragma warning disable xUnit1025
+	[InlineData (ObjCBindings.Property.WeakDelegate | ObjCBindings.Property.Default, true)]
+#pragma warning restore xUnit1025
+	public void IsWeakDelegate (ObjCBindings.Property flag, bool expectedResult)
+	{
+		var property = new Property (
+			name: "Test",
+			returnType: new TypeInfo ("string"),
+			symbolAvailability: new (),
+			attributes: [],
+			modifiers: [],
+			accessors: []
+		) {
+			ExportPropertyData = new ("name", ArgumentSemantic.None, flag),
+		};
+		Assert.Equal (expectedResult, property.IsWeakDelegate);
+	}
 }


### PR DESCRIPTION
Do not use the name of the property to decide if it is a WeakDelegate but use a flag. This will allow to know if we are generating WeakDelegate property.