### PR TITLE
[Rgen] Add extra attribute data for async methods.

### DIFF
--- a/src/ObjCBindings/ExportAttribute.cs
+++ b/src/ObjCBindings/ExportAttribute.cs
@@ -71,7 +71,7 @@ namespace ObjCBindings {
 		/// </summary>
 		public string? PostNonResultSnippet { get; set; } = null;
 
-		protected ExportAttribute() { }
+		protected ExportAttribute () { }
 
 		/// <summary>
 		/// Mark a managed method as a exported selector.

--- a/src/ObjCBindings/ExportAttribute.cs
+++ b/src/ObjCBindings/ExportAttribute.cs
@@ -51,7 +51,27 @@ namespace ObjCBindings {
 		/// </summary >
 		public string? Library { get; set; } = null;
 
-		protected ExportAttribute () { }
+		/// <summary>
+		/// The type of the result for an async method.
+		/// </summary>
+		public TypeInfo? ResultType { get; set; } = null;
+
+		/// <summary>
+		/// The name of the generated async method.
+		/// </summary>
+		public string? MethodName { get; set; } = null;
+
+		/// <summary>
+		/// The name of the type of the result for an async method.
+		/// </summary>
+		public string? ResultTypeName { get; set; } = null;
+
+		/// <summary>
+		/// A code snippet to be executed after the async method call.
+		/// </summary>
+		public string? PostNonResultSnippet { get; set; } = null;
+
+		protected ExportAttribute() { }
 
 		/// <summary>
 		/// Mark a managed method as a exported selector.

--- a/src/ObjCBindings/ExportTag.cs
+++ b/src/ObjCBindings/ExportTag.cs
@@ -105,7 +105,7 @@ namespace ObjCBindings {
 		/// Use this flag on a method to mark that the method is a factory method.
 		/// </summary>
 		Factory = 1 << 12,
-		
+
 		/// <summary>
 		/// Use this flag on a method to generate an async version of the method.
 		/// </summary>

--- a/src/ObjCBindings/ExportTag.cs
+++ b/src/ObjCBindings/ExportTag.cs
@@ -105,6 +105,11 @@ namespace ObjCBindings {
 		/// Use this flag on a method to mark that the method is a factory method.
 		/// </summary>
 		Factory = 1 << 12,
+		
+		/// <summary>
+		/// Use this flag on a method to generate an async version of the method.
+		/// </summary>
+		Async = 1 << 13,
 
 	}
 

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/ExportData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/ExportData.cs
@@ -51,10 +51,10 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 	/// Should only be present with the CustomeMarshalDirective flag.
 	/// </summary >
 	public string? Library { get; init; }
-	
+
 	// async related data. This data will only be present if the ExportAttribute is a Method AND has a 
 	// Async flag set. Otherwise they will be ignored. All this methods have to be named parameters
-	
+
 	/// <summary>
 	/// The type of the result for an async method.
 	/// </summary>
@@ -160,10 +160,10 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 			// set the flags first, so we can check if the export is an async method
 			flags = (T) flagsValue!;
 		}
-		
+
 		// from this point we have to check the name of the argument AND if the export method is an Async method.
 		var isAsync = typeof (T) == typeof (ObjCBindings.Method) && flags is not null && flags.HasFlag (ObjCBindings.Method.Async);
-		
+
 		// loop over all the named arguments and set the data accordingly, ignore the Flags one since we already set it
 		foreach (var (name, value) in attrsDict) {
 			switch (name) {

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/ExportData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/ExportData.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using ObjCRuntime;
+using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
 
 namespace Microsoft.Macios.Generator.Attributes;
 
@@ -22,7 +24,7 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 	/// <summary>
 	/// The configuration flags used on the exported member.
 	/// </summary>
-	public T? Flags { get; }
+	public T? Flags { get; init; }
 
 	/// <summary>
 	/// Argument semantics to use with the selector.
@@ -49,6 +51,29 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 	/// Should only be present with the CustomeMarshalDirective flag.
 	/// </summary >
 	public string? Library { get; init; }
+	
+	// async related data. This data will only be present if the ExportAttribute is a Method AND has a 
+	// Async flag set. Otherwise they will be ignored. All this methods have to be named parameters
+	
+	/// <summary>
+	/// The type of the result for an async method.
+	/// </summary>
+	public TypeInfo? ResultType { get; init; }
+
+	/// <summary>
+	/// The name of the generated async method.
+	/// </summary>
+	public string? MethodName { get; init; }
+
+	/// <summary>
+	/// The name of the type of the result for an async method.
+	/// </summary>
+	public string? ResultTypeName { get; init; }
+
+	/// <summary>
+	/// A code snippet to be executed after the async method call.
+	/// </summary>
+	public string? PostNonResultSnippet { get; init; }
 
 	public ExportData () { }
 
@@ -89,6 +114,11 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 		string? nativePrefix = null;
 		string? nativeSuffix = null;
 		string? library = null;
+		// async related data
+		TypeInfo? resultType = null;
+		string? methodName = null;
+		string? resultTypeName = null;
+		string? postNonResultSnippet = null;
 
 		switch (count) {
 		case 1:
@@ -123,25 +153,58 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 			return true;
 		}
 
-		foreach (var (name, value) in attributeData.NamedArguments) {
+		// convert the attrs names to a dictionary to avoid multiple lookups
+		var attrsDict = attributeData.NamedArguments
+			.ToDictionary (x => x.Key, x => x.Value.Value);
+		if (attrsDict.TryGetValue ("Flags", out var flagsValue)) {
+			// set the flags first, so we can check if the export is an async method
+			flags = (T) flagsValue!;
+		}
+		
+		// from this point we have to check the name of the argument AND if the export method is an Async method.
+		var isAsync = typeof (T) == typeof (ObjCBindings.Method) && flags is not null && flags.HasFlag (ObjCBindings.Method.Async);
+		
+		// loop over all the named arguments and set the data accordingly, ignore the Flags one since we already set it
+		foreach (var (name, value) in attrsDict) {
 			switch (name) {
 			case "Selector":
-				selector = (string?) value.Value!;
+				selector = (string?) value!;
 				break;
 			case "ArgumentSemantic":
-				argumentSemantic = (ArgumentSemantic) value.Value!;
-				break;
-			case "Flags":
-				flags = (T) value.Value!;
+				argumentSemantic = (ArgumentSemantic) value!;
 				break;
 			case "NativePrefix":
-				nativePrefix = (string?) value.Value!;
+				nativePrefix = (string?) value!;
 				break;
 			case "NativeSuffix":
-				nativeSuffix = (string?) value.Value!;
+				nativeSuffix = (string?) value!;
 				break;
 			case "Library":
-				library = (string?) value.Value!;
+				library = (string?) value!;
+				break;
+			case "Flags":
+				// we already set the flags, so we can ignore this one
+				break;
+			// async related data
+			case "ResultType":
+				if (isAsync) {
+					resultType = new ((INamedTypeSymbol) value!);
+				}
+				break;
+			case "MethodName":
+				if (isAsync) {
+					methodName = (string?) value!;
+				}
+				break;
+			case "ResultTypeName":
+				if (isAsync) {
+					resultTypeName = (string?) value!;
+				}
+				break;
+			case "PostNonResultSnippet":
+				if (isAsync) {
+					postNonResultSnippet = (string?) value;
+				}
 				break;
 			default:
 				data = null;
@@ -153,7 +216,12 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 			data = new (selector, argumentSemantic, flags) {
 				NativePrefix = nativePrefix,
 				NativeSuffix = nativeSuffix,
-				Library = library
+				Library = library,
+				// set the data for async methods only if the flags are set
+				ResultType = isAsync ? resultType : null,
+				MethodName = isAsync ? methodName : null,
+				ResultTypeName = isAsync ? resultTypeName : null,
+				PostNonResultSnippet = isAsync ? postNonResultSnippet : null
 			};
 			return true;
 		}
@@ -178,6 +246,14 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 		if (NativeSuffix != other.NativeSuffix)
 			return false;
 		if (Library != other.Library)
+			return false;
+		if (ResultType != other.ResultType)
+			return false;
+		if (MethodName != other.MethodName)
+			return false;
+		if (ResultTypeName != other.ResultTypeName)
+			return false;
+		if (PostNonResultSnippet != other.PostNonResultSnippet)
 			return false;
 		return (Flags, other.Flags) switch {
 			(null, null) => true,
@@ -226,6 +302,14 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 		sb.Append (NativeSuffix ?? "null");
 		sb.Append ("', Library: '");
 		sb.Append (Library ?? "null");
+		sb.Append ("', ResultType: '");
+		sb.Append (ResultType?.FullyQualifiedName ?? "null");
+		sb.Append ("', MethodName: '");
+		sb.Append (MethodName ?? "null");
+		sb.Append ("', ResultTypeName: '");
+		sb.Append (ResultTypeName ?? "null");
+		sb.Append ("', PostNonResultSnippet: '");
+		sb.Append (PostNonResultSnippet ?? "null");
 		sb.Append ("' }");
 		return sb.ToString ();
 	}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
@@ -78,6 +78,11 @@ readonly partial struct Method {
 	/// </summary>
 	public bool IsProxy => ExportMethodData.Flags.HasFlag (ObjCBindings.Method.Proxy);
 
+	/// <summary>
+	/// True if the method was marked to be generated as an async method.
+	/// </summary>
+	public bool IsAsync => ExportMethodData.Flags.HasFlag (ObjCBindings.Method.Async);
+
 	public Method (string type, string name, TypeInfo returnType,
 		SymbolAvailability symbolAvailability,
 		ExportData<ObjCBindings.Method> exportMethodData,

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Attributes/ExportDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Attributes/ExportDataTests.cs
@@ -54,22 +54,22 @@ public class ExportDataTests {
 			yield return [
 				Method.Default,
 				new ExportData<Method> ("symbol", ArgumentSemantic.None, Method.Default),
-				"{ Type: 'ObjCBindings.Method', Selector: 'symbol', ArgumentSemantic: 'None', Flags: 'Default', NativePrefix: 'null', NativeSuffix: 'null', Library: 'null' }"
+				"{ Type: 'ObjCBindings.Method', Selector: 'symbol', ArgumentSemantic: 'None', Flags: 'Default', NativePrefix: 'null', NativeSuffix: 'null', Library: 'null', ResultType: 'null', MethodName: 'null', ResultTypeName: 'null', PostNonResultSnippet: 'null' }",
 			];
 			yield return [
 				Method.Default,
 				new ExportData<Method> ("symbol"),
-				"{ Type: 'ObjCBindings.Method', Selector: 'symbol', ArgumentSemantic: 'None', Flags: 'Default', NativePrefix: 'null', NativeSuffix: 'null', Library: 'null' }"
+				"{ Type: 'ObjCBindings.Method', Selector: 'symbol', ArgumentSemantic: 'None', Flags: 'Default', NativePrefix: 'null', NativeSuffix: 'null', Library: 'null', ResultType: 'null', MethodName: 'null', ResultTypeName: 'null', PostNonResultSnippet: 'null' }",
 			];
 			yield return [
 				Property.Default,
 				new ExportData<Property> ("symbol", ArgumentSemantic.Retain, Property.Default),
-				"{ Type: 'ObjCBindings.Property', Selector: 'symbol', ArgumentSemantic: 'Retain', Flags: 'Default', NativePrefix: 'null', NativeSuffix: 'null', Library: 'null' }"
+				"{ Type: 'ObjCBindings.Property', Selector: 'symbol', ArgumentSemantic: 'Retain', Flags: 'Default', NativePrefix: 'null', NativeSuffix: 'null', Library: 'null', ResultType: 'null', MethodName: 'null', ResultTypeName: 'null', PostNonResultSnippet: 'null' }"
 			];
 			yield return [
 				Property.Default,
 				new ExportData<Property> ("symbol"),
-				"{ Type: 'ObjCBindings.Property', Selector: 'symbol', ArgumentSemantic: 'None', Flags: 'Default', NativePrefix: 'null', NativeSuffix: 'null', Library: 'null' }"
+				"{ Type: 'ObjCBindings.Property', Selector: 'symbol', ArgumentSemantic: 'None', Flags: 'Default', NativePrefix: 'null', NativeSuffix: 'null', Library: 'null', ResultType: 'null', MethodName: 'null', ResultTypeName: 'null', PostNonResultSnippet: 'null' }"
 			];
 			yield return [
 				Method.Default,
@@ -78,7 +78,7 @@ public class ExportDataTests {
 					NativePrefix = "xamarin_",
 					Library = "__Internal"
 				},
-				"{ Type: 'ObjCBindings.Method', Selector: 'symbol', ArgumentSemantic: 'None', Flags: 'CustomMarshalDirective', NativePrefix: 'xamarin_', NativeSuffix: 'null', Library: '__Internal' }"
+				"{ Type: 'ObjCBindings.Method', Selector: 'symbol', ArgumentSemantic: 'None', Flags: 'CustomMarshalDirective', NativePrefix: 'xamarin_', NativeSuffix: 'null', Library: '__Internal', ResultType: 'null', MethodName: 'null', ResultTypeName: 'null', PostNonResultSnippet: 'null' }"
 			];
 		}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests/FromDeclarationTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests/FromDeclarationTests.cs
@@ -78,6 +78,87 @@ namespace NS {
 				)
 			];
 
+			const string asyncVoidMethodNoParamsExportDataMisingFlag = @"
+using System;
+using ObjCBindings;
+
+namespace NS {
+	public class MyClass {
+		[Export<Method>(""myMethod"", Flags = Method.Default,
+			ResultTypeName = ""NSObject"",
+			PostNonResultSnippet = ""throw new NotImplementedException();"")]
+		public void MyMethod () {}
+	}
+}
+";
+
+			yield return [
+				asyncVoidMethodNoParamsExportDataMisingFlag,
+				new Method (
+					type: "NS.MyClass",
+					name: "MyMethod",
+					returnType: ReturnTypeForVoid (),
+					symbolAvailability: new (),
+					exportMethodData: new ("myMethod"), // async valus are null
+					attributes: [
+						new (
+							name: "ObjCBindings.ExportAttribute<ObjCBindings.Method>", 
+							arguments: [
+								"myMethod", 
+								"ObjCBindings.Method.Default",
+								"NSObject", 
+								"throw new NotImplementedException();"
+							]),
+					],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					parameters: []
+				)
+			];
+
+			const string asyncVoidMethodNoParamsExportDataAsyncFlag = @"
+using System;
+using ObjCBindings;
+
+namespace NS {
+	public class MyClass {
+		[Export<Method>(""myMethod"", Flags = Method.Default | Method.Async,
+			ResultTypeName = ""NSObject"",
+			PostNonResultSnippet = ""throw new NotImplementedException();"")]
+		public void MyMethod () {}
+	}
+}
+";
+
+			yield return [
+				asyncVoidMethodNoParamsExportDataAsyncFlag,
+				new Method (
+					type: "NS.MyClass",
+					name: "MyMethod",
+					returnType: ReturnTypeForVoid (),
+					symbolAvailability: new (),
+					exportMethodData: new ("myMethod") {
+						Flags = ObjCBindings.Method.Default | ObjCBindings.Method.Async,
+						ResultTypeName = "NSObject",
+						PostNonResultSnippet = "throw new NotImplementedException();",
+					},
+					attributes: [
+						new (
+							name: "ObjCBindings.ExportAttribute<ObjCBindings.Method>", 
+							arguments: [
+								"myMethod", 
+								"NSObject", 
+								"throw new NotImplementedException();"
+							]),
+					],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					parameters: []
+				)
+			];
+
 			const string stringMethodNoParams = @"
 using System;
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests/FromDeclarationTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests/FromDeclarationTests.cs
@@ -102,11 +102,11 @@ namespace NS {
 					exportMethodData: new ("myMethod"), // async valus are null
 					attributes: [
 						new (
-							name: "ObjCBindings.ExportAttribute<ObjCBindings.Method>", 
+							name: "ObjCBindings.ExportAttribute<ObjCBindings.Method>",
 							arguments: [
-								"myMethod", 
+								"myMethod",
 								"ObjCBindings.Method.Default",
-								"NSObject", 
+								"NSObject",
 								"throw new NotImplementedException();"
 							]),
 					],
@@ -145,10 +145,10 @@ namespace NS {
 					},
 					attributes: [
 						new (
-							name: "ObjCBindings.ExportAttribute<ObjCBindings.Method>", 
+							name: "ObjCBindings.ExportAttribute<ObjCBindings.Method>",
 							arguments: [
-								"myMethod", 
-								"NSObject", 
+								"myMethod",
+								"NSObject",
 								"throw new NotImplementedException();"
 							]),
 					],


### PR DESCRIPTION
Add extra data for the Export method that will only will be present when the async flags is present in the Export method. This allows to mark methods as async to be generated.