### PR TITLE
[Rgen] Add the signatures of async methods.

### DIFF
--- a/src/ObjCBindings/ExportAttribute.cs
+++ b/src/ObjCBindings/ExportAttribute.cs
@@ -71,7 +71,7 @@ namespace ObjCBindings {
 		/// </summary>
 		public string? PostNonResultSnippet { get; set; } = null;
 
-		protected ExportAttribute() { }
+		protected ExportAttribute () { }
 
 		/// <summary>
 		/// Mark a managed method as a exported selector.

--- a/src/ObjCBindings/ExportAttribute.cs
+++ b/src/ObjCBindings/ExportAttribute.cs
@@ -51,7 +51,27 @@ namespace ObjCBindings {
 		/// </summary >
 		public string? Library { get; set; } = null;
 
-		protected ExportAttribute () { }
+		/// <summary>
+		/// The type of the result for an async method.
+		/// </summary>
+		public TypeInfo? ResultType { get; set; } = null;
+
+		/// <summary>
+		/// The name of the generated async method.
+		/// </summary>
+		public string? MethodName { get; set; } = null;
+
+		/// <summary>
+		/// The name of the type of the result for an async method.
+		/// </summary>
+		public string? ResultTypeName { get; set; } = null;
+
+		/// <summary>
+		/// A code snippet to be executed after the async method call.
+		/// </summary>
+		public string? PostNonResultSnippet { get; set; } = null;
+
+		protected ExportAttribute() { }
 
 		/// <summary>
 		/// Mark a managed method as a exported selector.

--- a/src/ObjCBindings/ExportTag.cs
+++ b/src/ObjCBindings/ExportTag.cs
@@ -105,7 +105,7 @@ namespace ObjCBindings {
 		/// Use this flag on a method to mark that the method is a factory method.
 		/// </summary>
 		Factory = 1 << 12,
-		
+
 		/// <summary>
 		/// Use this flag on a method to generate an async version of the method.
 		/// </summary>

--- a/src/ObjCBindings/ExportTag.cs
+++ b/src/ObjCBindings/ExportTag.cs
@@ -105,6 +105,11 @@ namespace ObjCBindings {
 		/// Use this flag on a method to mark that the method is a factory method.
 		/// </summary>
 		Factory = 1 << 12,
+		
+		/// <summary>
+		/// Use this flag on a method to generate an async version of the method.
+		/// </summary>
+		Async = 1 << 13,
 
 	}
 

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/ExportData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/ExportData.cs
@@ -51,10 +51,10 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 	/// Should only be present with the CustomeMarshalDirective flag.
 	/// </summary >
 	public string? Library { get; init; }
-	
+
 	// async related data. This data will only be present if the ExportAttribute is a Method AND has a 
 	// Async flag set. Otherwise they will be ignored. All this methods have to be named parameters
-	
+
 	/// <summary>
 	/// The type of the result for an async method.
 	/// </summary>
@@ -160,10 +160,10 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 			// set the flags first, so we can check if the export is an async method
 			flags = (T) flagsValue!;
 		}
-		
+
 		// from this point we have to check the name of the argument AND if the export method is an Async method.
 		var isAsync = typeof (T) == typeof (ObjCBindings.Method) && flags is not null && flags.HasFlag (ObjCBindings.Method.Async);
-		
+
 		// loop over all the named arguments and set the data accordingly, ignore the Flags one since we already set it
 		foreach (var (name, value) in attrsDict) {
 			switch (name) {

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/ExportData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/ExportData.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using ObjCRuntime;
+using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
 
 namespace Microsoft.Macios.Generator.Attributes;
 
@@ -22,7 +24,7 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 	/// <summary>
 	/// The configuration flags used on the exported member.
 	/// </summary>
-	public T? Flags { get; }
+	public T? Flags { get; init; }
 
 	/// <summary>
 	/// Argument semantics to use with the selector.
@@ -49,6 +51,29 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 	/// Should only be present with the CustomeMarshalDirective flag.
 	/// </summary >
 	public string? Library { get; init; }
+	
+	// async related data. This data will only be present if the ExportAttribute is a Method AND has a 
+	// Async flag set. Otherwise they will be ignored. All this methods have to be named parameters
+	
+	/// <summary>
+	/// The type of the result for an async method.
+	/// </summary>
+	public TypeInfo? ResultType { get; init; }
+
+	/// <summary>
+	/// The name of the generated async method.
+	/// </summary>
+	public string? MethodName { get; init; }
+
+	/// <summary>
+	/// The name of the type of the result for an async method.
+	/// </summary>
+	public string? ResultTypeName { get; init; }
+
+	/// <summary>
+	/// A code snippet to be executed after the async method call.
+	/// </summary>
+	public string? PostNonResultSnippet { get; init; }
 
 	public ExportData () { }
 
@@ -89,6 +114,11 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 		string? nativePrefix = null;
 		string? nativeSuffix = null;
 		string? library = null;
+		// async related data
+		TypeInfo? resultType = null;
+		string? methodName = null;
+		string? resultTypeName = null;
+		string? postNonResultSnippet = null;
 
 		switch (count) {
 		case 1:
@@ -123,25 +153,58 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 			return true;
 		}
 
-		foreach (var (name, value) in attributeData.NamedArguments) {
+		// convert the attrs names to a dictionary to avoid multiple lookups
+		var attrsDict = attributeData.NamedArguments
+			.ToDictionary (x => x.Key, x => x.Value.Value);
+		if (attrsDict.TryGetValue ("Flags", out var flagsValue)) {
+			// set the flags first, so we can check if the export is an async method
+			flags = (T) flagsValue!;
+		}
+		
+		// from this point we have to check the name of the argument AND if the export method is an Async method.
+		var isAsync = typeof (T) == typeof (ObjCBindings.Method) && flags is not null && flags.HasFlag (ObjCBindings.Method.Async);
+		
+		// loop over all the named arguments and set the data accordingly, ignore the Flags one since we already set it
+		foreach (var (name, value) in attrsDict) {
 			switch (name) {
 			case "Selector":
-				selector = (string?) value.Value!;
+				selector = (string?) value!;
 				break;
 			case "ArgumentSemantic":
-				argumentSemantic = (ArgumentSemantic) value.Value!;
-				break;
-			case "Flags":
-				flags = (T) value.Value!;
+				argumentSemantic = (ArgumentSemantic) value!;
 				break;
 			case "NativePrefix":
-				nativePrefix = (string?) value.Value!;
+				nativePrefix = (string?) value!;
 				break;
 			case "NativeSuffix":
-				nativeSuffix = (string?) value.Value!;
+				nativeSuffix = (string?) value!;
 				break;
 			case "Library":
-				library = (string?) value.Value!;
+				library = (string?) value!;
+				break;
+			case "Flags":
+				// we already set the flags, so we can ignore this one
+				break;
+			// async related data
+			case "ResultType":
+				if (isAsync) {
+					resultType = new ((INamedTypeSymbol) value!);
+				}
+				break;
+			case "MethodName":
+				if (isAsync) {
+					methodName = (string?) value!;
+				}
+				break;
+			case "ResultTypeName":
+				if (isAsync) {
+					resultTypeName = (string?) value!;
+				}
+				break;
+			case "PostNonResultSnippet":
+				if (isAsync) {
+					postNonResultSnippet = (string?) value;
+				}
 				break;
 			default:
 				data = null;
@@ -153,7 +216,12 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 			data = new (selector, argumentSemantic, flags) {
 				NativePrefix = nativePrefix,
 				NativeSuffix = nativeSuffix,
-				Library = library
+				Library = library,
+				// set the data for async methods only if the flags are set
+				ResultType = isAsync ? resultType : null,
+				MethodName = isAsync ? methodName : null,
+				ResultTypeName = isAsync ? resultTypeName : null,
+				PostNonResultSnippet = isAsync ? postNonResultSnippet : null
 			};
 			return true;
 		}
@@ -178,6 +246,14 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 		if (NativeSuffix != other.NativeSuffix)
 			return false;
 		if (Library != other.Library)
+			return false;
+		if (ResultType != other.ResultType)
+			return false;
+		if (MethodName != other.MethodName)
+			return false;
+		if (ResultTypeName != other.ResultTypeName)
+			return false;
+		if (PostNonResultSnippet != other.PostNonResultSnippet)
 			return false;
 		return (Flags, other.Flags) switch {
 			(null, null) => true,
@@ -226,6 +302,14 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 		sb.Append (NativeSuffix ?? "null");
 		sb.Append ("', Library: '");
 		sb.Append (Library ?? "null");
+		sb.Append ("', ResultType: '");
+		sb.Append (ResultType?.FullyQualifiedName ?? "null");
+		sb.Append ("', MethodName: '");
+		sb.Append (MethodName ?? "null");
+		sb.Append ("', ResultTypeName: '");
+		sb.Append (ResultTypeName ?? "null");
+		sb.Append ("', PostNonResultSnippet: '");
+		sb.Append (PostNonResultSnippet ?? "null");
 		sb.Append ("' }");
 		return sb.ToString ();
 	}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
@@ -78,6 +78,11 @@ readonly partial struct Method {
 	/// </summary>
 	public bool IsProxy => ExportMethodData.Flags.HasFlag (ObjCBindings.Method.Proxy);
 
+	/// <summary>
+	/// True if the method was marked to be generated as an async method.
+	/// </summary>
+	public bool IsAsync => ExportMethodData.Flags.HasFlag (ObjCBindings.Method.Async);
+
 	public Method (string type, string name, TypeInfo returnType,
 		SymbolAvailability symbolAvailability,
 		ExportData<ObjCBindings.Method> exportMethodData,

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
@@ -10,6 +10,7 @@ using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Availability;
 using Microsoft.Macios.Generator.Context;
 using Microsoft.Macios.Generator.Extensions;
+using Microsoft.Macios.Generator.Formatters;
 using ObjCRuntime;
 
 namespace Microsoft.Macios.Generator.DataModel;
@@ -138,5 +139,39 @@ readonly partial struct Method {
 		};
 
 		return true;
+	}
+	
+	/// <summary>
+	/// Converts the current method to its asynchronous version if it's marked with the `Async` flag.
+	/// </summary>
+	/// <returns>
+	/// A new <see cref="Method"/> instance representing the asynchronous version of the method,
+	/// or the current instance if the method is not marked as async.
+	/// </returns>
+	public Method ToAsync ()
+	{
+		if (!IsAsync)
+			return this;
+		
+		// calculating the return type depends on the data present in the export data
+		var resultType = Parameters[^1].Type.ToTask ();
+		
+		// if the user provided a result type, we need to update the calculated result type to a task
+		if (ExportMethodData.ResultType is not null) {
+			resultType = resultType.ToTask (ExportMethodData.ResultType.Value.GetIdentifierSyntax ().ToString ());
+		}
+
+		if (ExportMethodData.ResultTypeName is not null) {
+			resultType = resultType.ToTask (ExportMethodData.ResultTypeName);
+		}
+		
+		return this with {
+			// update name to include async
+			Name = ExportMethodData.MethodName ?? $"{Name}Async", // update name, if user did not specify a name, use the default one
+			// remove last parameter which is the completion handler
+			Parameters = [..Parameters.SkipLast (1)],
+			// update the return type to be a task
+			ReturnType = resultType,
+		};
 	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.cs
@@ -22,12 +22,12 @@ readonly partial struct Method : IEquatable<Method> {
 	/// <summary>
 	/// Method name.
 	/// </summary>
-	public string Name { get; }
+	public string Name { get; init; }
 
 	/// <summary>
 	/// Method return type.
 	/// </summary>
-	public TypeInfo ReturnType { get; }
+	public TypeInfo ReturnType { get; init; }
 
 	/// <summary>
 	/// The platform availability of the method.
@@ -47,7 +47,7 @@ readonly partial struct Method : IEquatable<Method> {
 	/// <summary>
 	/// Parameters list.
 	/// </summary>
-	public ImmutableArray<Parameter> Parameters { get; } = [];
+	public ImmutableArray<Parameter> Parameters { get; init; } = [];
 
 	/// <inheritdoc/>
 	public bool Equals (Method other)

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -653,6 +653,26 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 
 	/// <summary>
 	/// If the current <see cref="TypeInfo"/> represents a <see cref="System.Threading.Tasks.Task"/>, this method returns a new <see cref="TypeInfo"/>
+	/// with its generic type arguments replaced by the provided types. Otherwise, it returns the current instance.
+	/// </summary>
+	/// <param name="types">The new generic type arguments for the task.</param>
+	/// <returns>
+	/// A new <see cref="TypeInfo"/> instance with updated generic type arguments if the type is a <c>Task</c>;
+	/// otherwise, returns the current <see cref="TypeInfo"/> instance.
+	/// </returns>
+	public TypeInfo ToTask (params string [] types)
+	{
+		if (!IsTask)
+			return this;
+		
+		// update the type arguments to use the provided ones in the method
+		return this with {
+			TypeArguments = [..types],
+		};
+	}
+
+	/// <summary>
+	/// If the current <see cref="TypeInfo"/> represents a <see cref="System.Threading.Tasks.Task"/>, this method returns a new <see cref="TypeInfo"/>
 	/// representing a <see cref="System.Threading.Tasks.TaskCompletionSource{TResult}"/> with the task's generic arguments.
 	/// Otherwise, it returns the current instance.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
@@ -270,6 +270,19 @@ $@"if (IsDirectBinding) {{
 			using (var methodBlock = classBlock.CreateBlock (method.ToDeclaration ().ToString (), block: true)) {
 				methodBlock.WriteLine ("throw new NotImplementedException ();");
 			}
+			
+			if (!method.IsAsync) 
+				continue;
+			
+			// if the method is an async method, generate its async version
+			classBlock.WriteLine ();
+			classBlock.AppendMemberAvailability (method.SymbolAvailability);
+			classBlock.AppendGeneratedCodeAttribute (optimizable: true);
+			
+			var asyncMethod = method.ToAsync ();
+			using (var methodBlock = classBlock.CreateBlock (asyncMethod.ToDeclaration ().ToString (), block: true)) {
+				methodBlock.WriteLine ("throw new NotImplementedException ();");
+			}
 		}
 	}
 

--- a/src/scenekit.cs
+++ b/src/scenekit.cs
@@ -82,7 +82,7 @@ using NSBezierPath = global::UIKit.UIBezierPath;
 namespace SceneKit {
 	/// <summary>Callback used to reflect progress during execution of <see cref="SceneKit.SCNSceneSource.SceneFromOptions(SceneKit.SCNSceneLoadingOptions,SceneKit.SCNSceneSourceStatusHandler)" />.</summary>
 	[MacCatalyst (13, 1)]
-	delegate void SCNSceneSourceStatusHandler (float /* float, not CGFloat */ totalProgress, SCNSceneSourceStatus status, NSError error, ref bool stopLoading);
+	delegate void SCNSceneSourceStatusHandler (float /* float, not CGFloat */ totalProgress, SCNSceneSourceStatus status, [NullAllowed] NSError error, ref bool stopLoading);
 
 	delegate void SCNAnimationDidStartHandler (SCNAnimation animation, ISCNAnimatable receiver);
 
@@ -3226,7 +3226,7 @@ namespace SceneKit {
 	///     <param name="stop">Developers set this to true to cancel processing.</param>
 	///     <summary>Continuation handler that SceneKit repeatedly calls when exporting a scene.</summary>
 	[MacCatalyst (13, 1)]
-	delegate void SCNSceneExportProgressHandler (float /* float, not CGFloat */ totalProgress, NSError error, out bool stop);
+	delegate void SCNSceneExportProgressHandler (float /* float, not CGFloat */ totalProgress, [NullAllowed] NSError error, out bool stop);
 
 	/// <summary>The highest-level description of a 3D scene.</summary>
 	///     
@@ -5106,7 +5106,7 @@ namespace SceneKit {
 
 	/// <summary>Completion handler used with <see cref="SceneKit.SCNShadable.HandleBinding(System.String,SceneKit.SCNBindingHandler)" />.</summary>
 	[MacCatalyst (13, 1)]
-	delegate void SCNBindingHandler (uint /* unsigned int */ programId, uint /* unsigned int */ location, SCNNode renderedNode, SCNRenderer renderer);
+	delegate void SCNBindingHandler (uint /* unsigned int */ programId, uint /* unsigned int */ location, [NullAllowed] SCNNode renderedNode, SCNRenderer renderer);
 
 	/// <summary>A <see cref="Foundation.DictionaryContainer" /> containing options for shaders.</summary>
 	[MacCatalyst (13, 1)]

--- a/src/spritekit.cs
+++ b/src/spritekit.cs
@@ -1937,7 +1937,7 @@ namespace SpriteKit {
 		void ModifyPixelData (SKTextureModify modifyMethod);
 	}
 
-	delegate void SKTextureAtlasLoadCallback (NSError error, SKTextureAtlas foundAtlases);
+	delegate void SKTextureAtlasLoadCallback ([NullAllowed] NSError error, SKTextureAtlas foundAtlases);
 
 	/// <summary>A collection of <see cref="SpriteKit.SKTexture" />s that are loaded from a single source.</summary>
 	///     

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Attributes/ExportDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Attributes/ExportDataTests.cs
@@ -54,22 +54,22 @@ public class ExportDataTests {
 			yield return [
 				Method.Default,
 				new ExportData<Method> ("symbol", ArgumentSemantic.None, Method.Default),
-				"{ Type: 'ObjCBindings.Method', Selector: 'symbol', ArgumentSemantic: 'None', Flags: 'Default', NativePrefix: 'null', NativeSuffix: 'null', Library: 'null' }"
+				"{ Type: 'ObjCBindings.Method', Selector: 'symbol', ArgumentSemantic: 'None', Flags: 'Default', NativePrefix: 'null', NativeSuffix: 'null', Library: 'null', ResultType: 'null', MethodName: 'null', ResultTypeName: 'null', PostNonResultSnippet: 'null' }",
 			];
 			yield return [
 				Method.Default,
 				new ExportData<Method> ("symbol"),
-				"{ Type: 'ObjCBindings.Method', Selector: 'symbol', ArgumentSemantic: 'None', Flags: 'Default', NativePrefix: 'null', NativeSuffix: 'null', Library: 'null' }"
+				"{ Type: 'ObjCBindings.Method', Selector: 'symbol', ArgumentSemantic: 'None', Flags: 'Default', NativePrefix: 'null', NativeSuffix: 'null', Library: 'null', ResultType: 'null', MethodName: 'null', ResultTypeName: 'null', PostNonResultSnippet: 'null' }",
 			];
 			yield return [
 				Property.Default,
 				new ExportData<Property> ("symbol", ArgumentSemantic.Retain, Property.Default),
-				"{ Type: 'ObjCBindings.Property', Selector: 'symbol', ArgumentSemantic: 'Retain', Flags: 'Default', NativePrefix: 'null', NativeSuffix: 'null', Library: 'null' }"
+				"{ Type: 'ObjCBindings.Property', Selector: 'symbol', ArgumentSemantic: 'Retain', Flags: 'Default', NativePrefix: 'null', NativeSuffix: 'null', Library: 'null', ResultType: 'null', MethodName: 'null', ResultTypeName: 'null', PostNonResultSnippet: 'null' }"
 			];
 			yield return [
 				Property.Default,
 				new ExportData<Property> ("symbol"),
-				"{ Type: 'ObjCBindings.Property', Selector: 'symbol', ArgumentSemantic: 'None', Flags: 'Default', NativePrefix: 'null', NativeSuffix: 'null', Library: 'null' }"
+				"{ Type: 'ObjCBindings.Property', Selector: 'symbol', ArgumentSemantic: 'None', Flags: 'Default', NativePrefix: 'null', NativeSuffix: 'null', Library: 'null', ResultType: 'null', MethodName: 'null', ResultTypeName: 'null', PostNonResultSnippet: 'null' }"
 			];
 			yield return [
 				Method.Default,
@@ -78,7 +78,7 @@ public class ExportDataTests {
 					NativePrefix = "xamarin_",
 					Library = "__Internal"
 				},
-				"{ Type: 'ObjCBindings.Method', Selector: 'symbol', ArgumentSemantic: 'None', Flags: 'CustomMarshalDirective', NativePrefix: 'xamarin_', NativeSuffix: 'null', Library: '__Internal' }"
+				"{ Type: 'ObjCBindings.Method', Selector: 'symbol', ArgumentSemantic: 'None', Flags: 'CustomMarshalDirective', NativePrefix: 'xamarin_', NativeSuffix: 'null', Library: '__Internal', ResultType: 'null', MethodName: 'null', ResultTypeName: 'null', PostNonResultSnippet: 'null' }"
 			];
 		}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/ClassGenerationTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/ClassGenerationTests.cs
@@ -43,7 +43,7 @@ public class ClassGenerationTests : BaseGeneratorTestClass {
 			(ApplePlatform.MacOSX, "NSUserDefaults", "NSUserDefaults.cs", "ExpectedNSUserDefaults.cs", null, null),
 
 			(ApplePlatform.iOS, "MethodTests", "MethodTests.cs", "ExpectedMethodsTests.cs", null, null),
-			(ApplePlatform.TVOS, "MethodTests", "MethodTests.cs", "ExpectedMethodsTests.cs", null, null),
+			(ApplePlatform.TVOS, "MethodTests", "MethodTests.cs", "tvOSExpectedMethodsTests.cs", null, null),
 			(ApplePlatform.MacCatalyst, "MethodTests", "MethodTests.cs", "ExpectedMethodsTests.cs", null, null),
 			(ApplePlatform.MacOSX, "MethodTests", "MethodTests.cs", "ExpectedMethodsTests.cs", null, null),
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
@@ -56,4 +56,20 @@ public partial class MethodTests {
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[Export<Method> ("filteredArrayUsingPredicate:")]
 	public partial NSArray Filter (NSPredicate predicate);
+	
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[UnsupportedOSPlatform ("tvos")]
+	[Export<Method> ("loadFromHTMLWithRequest:options:completionHandler:", 
+		Flags = ObjCBindings.Method.Async, 
+		ResultTypeName = "NSLoadFromHtmlResult")]
+	public partial static void LoadFromHtml (NSUrlRequest request, NSDictionary options, NSAttributedStringCompletionHandler completionHandler);
+	
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[Export<Method> ("completeRequestReturningItems:completionHandler:", Flags = ObjCBindings.Method.Async)] 
+	public partial void CompleteRequest (NSExtensionItem [] returningItems, Action<bool>? completionHandler);
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
@@ -57,6 +57,8 @@ public partial class MethodTests {
 	[Export<Method> ("filteredArrayUsingPredicate:")]
 	public partial NSArray Filter (NSPredicate predicate);
 	
+#if !__TVOS__
+	
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
@@ -65,6 +67,8 @@ public partial class MethodTests {
 		Flags = ObjCBindings.Method.Async, 
 		ResultTypeName = "NSLoadFromHtmlResult")]
 	public partial static void LoadFromHtml (NSUrlRequest request, NSDictionary options, NSAttributedStringCompletionHandler completionHandler);
+	
+#endif
 	
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
@@ -56,9 +56,9 @@ public partial class MethodTests {
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[Export<Method> ("filteredArrayUsingPredicate:")]
 	public partial NSArray Filter (NSPredicate predicate);
-	
+
 #if !__TVOS__
-	
+
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
@@ -69,7 +69,7 @@ public partial class MethodTests {
 	public partial static void LoadFromHtml (NSUrlRequest request, NSDictionary options, NSAttributedStringCompletionHandler completionHandler);
 
 #endif
-	
+
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("macos")]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedMethodsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedMethodsTests.cs
@@ -42,10 +42,6 @@ public partial class MethodTests
 	static readonly global::ObjCRuntime.NativeHandle selFilteredArrayUsingPredicate_XHandle = global::ObjCRuntime.Selector.GetHandle ("filteredArrayUsingPredicate:");
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	const string selLoadFromHTMLWithRequest_Options_CompletionHandler_X = "loadFromHTMLWithRequest:options:completionHandler:";
-	static readonly global::ObjCRuntime.NativeHandle selLoadFromHTMLWithRequest_Options_CompletionHandler_XHandle = global::ObjCRuntime.Selector.GetHandle ("loadFromHTMLWithRequest:options:completionHandler:");
-
-	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	const string selCompleteRequestReturningItems_CompletionHandler_X = "completeRequestReturningItems:completionHandler:";
 	static readonly global::ObjCRuntime.NativeHandle selCompleteRequestReturningItems_CompletionHandler_XHandle = global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:");
 
@@ -170,26 +166,6 @@ public partial class MethodTests
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	public partial static global::Foundation.NSArray FromFile (string path)
-	{
-		throw new NotImplementedException ();
-	}
-
-	[SupportedOSPlatform ("macos")]
-	[SupportedOSPlatform ("ios")]
-	[UnsupportedOSPlatform ("tvos")]
-	[SupportedOSPlatform ("maccatalyst13.1")]
-	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial static void LoadFromHtml (global::Foundation.NSUrlRequest request, global::Foundation.NSDictionary options, global::.NSAttributedStringCompletionHandler completionHandler)
-	{
-		throw new NotImplementedException ();
-	}
-
-	[SupportedOSPlatform ("macos")]
-	[SupportedOSPlatform ("ios")]
-	[UnsupportedOSPlatform ("tvos")]
-	[SupportedOSPlatform ("maccatalyst13.1")]
-	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial static global::.NSAttributedStringCompletionHandler LoadFromHtmlAsync (global::Foundation.NSUrlRequest request, global::Foundation.NSDictionary options)
 	{
 		throw new NotImplementedException ();
 	}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedMethodsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedMethodsTests.cs
@@ -179,7 +179,7 @@ public partial class MethodTests
 	[UnsupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial static void LoadFromHtml (global::Foundation.NSUrlRequest request, global::Foundation.NSDictionary options, global::Foundation.NSAttributedStringCompletionHandler completionHandler)
+	public partial static void LoadFromHtml (global::Foundation.NSUrlRequest request, global::Foundation.NSDictionary options, global::.NSAttributedStringCompletionHandler completionHandler)
 	{
 		throw new NotImplementedException ();
 	}
@@ -189,7 +189,7 @@ public partial class MethodTests
 	[UnsupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial static global::System.Threading.Tasks.Task<NSLoadFromHtmlResult> LoadFromHtmlAsync (global::Foundation.NSUrlRequest request, global::Foundation.NSDictionary options)
+	public partial static global::.NSAttributedStringCompletionHandler LoadFromHtmlAsync (global::Foundation.NSUrlRequest request, global::Foundation.NSDictionary options)
 	{
 		throw new NotImplementedException ();
 	}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests/FromDeclarationTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests/FromDeclarationTests.cs
@@ -78,6 +78,87 @@ namespace NS {
 				)
 			];
 
+			const string asyncVoidMethodNoParamsExportDataMisingFlag = @"
+using System;
+using ObjCBindings;
+
+namespace NS {
+	public class MyClass {
+		[Export<Method>(""myMethod"", Flags = Method.Default,
+			ResultTypeName = ""NSObject"",
+			PostNonResultSnippet = ""throw new NotImplementedException();"")]
+		public void MyMethod () {}
+	}
+}
+";
+
+			yield return [
+				asyncVoidMethodNoParamsExportDataMisingFlag,
+				new Method (
+					type: "NS.MyClass",
+					name: "MyMethod",
+					returnType: ReturnTypeForVoid (),
+					symbolAvailability: new (),
+					exportMethodData: new ("myMethod"), // async valus are null
+					attributes: [
+						new (
+							name: "ObjCBindings.ExportAttribute<ObjCBindings.Method>", 
+							arguments: [
+								"myMethod", 
+								"ObjCBindings.Method.Default",
+								"NSObject", 
+								"throw new NotImplementedException();"
+							]),
+					],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					parameters: []
+				)
+			];
+
+			const string asyncVoidMethodNoParamsExportDataAsyncFlag = @"
+using System;
+using ObjCBindings;
+
+namespace NS {
+	public class MyClass {
+		[Export<Method>(""myMethod"", Flags = Method.Default | Method.Async,
+			ResultTypeName = ""NSObject"",
+			PostNonResultSnippet = ""throw new NotImplementedException();"")]
+		public void MyMethod () {}
+	}
+}
+";
+
+			yield return [
+				asyncVoidMethodNoParamsExportDataAsyncFlag,
+				new Method (
+					type: "NS.MyClass",
+					name: "MyMethod",
+					returnType: ReturnTypeForVoid (),
+					symbolAvailability: new (),
+					exportMethodData: new ("myMethod") {
+						Flags = ObjCBindings.Method.Default | ObjCBindings.Method.Async,
+						ResultTypeName = "NSObject",
+						PostNonResultSnippet = "throw new NotImplementedException();",
+					},
+					attributes: [
+						new (
+							name: "ObjCBindings.ExportAttribute<ObjCBindings.Method>", 
+							arguments: [
+								"myMethod", 
+								"NSObject", 
+								"throw new NotImplementedException();"
+							]),
+					],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					parameters: []
+				)
+			];
+
 			const string stringMethodNoParams = @"
 using System;
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests/FromDeclarationTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests/FromDeclarationTests.cs
@@ -102,11 +102,11 @@ namespace NS {
 					exportMethodData: new ("myMethod"), // async valus are null
 					attributes: [
 						new (
-							name: "ObjCBindings.ExportAttribute<ObjCBindings.Method>", 
+							name: "ObjCBindings.ExportAttribute<ObjCBindings.Method>",
 							arguments: [
-								"myMethod", 
+								"myMethod",
 								"ObjCBindings.Method.Default",
-								"NSObject", 
+								"NSObject",
 								"throw new NotImplementedException();"
 							]),
 					],
@@ -145,10 +145,10 @@ namespace NS {
 					},
 					attributes: [
 						new (
-							name: "ObjCBindings.ExportAttribute<ObjCBindings.Method>", 
+							name: "ObjCBindings.ExportAttribute<ObjCBindings.Method>",
 							arguments: [
-								"myMethod", 
-								"NSObject", 
+								"myMethod",
+								"NSObject",
 								"throw new NotImplementedException();"
 							]),
 					],

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests/FromDeclarationTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests/FromDeclarationTests.cs
@@ -877,4 +877,71 @@ namespace NS {
 		Assert.NotNull (changes);
 		Assert.Equal (expected, changes);
 	}
+	
+	class TestDataFromMethodDeclarationToAsync : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			const string simpleAsyncMethod = @"
+using System;
+using ObjCBindings;
+using ObjCRuntime;
+
+namespace NS {
+	public class MyClass {
+
+		[Export<Method> (""completeRequestReturningItems:completionHandler:"", Flags = ObjCBindings.Method.Async)] 
+		public void MyMethod (string[]? input, Action<bool> callback) { }
+	}
+}
+";
+
+			yield return [simpleAsyncMethod];
+			
+			const string asyncMethodWithName = @"
+using System;
+using ObjCBindings;
+using ObjCRuntime;
+
+namespace NS {
+	public class MyClass {
+
+		[Export<Method> (""completeRequestReturningItems:completionHandler:"", 
+			Flags = ObjCBindings.Method.Async,
+			MethodName = ""MyMethodAsync"")] 
+		public void MyMethod (string[]? input, Action<bool> callback) { }
+	}
+}
+";
+
+			yield return [asyncMethodWithName];
+
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataFromMethodDeclarationToAsync>]
+	void FromMethodDeclarationToAsync (ApplePlatform platform, string inputText)
+	{
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
+		Assert.Single (syntaxTrees);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ().OfType<MethodDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		Assert.True (Method.TryCreate (declaration, semanticModel, out var changes));
+		Assert.NotNull (changes);
+		
+		var asyncMethod = changes.Value.ToAsync ();
+		if (changes.Value.ExportMethodData.MethodName is null) {
+			Assert.Equal ($"{changes.Value.Name}Async", asyncMethod.Name);
+		} else {
+			Assert.Equal (changes.Value.ExportMethodData.MethodName, asyncMethod.Name);
+		}
+		Assert.False (asyncMethod.ReturnType.IsVoid);
+		Assert.True (asyncMethod.ReturnType.IsTask);
+		Assert.Equal (changes.Value.Parameters.Length - 1, asyncMethod.Parameters.Length);
+	}
 }


### PR DESCRIPTION
This commit adds the signatures of the async methods when a method is marked as Async. The code removes the last parameter of the original method - it is the callback - and updates the return type to be of the correct Task generic type.