### PR TITLE
[RGen] Generate the StrongDelegates property for a WeakDelegate.

### DIFF
--- a/src/ObjCBindings/ExportAttribute.cs
+++ b/src/ObjCBindings/ExportAttribute.cs
@@ -54,7 +54,7 @@ namespace ObjCBindings {
 		/// <summary>
 		/// The type of the result for an async method.
 		/// </summary>
-		public TypeInfo? ResultType { get; set; } = null;
+		public Type? ResultType { get; set; } = null;
 
 		/// <summary>
 		/// The name of the generated async method.
@@ -70,6 +70,16 @@ namespace ObjCBindings {
 		/// A code snippet to be executed after the async method call.
 		/// </summary>
 		public string? PostNonResultSnippet { get; set; } = null;
+
+		/// <summary>
+		/// The type of the strong delegate for a weak delegate property.
+		/// </summary>
+		public Type? StrongDelegateType { get; set; } = null;
+
+		/// <summary>
+		/// The name of the strong delegate for a weak delegate property.
+		/// </summary>
+		public string? StrongDelegateName { get; set; } = null;
 
 		protected ExportAttribute () { }
 

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/ExportData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/ExportData.cs
@@ -74,6 +74,16 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 	/// A code snippet to be executed after the async method call.
 	/// </summary>
 	public string? PostNonResultSnippet { get; init; }
+	
+	/// <summary>
+	/// The type of the strong delegate for a weak delegate property.
+	/// </summary>
+	public TypeInfo? StrongDelegateType { get; init; }
+	
+	/// <summary>
+	/// The name of the strong delegate for a weak delegate property.
+	/// </summary>
+	public string? StrongDelegateName{ get; init; }
 
 	public ExportData () { }
 
@@ -119,6 +129,9 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 		string? methodName = null;
 		string? resultTypeName = null;
 		string? postNonResultSnippet = null;
+		// weak delegate related data
+		TypeInfo? strongDelegateType = null;
+		string? strongDelegateName = null;
 
 		switch (count) {
 		case 1:
@@ -163,6 +176,7 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 
 		// from this point we have to check the name of the argument AND if the export method is an Async method.
 		var isAsync = typeof (T) == typeof (ObjCBindings.Method) && flags is not null && flags.HasFlag (ObjCBindings.Method.Async);
+		var isWeakDelegate = typeof (T) == typeof (ObjCBindings.Property) && flags is not null && flags.HasFlag (ObjCBindings.Property.WeakDelegate);
 
 		// loop over all the named arguments and set the data accordingly, ignore the Flags one since we already set it
 		foreach (var (name, value) in attrsDict) {
@@ -206,6 +220,17 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 					postNonResultSnippet = (string?) value;
 				}
 				break;
+			// weak delegate related data
+			case "StrongDelegateType":
+				if (isWeakDelegate) {
+					strongDelegateType = new ((INamedTypeSymbol) value!);
+				}
+				break;
+			case "StrongDelegateName":
+				if (isWeakDelegate) {
+					strongDelegateName = (string?) value!;
+				}
+				break;
 			default:
 				data = null;
 				return false;
@@ -221,7 +246,10 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 				ResultType = isAsync ? resultType : null,
 				MethodName = isAsync ? methodName : null,
 				ResultTypeName = isAsync ? resultTypeName : null,
-				PostNonResultSnippet = isAsync ? postNonResultSnippet : null
+				PostNonResultSnippet = isAsync ? postNonResultSnippet : null,
+				// we set the data for the weak delegate only if the flags are set
+				StrongDelegateType = isWeakDelegate ? strongDelegateType : null,
+				StrongDelegateName = isWeakDelegate ? strongDelegateName : null
 			};
 			return true;
 		}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
@@ -266,6 +266,19 @@ readonly partial struct Property {
 		return RequiresDirtyCheck == other.RequiresDirtyCheck;
 	}
 
+	public Property ToStrongDelegate ()
+	{
+		// has to be a property, weak delegate and have its strong delegate type set
+		if (!IsProperty || !IsWeakDelegate || ExportPropertyData.Value.StrongDelegateType is null)
+			return this;
+
+		// update the return type, all the rest is the same
+		return this with {
+			Name = ExportPropertyData.Value.StrongDelegateName ?? Name.Remove (0, 4 /* "Weak".Length */),
+			ReturnType = ExportPropertyData.Value.StrongDelegateType.Value.WithNullable (true),
+		};
+	}
+
 	/// <inheritdoc />
 	public override string ToString ()
 	{

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
@@ -18,7 +18,7 @@ readonly partial struct Property : IEquatable<Property> {
 	/// <summary>
 	/// Name of the property.
 	/// </summary>
-	public string Name { get; } = string.Empty;
+	public string Name { get; init; } = string.Empty;
 
 	readonly string? backingField = null;
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -556,20 +556,19 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	}
 
 	/// <summary>
-	/// If the current <see cref="TypeInfo"/> is nullable, this method returns a new <see cref="TypeInfo"/>
-	/// representing the non-nullable version of the type. Otherwise, it returns the current instance.
+	/// Returns a new <see cref="TypeInfo"/> with the specified nullability.
 	/// </summary>
+	/// <param name="isNullable">A boolean value indicating whether the new type should be nullable.</param>
 	/// <returns>
-	/// A new <see cref="TypeInfo"/> instance with <see cref="IsNullable"/> set to false if the original <see cref="IsNullable"/> was true;
-	/// otherwise, returns the current <see cref="TypeInfo"/> instance.
+	/// A new <see cref="TypeInfo"/> instance with the specified nullability. If the current instance already has the
+	/// specified nullability, the current instance is returned.
 	/// </returns>
-	public TypeInfo ToNonNullable ()
+	public TypeInfo WithNullable (bool isNullable)
 	{
-		if (!IsNullable)
+		if (IsNullable == isNullable)
 			return this;
-		// copy all the elements from the current array type and set the array type to false
 		return this with {
-			IsNullable = false,
+			IsNullable = isNullable,
 		};
 	}
 

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -1229,12 +1229,12 @@ static partial class BindingSyntaxFactory {
 			
 			// NSObject[] => CFArray.ArrayFromHandle<Foundation.NSMetadataItem> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, Selector.GetHandle ("results")))!;
 			{ Type.IsArray: true, Type.ArrayElementTypeIsWrapped: true }
-				=> GetCFArrayFromHandle (info.Type.ToArrayElementType ().ToNonNullable ().GetIdentifierSyntax (), [
+				=> GetCFArrayFromHandle (info.Type.ToArrayElementType ().WithNullable (isNullable: false).GetIdentifierSyntax (), [
 					Argument (expression)
 				], suppressNullableWarning: !info.Type.IsNullable), 
 			
 			{ Type.IsArray: true, Type.ArrayElementIsINativeObject: true }
-				=> GetCFArrayFromHandle (info.Type.ToArrayElementType ().ToNonNullable ().GetIdentifierSyntax (), [
+				=> GetCFArrayFromHandle (info.Type.ToArrayElementType ().WithNullable (isNullable: false).GetIdentifierSyntax (), [
 					Argument (expression)
 				], suppressNullableWarning: !info.Type.IsNullable), 
 			
@@ -1244,7 +1244,7 @@ static partial class BindingSyntaxFactory {
 			// Runtime.GetINativeObject<NSString> (auxVariable, false)!;
 			{ Type.IsINativeObject: true, Type.IsNSObject: false, ReleaseHandle: not null}
 				=> GetINativeObject (
-					nsObjectType: info.Type.ToNonNullable ().GetIdentifierSyntax (), 
+					nsObjectType: info.Type.WithNullable (isNullable: false).GetIdentifierSyntax (), 
 					args: [
 						Argument (expression),
 						BoolArgument (info.ReleaseHandle.Value)
@@ -1253,7 +1253,7 @@ static partial class BindingSyntaxFactory {
 			
 			{ Type.IsINativeObject: true, Type.IsNSObject: false, ReleaseHandle: null}
 				=> GetINativeObject (
-					nsObjectType: info.Type.ToNonNullable ().GetIdentifierSyntax (), 
+					nsObjectType: info.Type.WithNullable (isNullable: false).GetIdentifierSyntax (), 
 					args: [
 						Argument (expression),
 					], 
@@ -1263,7 +1263,7 @@ static partial class BindingSyntaxFactory {
 			// Runtime.GetNSObject<NSString> (auxVariable, false)!;
 			{ Type.IsNSObject: true, ReleaseHandle: not null} 
 				=> GetNSObject (
-					nsObjectType: info.Type.ToNonNullable ().GetIdentifierSyntax (), 
+					nsObjectType: info.Type.WithNullable (isNullable: false).GetIdentifierSyntax (), 
 					args: [
 						Argument (expression),
 						BoolArgument (false)
@@ -1272,7 +1272,7 @@ static partial class BindingSyntaxFactory {
 			
 			{ Type.IsNSObject: true, ReleaseHandle: null} 
 				=> GetNSObject (
-					nsObjectType: info.Type.ToNonNullable ().GetIdentifierSyntax (), 
+					nsObjectType: info.Type.WithNullable (isNullable: false).GetIdentifierSyntax (), 
 					args: [
 						Argument (expression),
 					],

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
@@ -208,7 +208,7 @@ static partial class BindingSyntaxFactory {
 			// parameters that are passed by reference, depend on the type that is referenced
 			{ IsByRef: true, Type.IsReferenceType: false, Type.IsNullable: true} 
 				=> (parameterIdentifier, 
-					PointerType (GetLowLevelType (parameterType.ToNonNullable ()))),
+					PointerType (GetLowLevelType (parameterType.WithNullable (isNullable: false)))),
 			
 			{ IsByRef: true, Type.IsReferenceType: false, Type.IsNullable: false} 
 				=> (parameterIdentifier, 
@@ -333,7 +333,7 @@ static partial class BindingSyntaxFactory {
 			
 			// Runtime.GetNSObject<ParameterType> (ParameterName) 
 			{ Type.IsNSObject: true, Type.IsNullable: true} =>
-				GetNSObject (parameterType.ToNonNullable ().GetIdentifierSyntax (), [
+				GetNSObject (parameterType.WithNullable (isNullable: false).GetIdentifierSyntax (), [
 					Argument (parameterIdentifier)
 				], suppressNullableWarning: false),
 			
@@ -345,7 +345,7 @@ static partial class BindingSyntaxFactory {
 			
 			// Runtime.GetINativeObject<ParameterType> (ParameterName, false)!
 			{ Type.IsINativeObject: true, Type.IsNullable: true } =>
-				GetINativeObject (parameterType.ToNonNullable ().GetIdentifierSyntax (), [
+				GetINativeObject (parameterType.WithNullable (isNullable: false).GetIdentifierSyntax (), [
 					Argument (parameterIdentifier), 
 					BoolArgument (false)
 				], suppressNullableWarning: false),

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
@@ -259,6 +259,33 @@ $@"if (IsDirectBinding) {{
 					}
 				}
 			}
+			
+			// if the property is a weak delegate and has the strong delegate type set, we need to emit the
+			// strong delegate property
+			if (property is { IsProperty: true, IsWeakDelegate: true } 
+			    && property.ExportPropertyData.Value.StrongDelegateType is not null) {
+				classBlock.WriteLine ();
+				var strongDelegate = property.ToStrongDelegate ();
+				using (var propertyBlock =
+				       classBlock.CreateBlock (strongDelegate.ToDeclaration ().ToString (), block: true)) {
+					using (var getterBlock = 
+					       propertyBlock.CreateBlock ("get", block: true)) {
+						getterBlock.WriteLine (
+							$"return {property.Name} as {strongDelegate.ReturnType.WithNullable (isNullable: false).GetIdentifierSyntax ()};");
+					}
+					
+					using (var setterBlock = 
+					       propertyBlock.CreateBlock ("set", block: true)) {
+						setterBlock.WriteRaw (
+$@"var rvalue = value as NSObject;
+if (!(value is null) && rvalue is null) {{
+	throw new ArgumentException ($""The object passed of type {{value.GetType ()}} does not derive from NSObject"");
+}}
+{property.Name} = rvalue;
+");
+					}
+				}
+			}
 		}
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/AVAudioPcmBufferDefaultCtr.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/AVAudioPcmBufferDefaultCtr.cs
@@ -1,3 +1,4 @@
+#pragma warning disable APL0003
 using System;
 using Foundation;
 using ObjCBindings;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/AVAudioPcmBufferNoDefaultCtr.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/AVAudioPcmBufferNoDefaultCtr.cs
@@ -1,3 +1,4 @@
+#pragma warning disable APL0003
 using System;
 using Foundation;
 using ObjCBindings;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/AVAudioPcmBufferNoNativeName.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/AVAudioPcmBufferNoNativeName.cs
@@ -1,3 +1,4 @@
+#pragma warning disable APL0003
 using System;
 using Foundation;
 using ObjCBindings;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/AppKitPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/AppKitPropertyTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma warning disable APL0003
 
 using System;
 using System.Runtime.Versioning;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/CIImage.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/CIImage.cs
@@ -1,3 +1,4 @@
+#pragma warning disable APL0003
 using System;
 using System.Runtime.Versioning;
 using Foundation;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma warning disable APL0003
 
 using System;
 using System.Runtime.Versioning;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/NSUserDefaults.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/NSUserDefaults.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma warning disable APL0003
 
 using System;
 using System.Runtime.Versioning;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/PropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/PropertyTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma warning disable APL0003
 
 using System;
 using System.Runtime.Versioning;
@@ -12,7 +13,7 @@ using nfloat = System.Runtime.InteropServices.NFloat;
 
 namespace TestNamespace;
 
-[BindingType<Class>]
+[BindingType<ObjCBindings.Class>]
 public partial class PropertyTests {
 
 	// the following are a list of examples of all possible property definitions
@@ -62,7 +63,7 @@ public partial class PropertyTests {
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
-	public virtual partial string? Name { get; set; }
+	public virtual partial string? OtherName { get; set; }
 
 	// array of strings
 	[Export<Property> ("surnames")]
@@ -70,7 +71,7 @@ public partial class PropertyTests {
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
-	public virtual partial string [] Name { get; set; }
+	public virtual partial string [] Names { get; set; }
 
 	// simple NSObject
 	[SupportedOSPlatform ("ios")]
@@ -85,7 +86,10 @@ public partial class PropertyTests {
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
-	[Export<Property> ("delegate", ArgumentSemantic.Weak, Flags = Property.WeakDelegate)]
+	[Export<Property> ("delegate", 
+		ArgumentSemantic.Weak, 
+		Flags = Property.WeakDelegate, 
+		StrongDelegateType = typeof (INSUserActivityDelegate))]
 	public virtual partial NSObject? WeakDelegate { get; set; }
 
 	// array nsobject
@@ -142,16 +146,6 @@ public partial class PropertyTests {
 		get;
 		[Export<Property> ("setLenient:")]
 		set;
-	}
-
-	// wrapper property example
-	[SupportedOSPlatform ("ios")]
-	[SupportedOSPlatform ("tvos")]
-	[SupportedOSPlatform ("macos")]
-	[SupportedOSPlatform ("maccatalyst13.1")]
-	public virtual INSMetadataQueryDelegate? Delegate {
-		get => WeakDelegate as INSMetadataQueryDelegate;
-		set => WeakDelegate = value;
 	}
 
 	// bindfrom

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ThreadSafeAppKitPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ThreadSafeAppKitPropertyTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma warning disable APL0003
 
 using System;
 using System.Runtime.Versioning;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ThreadSafeUIKitPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ThreadSafeUIKitPropertyTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma warning disable APL0003
 
 using System;
 using System.Runtime.Versioning;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/TrampolinePropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/TrampolinePropertyTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma warning disable APL0003
 
 namespace Microsoft.Macios.Generator.Tests.Classes.Data;
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/UIKitPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/UIKitPropertyTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma warning disable APL0003
 
 using System;
 using System.Runtime.Versioning;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
@@ -734,47 +734,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial string? Name
-	{
-		[SupportedOSPlatform ("macos")]
-		[SupportedOSPlatform ("ios")]
-		[SupportedOSPlatform ("tvos")]
-		[SupportedOSPlatform ("maccatalyst13.1")]
-		get
-		{
-			string? ret;
-			if (IsDirectBinding) {
-				ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("name")), false);
-			} else {
-				ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("name")), false);
-			}
-			global::System.GC.KeepAlive (this);
-			return ret;
-		}
-
-		[SupportedOSPlatform ("macos")]
-		[SupportedOSPlatform ("ios")]
-		[SupportedOSPlatform ("tvos")]
-		[SupportedOSPlatform ("maccatalyst13.1")]
-		set
-		{
-			var nsvalue = global::CoreFoundation.CFString.CreateNative (value);
-			if (IsDirectBinding) {
-				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setName:"), nsvalue);
-			} else {
-				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setName:"), nsvalue);
-			}
-			global::System.GC.KeepAlive (this);
-			global::CoreFoundation.CFString.ReleaseNative (nsvalue);
-		}
-	}
-
-	[SupportedOSPlatform ("macos")]
-	[SupportedOSPlatform ("ios")]
-	[SupportedOSPlatform ("tvos")]
-	[SupportedOSPlatform ("maccatalyst13.1")]
-	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial string[] Name
+	public virtual partial string[] Names
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -808,6 +768,46 @@ public partial class PropertyTests
 			}
 			global::System.GC.KeepAlive (this);
 			global::System.GC.KeepAlive (nsa_value);
+		}
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public virtual partial string? OtherName
+	{
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("ios")]
+		[SupportedOSPlatform ("tvos")]
+		[SupportedOSPlatform ("maccatalyst13.1")]
+		get
+		{
+			string? ret;
+			if (IsDirectBinding) {
+				ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("name")), false);
+			} else {
+				ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("name")), false);
+			}
+			global::System.GC.KeepAlive (this);
+			return ret;
+		}
+
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("ios")]
+		[SupportedOSPlatform ("tvos")]
+		[SupportedOSPlatform ("maccatalyst13.1")]
+		set
+		{
+			var nsvalue = global::CoreFoundation.CFString.CreateNative (value);
+			if (IsDirectBinding) {
+				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setName:"), nsvalue);
+			} else {
+				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setName:"), nsvalue);
+			}
+			global::System.GC.KeepAlive (this);
+			global::CoreFoundation.CFString.ReleaseNative (nsvalue);
 		}
 	}
 
@@ -1023,6 +1023,22 @@ public partial class PropertyTests
 			global::System.GC.KeepAlive (value);
 			MarkDirty ();
 			__mt_WeakDelegate_var = value;
+		}
+	}
+
+	public virtual partial global::Foundation.INSUserActivityDelegate? Delegate
+	{
+		get
+		{
+			return WeakDelegate as global::Foundation.INSUserActivityDelegate;
+		}
+		set
+		{
+			var rvalue = value as NSObject;
+			if (!(value is null) && rvalue is null) {
+				throw new ArgumentException ($"The object passed of type {value.GetType ()} does not derive from NSObject");
+			}
+			WeakDelegate = rvalue;
 		}
 	}
 	// TODO: add binding code here

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
@@ -734,47 +734,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial string? Name
-	{
-		[SupportedOSPlatform ("macos")]
-		[SupportedOSPlatform ("ios")]
-		[SupportedOSPlatform ("tvos")]
-		[SupportedOSPlatform ("maccatalyst13.1")]
-		get
-		{
-			string? ret;
-			if (IsDirectBinding) {
-				ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("name")), false);
-			} else {
-				ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("name")), false);
-			}
-			global::System.GC.KeepAlive (this);
-			return ret;
-		}
-
-		[SupportedOSPlatform ("macos")]
-		[SupportedOSPlatform ("ios")]
-		[SupportedOSPlatform ("tvos")]
-		[SupportedOSPlatform ("maccatalyst13.1")]
-		set
-		{
-			var nsvalue = global::CoreFoundation.CFString.CreateNative (value);
-			if (IsDirectBinding) {
-				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setName:"), nsvalue);
-			} else {
-				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setName:"), nsvalue);
-			}
-			global::System.GC.KeepAlive (this);
-			global::CoreFoundation.CFString.ReleaseNative (nsvalue);
-		}
-	}
-
-	[SupportedOSPlatform ("macos")]
-	[SupportedOSPlatform ("ios")]
-	[SupportedOSPlatform ("tvos")]
-	[SupportedOSPlatform ("maccatalyst13.1")]
-	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial string[] Name
+	public virtual partial string[] Names
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -808,6 +768,46 @@ public partial class PropertyTests
 			}
 			global::System.GC.KeepAlive (this);
 			global::System.GC.KeepAlive (nsa_value);
+		}
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public virtual partial string? OtherName
+	{
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("ios")]
+		[SupportedOSPlatform ("tvos")]
+		[SupportedOSPlatform ("maccatalyst13.1")]
+		get
+		{
+			string? ret;
+			if (IsDirectBinding) {
+				ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("name")), false);
+			} else {
+				ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("name")), false);
+			}
+			global::System.GC.KeepAlive (this);
+			return ret;
+		}
+
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("ios")]
+		[SupportedOSPlatform ("tvos")]
+		[SupportedOSPlatform ("maccatalyst13.1")]
+		set
+		{
+			var nsvalue = global::CoreFoundation.CFString.CreateNative (value);
+			if (IsDirectBinding) {
+				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setName:"), nsvalue);
+			} else {
+				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setName:"), nsvalue);
+			}
+			global::System.GC.KeepAlive (this);
+			global::CoreFoundation.CFString.ReleaseNative (nsvalue);
 		}
 	}
 
@@ -1023,6 +1023,22 @@ public partial class PropertyTests
 			global::System.GC.KeepAlive (value);
 			MarkDirty ();
 			__mt_WeakDelegate_var = value;
+		}
+	}
+
+	public virtual partial global::Foundation.INSUserActivityDelegate? Delegate
+	{
+		get
+		{
+			return WeakDelegate as global::Foundation.INSUserActivityDelegate;
+		}
+		set
+		{
+			var rvalue = value as NSObject;
+			if (!(value is null) && rvalue is null) {
+				throw new ArgumentException ($"The object passed of type {value.GetType ()} does not derive from NSObject");
+			}
+			WeakDelegate = rvalue;
 		}
 	}
 	// TODO: add binding code here

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
@@ -734,47 +734,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial string? Name
-	{
-		[SupportedOSPlatform ("macos")]
-		[SupportedOSPlatform ("ios")]
-		[SupportedOSPlatform ("tvos")]
-		[SupportedOSPlatform ("maccatalyst13.1")]
-		get
-		{
-			string? ret;
-			if (IsDirectBinding) {
-				ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("name")), false);
-			} else {
-				ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("name")), false);
-			}
-			global::System.GC.KeepAlive (this);
-			return ret;
-		}
-
-		[SupportedOSPlatform ("macos")]
-		[SupportedOSPlatform ("ios")]
-		[SupportedOSPlatform ("tvos")]
-		[SupportedOSPlatform ("maccatalyst13.1")]
-		set
-		{
-			var nsvalue = global::CoreFoundation.CFString.CreateNative (value);
-			if (IsDirectBinding) {
-				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setName:"), nsvalue);
-			} else {
-				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setName:"), nsvalue);
-			}
-			global::System.GC.KeepAlive (this);
-			global::CoreFoundation.CFString.ReleaseNative (nsvalue);
-		}
-	}
-
-	[SupportedOSPlatform ("macos")]
-	[SupportedOSPlatform ("ios")]
-	[SupportedOSPlatform ("tvos")]
-	[SupportedOSPlatform ("maccatalyst13.1")]
-	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial string[] Name
+	public virtual partial string[] Names
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -808,6 +768,46 @@ public partial class PropertyTests
 			}
 			global::System.GC.KeepAlive (this);
 			global::System.GC.KeepAlive (nsa_value);
+		}
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public virtual partial string? OtherName
+	{
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("ios")]
+		[SupportedOSPlatform ("tvos")]
+		[SupportedOSPlatform ("maccatalyst13.1")]
+		get
+		{
+			string? ret;
+			if (IsDirectBinding) {
+				ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("name")), false);
+			} else {
+				ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("name")), false);
+			}
+			global::System.GC.KeepAlive (this);
+			return ret;
+		}
+
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("ios")]
+		[SupportedOSPlatform ("tvos")]
+		[SupportedOSPlatform ("maccatalyst13.1")]
+		set
+		{
+			var nsvalue = global::CoreFoundation.CFString.CreateNative (value);
+			if (IsDirectBinding) {
+				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setName:"), nsvalue);
+			} else {
+				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setName:"), nsvalue);
+			}
+			global::System.GC.KeepAlive (this);
+			global::CoreFoundation.CFString.ReleaseNative (nsvalue);
 		}
 	}
 
@@ -1023,6 +1023,22 @@ public partial class PropertyTests
 			global::System.GC.KeepAlive (value);
 			MarkDirty ();
 			__mt_WeakDelegate_var = value;
+		}
+	}
+
+	public virtual partial global::Foundation.INSUserActivityDelegate? Delegate
+	{
+		get
+		{
+			return WeakDelegate as global::Foundation.INSUserActivityDelegate;
+		}
+		set
+		{
+			var rvalue = value as NSObject;
+			if (!(value is null) && rvalue is null) {
+				throw new ArgumentException ($"The object passed of type {value.GetType ()} does not derive from NSObject");
+			}
+			WeakDelegate = rvalue;
 		}
 	}
 	// TODO: add binding code here


### PR DESCRIPTION
This commit allows to generate the strong delegate for a weak delegate in a bindings. The API provides two ways to configure the strong property:

1. StrongDelegateType: provide a Type for the new property.
2. StrongDelegateName: Allow to choose the generated property name. If empty the name will be the name of the WeakDelefate with the Weak prefix removed.

We have some tests updates:

1. Remove the warnings from the tests. Some are due to the API being experimenta, other due to a rename. We will remove all errors in a comming PR.
2. Remove the strong delegate property from the test source since it is now generated.

This completes the work for support properties (so far).