### PR TITLE
[RGen] If not class is provide for an Async method use Tuples.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/DelegateInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/DelegateInfo.cs
@@ -18,7 +18,7 @@ sealed record DelegateInfo {
 	/// Method name.
 	/// </summary>
 	public string Name { get; }
-	
+
 	/// <summary>
 	/// The fully qualified type name of the delegate.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/DelegateInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/DelegateInfo.cs
@@ -18,6 +18,11 @@ sealed record DelegateInfo {
 	/// Method name.
 	/// </summary>
 	public string Name { get; }
+	
+	/// <summary>
+	/// The fully qualified type name of the delegate.
+	/// </summary>
+	public string FullyQualifiedType { get; init; }
 
 	/// <summary>
 	/// Method return type.
@@ -39,9 +44,10 @@ sealed record DelegateInfo {
 	/// </summary>
 	public ImmutableArray<DelegateParameter> Parameters { get; } = [];
 
-	public DelegateInfo (string name, TypeInfo returnType, ImmutableArray<DelegateParameter> parameters)
+	public DelegateInfo (string name, string delegateType, TypeInfo returnType, ImmutableArray<DelegateParameter> parameters)
 	{
 		Name = name;
+		FullyQualifiedType = delegateType;
 		ReturnType = returnType;
 		Parameters = parameters;
 	}
@@ -53,6 +59,7 @@ sealed record DelegateInfo {
 			return false;
 		}
 
+		var type = symbol.ToDisplayString ();
 		var method = symbol.DelegateInvokeMethod;
 		var parametersBucket = ImmutableArray.CreateBuilder<DelegateParameter> ();
 		// loop over the parameters of the construct since changes on those implies a change in the generated code
@@ -64,6 +71,7 @@ sealed record DelegateInfo {
 
 		change = new (
 			name: method.Name,
+			delegateType: type,
 			returnType: new (method.ReturnType),
 			parameters: parametersBucket.ToImmutableArray ()) {
 			IsBlockCallback = symbol.HasAttribute (AttributesNames.BlockCallbackAttribute),
@@ -78,6 +86,8 @@ sealed record DelegateInfo {
 		if (other is null)
 			return false;
 		if (Name != other.Name)
+			return false;
+		if (FullyQualifiedType != other.FullyQualifiedType)
 			return false;
 		if (ReturnType != other.ReturnType)
 			return false;

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -191,6 +191,17 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// True if the type represents a ObjC protocol.
 	/// </summary>
 	public bool IsProtocol { get; init; }
+	
+	/// <summary>
+	/// True if the type represents a named tuple.
+	/// </summary>
+	public bool IsNamedTuple { get; init; }
+
+	/// <summary>
+	/// Array of named tuple field names and their types. We use an array of key-value pairs instead of a dictionary
+	/// because we care about the order in which the values were added.
+	/// </summary>
+	public ImmutableArray<KeyValuePair<string, string>> NamedTupleFields { get; init; } = [];
 
 	readonly ImmutableArray<string> parents = [];
 	/// <summary>
@@ -352,19 +363,32 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		// store the enum special type, useful when generate code that needs to cast
 		EnumUnderlyingType = namedTypeSymbol?.EnumUnderlyingType?.SpecialType;
 		if (namedTypeSymbol is not null) {
-			IsGenericType = namedTypeSymbol.IsGenericType;
-			var typeArgumentsBucket = ImmutableArray.CreateBuilder<string> (namedTypeSymbol.TypeArguments.Length);
-			foreach (var typeArgument in namedTypeSymbol.TypeArguments) {
-				// rather than use the display name, which could be a generic name, we will create a struct for the 
-				// type and use our type formater
-				var info = new TypeInfo (typeArgument);
-				var syntax = info.GetIdentifierSyntax ();
-				typeArgumentsBucket.Add (syntax.ToString ());
+			// if we are dealing with a tuple type, we will set the named tuple fields otherwise we try to retrieve the 
+			// generic type arguments
+			if (!namedTypeSymbol.TupleElements.IsDefaultOrEmpty) {
+				IsNamedTuple = true;
+				var namedTupleFieldsBucket = ImmutableArray.CreateBuilder<KeyValuePair<string, string>> (namedTypeSymbol.TupleElements.Length);
+				foreach (var field in namedTypeSymbol.TupleElements) {
+					var currentType = new TypeInfo (field.Type);
+					namedTupleFieldsBucket.Add (new (field.Name, currentType.GetIdentifierSyntax ().ToString ()));
+				}
+				NamedTupleFields = namedTupleFieldsBucket.ToImmutable ();
+			} else {
+				IsGenericType = namedTypeSymbol.IsGenericType;
+				var typeArgumentsBucket = ImmutableArray.CreateBuilder<string> (namedTypeSymbol.TypeArguments.Length);
+				foreach (var typeArgument in namedTypeSymbol.TypeArguments) {
+					// rather than use the display name, which could be a generic name, we will create a struct for the 
+					// type and use our type formater
+					var info = new TypeInfo (typeArgument);
+					var syntax = info.GetIdentifierSyntax ();
+					typeArgumentsBucket.Add (syntax.ToString ());
+				}
+
+				TypeArguments = typeArgumentsBucket.ToImmutable ();
 			}
-			TypeArguments = typeArgumentsBucket.ToImmutable ();
 
 			if (namedTypeSymbol.DelegateInvokeMethod is not null &&
-				DelegateInfo.TryCreate (namedTypeSymbol, out var delegateInfo))
+			    DelegateInfo.TryCreate (namedTypeSymbol, out var delegateInfo))
 				Delegate = delegateInfo;
 		}
 
@@ -598,7 +622,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// This method extracts the parameter types from the delegate. If the last parameter is an <c>NSError</c>,
 	/// it is omitted from the returned types, as it will be handled as an exception in the async method.
 	/// </remarks>
-	ImmutableArray<string> GetDelegateTypesForTask ()
+	ImmutableArray<KeyValuePair<string, string>> GetDelegateTypesForTask ()
 	{
 		if (Delegate is null)
 			return [];
@@ -606,13 +630,17 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		// get all the type information from the delegate parameters since this is what is needed for 
 		// the task type. It is important to remember that for async methods in objc if the last parameter is a
 		// a NSError we will drop it since that will be converted to an exception in the generated code.
-		var delegateTypes = Delegate.Parameters.Select (p => p.Type).ToArray ();
-		if (delegateTypes.Length > 0 && delegateTypes [^1].Name.Contains ("NSError")) {
+		var builder = ImmutableArray.CreateBuilder<KeyValuePair<string, string>> (Delegate.Parameters.Length);
+		foreach (var param in Delegate.Parameters) {
+			builder.Add (new (param.Name, param.Type.GetIdentifierSyntax ().ToString ()));
+		}
+		var delegateTypes = builder.ToImmutableArray ();
+		if (delegateTypes.Length > 0 && delegateTypes [^1].Value.Contains ("NSError")) {
 			// remove the last parameter since it is not needed for the task type
 			delegateTypes = delegateTypes [..^1];
 		}
 
-		return [.. delegateTypes.Select (t => t.GetIdentifierSyntax ().ToString ())];
+		return delegateTypes;
 	}
 
 	/// <summary>
@@ -630,7 +658,24 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		if (Delegate is null)
 			return this;
 
-		var genericTypeArguments = GetDelegateTypesForTask ();
+		var delegateTypes= GetDelegateTypesForTask ();
+		var genericTypeArguments = ImmutableArray.CreateBuilder<string> (delegateTypes.Length);
+		if (delegateTypes.Length > 1) {
+			// we need to create a named tuple or tuple, that depends on the type of delegate type, if we are
+			// dealing with a Action or Func, we will create a tuple type else we will create a named tuple type.
+			if (Delegate.FullyQualifiedType.Contains ("Action")) {
+				// we are dealing with a tuple type, so we will use the tuple syntax
+				genericTypeArguments.Add ($"({string.Join (", ", delegateTypes.Select (d => d.Value))})");
+			} else {
+				// we are dealing with a named tuple type, so we will use the named tuple syntax
+				var namedTuple = string.Join (", ", delegateTypes.Select (d => $"{d.Value} {d.Key.Capitalize ()}"));
+				genericTypeArguments.Add ($"({namedTuple})");
+			}
+			
+		} else if (delegateTypes.Length == 1) {
+			genericTypeArguments.Add (delegateTypes[0].Value);
+		}
+		
 		// generate a task type that will contain the delegate type information.
 		return new TypeInfo (
 			name: "System.Threading.Tasks.Task",
@@ -644,9 +689,9 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		) {
 			Delegate = null,
 			EnumUnderlyingType = null,
-			IsGenericType = genericTypeArguments.Length > 0,
+			IsGenericType = genericTypeArguments.Count > 0,
 			IsTask = true,
-			TypeArguments = genericTypeArguments,
+			TypeArguments = genericTypeArguments.ToImmutable (),
 		};
 	}
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -191,7 +191,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// True if the type represents a ObjC protocol.
 	/// </summary>
 	public bool IsProtocol { get; init; }
-	
+
 	/// <summary>
 	/// True if the type represents a named tuple.
 	/// </summary>
@@ -388,7 +388,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 			}
 
 			if (namedTypeSymbol.DelegateInvokeMethod is not null &&
-			    DelegateInfo.TryCreate (namedTypeSymbol, out var delegateInfo))
+				DelegateInfo.TryCreate (namedTypeSymbol, out var delegateInfo))
 				Delegate = delegateInfo;
 		}
 
@@ -658,7 +658,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		if (Delegate is null)
 			return this;
 
-		var delegateTypes= GetDelegateTypesForTask ();
+		var delegateTypes = GetDelegateTypesForTask ();
 		var genericTypeArguments = ImmutableArray.CreateBuilder<string> (delegateTypes.Length);
 		if (delegateTypes.Length > 1) {
 			// we need to create a named tuple or tuple, that depends on the type of delegate type, if we are
@@ -671,11 +671,11 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 				var namedTuple = string.Join (", ", delegateTypes.Select (d => $"{d.Value} {d.Key.Capitalize ()}"));
 				genericTypeArguments.Add ($"({namedTuple})");
 			}
-			
+
 		} else if (delegateTypes.Length == 1) {
-			genericTypeArguments.Add (delegateTypes[0].Value);
+			genericTypeArguments.Add (delegateTypes [0].Value);
 		}
-		
+
 		// generate a task type that will contain the delegate type information.
 		return new TypeInfo (
 			name: "System.Threading.Tasks.Task",

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Runtime.cs
@@ -447,8 +447,14 @@ static partial class BindingSyntaxFactory {
 	/// <param name="type">The information of the type of object to be created.</param>
 	/// <param name="arguments">The argument list for the object creation expression.</param>
 	/// <returns>An object creation expression.</returns>
-	internal static ObjectCreationExpressionSyntax New (in TypeInfo type, ImmutableArray<ArgumentSyntax> arguments)
-		=> New (type.GetIdentifierSyntax (), arguments);
+	internal static ExpressionSyntax New (in TypeInfo type, ImmutableArray<ArgumentSyntax> arguments)
+	{
+		if (type.IsNamedTuple) {
+			// special case for named tuples, we need to use the tuple type syntax	
+			return TupleExpression (SeparatedList<ArgumentSyntax> (arguments.ToSyntaxNodeOrTokenArray ()));
+		}
+		return New (type.GetIdentifierSyntax (), arguments);
+	}
 
 	/// <summary>
 	/// Generates a nameof(variableName) expression.

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
@@ -748,7 +748,7 @@ static partial class BindingSyntaxFactory {
 
 		var parametersSyntax = ParameterList (
 			SeparatedList<ParameterSyntax> (
-				parameterBucket.ToImmutableArray ().ToSyntaxNodeOrTokenArray ())).NormalizeWhitespace ();
+				parameterBucket.ToSyntaxNodeOrTokenArray ())).NormalizeWhitespace ();
 		return parametersSyntax;
 	}
 
@@ -803,7 +803,7 @@ static partial class BindingSyntaxFactory {
 		// that is, the block ptr, the parameters and the return type
 		var parametersSyntax = FunctionPointerParameterList (
 			SeparatedList<FunctionPointerParameterSyntax> (
-				parameterBucket.ToImmutableArray ().ToSyntaxNodeOrTokenArray ())).NormalizeWhitespace ();
+				parameterBucket.ToSyntaxNodeOrTokenArray ())).NormalizeWhitespace ();
 
 		// function pointer type
 		var pointerType = FunctionPointerType ()
@@ -869,7 +869,7 @@ static partial class BindingSyntaxFactory {
 
 		var parametersSyntax = ParameterList (
 			SeparatedList<ParameterSyntax> (
-				parameterBucket.ToImmutableArray ().ToSyntaxNodeOrTokenArray ())).NormalizeWhitespace ();
+				parameterBucket.ToSyntaxNodeOrTokenArray ())).NormalizeWhitespace ();
 
 		var returnType = delegateTypeInfo.Delegate!.ReturnType.IsVoid
 			? PredefinedType (Token (SyntaxKind.VoidKeyword))

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/ArgumentSyntaxExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/ArgumentSyntaxExtensions.cs
@@ -10,6 +10,13 @@ namespace Microsoft.Macios.Generator.Extensions;
 
 static class ArgumentSyntaxExtensions {
 
+	/// <summary>
+	/// Converts an immutable array of syntax nodes to an array of syntax nodes and tokens,
+	/// inserting commas between each node for use in syntax separated lists.
+	/// </summary>
+	/// <typeparam name="T">The type of syntax nodes in the array.</typeparam>
+	/// <param name="arguments">The immutable array of syntax nodes to convert.</param>
+	/// <returns>An array of syntax nodes and tokens with commas inserted between nodes.</returns>
 	public static SyntaxNodeOrToken [] ToSyntaxNodeOrTokenArray<T> (this ImmutableArray<T> arguments) where T : CSharpSyntaxNode
 	{
 		// the size of the array is simple to calculate, we need space for all parameters
@@ -31,5 +38,16 @@ static class ArgumentSyntaxExtensions {
 
 		return nodes;
 	}
+
+	/// <summary>
+	/// Converts an immutable array builder of syntax nodes to an array of syntax nodes and tokens,
+	/// inserting commas between each node for use in syntax separated lists.
+	/// </summary>
+	/// <typeparam name="T">The type of syntax nodes in the array builder.</typeparam>
+	/// <param name="arguments">The immutable array builder of syntax nodes to convert.</param>
+	/// <returns>An array of syntax nodes and tokens with commas inserted between nodes.</returns>
+	public static SyntaxNodeOrToken [] ToSyntaxNodeOrTokenArray<T> (this ImmutableArray<T>.Builder arguments)
+		where T : CSharpSyntaxNode
+		=> arguments.ToImmutable ().ToSyntaxNodeOrTokenArray ();
 
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedMethodsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedMethodsTests.cs
@@ -159,6 +159,46 @@ public partial class MethodTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public partial void CompleteRequest (global::Foundation.NSExtensionItem[] returningItems, global::System.Action<bool, string?>? completionHandler)
+	{
+		throw new NotImplementedException ();
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public partial global::System.Threading.Tasks.Task<(bool, string?)> CompleteRequestAsync (global::Foundation.NSExtensionItem[] returningItems)
+	{
+		throw new NotImplementedException ();
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public partial void CompleteRequest (global::Foundation.NSExtensionItem[] returningItems, global::System.Action<bool, string, string?>? completionHandler)
+	{
+		throw new NotImplementedException ();
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public partial global::System.Threading.Tasks.Task<(bool Success, string Name, string? Surname)> CompleteRequestAsync (global::Foundation.NSExtensionItem[] returningItems)
+	{
+		throw new NotImplementedException ();
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	public partial global::Foundation.NSArray Filter (global::Foundation.NSPredicate predicate)
 	{
 		throw new NotImplementedException ();
@@ -190,6 +230,26 @@ public partial class MethodTests
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	public partial static global::System.Threading.Tasks.Task<NSLoadFromHtmlResult> LoadFromHtmlAsync (global::Foundation.NSUrlRequest request, global::Foundation.NSDictionary options)
+	{
+		throw new NotImplementedException ();
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[UnsupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public partial static void LoadFromHtmlNoName (global::Foundation.NSUrlRequest request, global::Foundation.NSDictionary options, global::Foundation.NSAttributedStringCompletionHandler completionHandler)
+	{
+		throw new NotImplementedException ();
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[UnsupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public partial static global::System.Threading.Tasks.Task<(global::Foundation.NSAttributedString? AttributedString, global::Foundation.NSDictionary<global::Foundation.NSString, global::Foundation.NSObject>? Attributes)> LoadFromHtmlNoNameAsync (global::Foundation.NSUrlRequest request, global::Foundation.NSDictionary options)
 	{
 		throw new NotImplementedException ();
 	}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
@@ -68,7 +68,7 @@ public partial class MethodTests {
 		Flags = ObjCBindings.Method.Async,
 		ResultTypeName = "NSLoadFromHtmlResult")]
 	public partial static void LoadFromHtml (NSUrlRequest request, NSDictionary options, NSAttributedStringCompletionHandler completionHandler);
-	
+
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
@@ -85,20 +85,20 @@ public partial class MethodTests {
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[Export<Method> ("completeRequestReturningItems:completionHandler:", Flags = ObjCBindings.Method.Async)]
 	public partial void CompleteRequest (NSExtensionItem [] returningItems, Action<bool>? completionHandler);
-	
+
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[Export<Method> ("completeRequestReturningItems:completionHandler:", Flags = ObjCBindings.Method.Async)]
 	public partial void CompleteRequest (NSExtensionItem [] returningItems, Action<bool, string?>? completionHandler);
-	
+
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[Export<Method> ("completeRequestReturningItems:completionHandler:",
 		Flags = ObjCBindings.Method.Async,
-		ResultType = typeof((bool Success, string Name, string? Surname)))]
+		ResultType = typeof ((bool Success, string Name, string? Surname)))]
 	public partial void CompleteRequest (NSExtensionItem [] returningItems, Action<bool, string, string?>? completionHandler);
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
@@ -68,6 +68,14 @@ public partial class MethodTests {
 		Flags = ObjCBindings.Method.Async,
 		ResultTypeName = "NSLoadFromHtmlResult")]
 	public partial static void LoadFromHtml (NSUrlRequest request, NSDictionary options, NSAttributedStringCompletionHandler completionHandler);
+	
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[UnsupportedOSPlatform ("tvos")]
+	[Export<Method> ("loadFromHTMLWithRequest:options:completionHandler:",
+		Flags = ObjCBindings.Method.Async)]
+	public partial static void LoadFromHtmlNoName (NSUrlRequest request, NSDictionary options, NSAttributedStringCompletionHandler completionHandler);
 
 #endif
 
@@ -77,4 +85,20 @@ public partial class MethodTests {
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[Export<Method> ("completeRequestReturningItems:completionHandler:", Flags = ObjCBindings.Method.Async)]
 	public partial void CompleteRequest (NSExtensionItem [] returningItems, Action<bool>? completionHandler);
+	
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[Export<Method> ("completeRequestReturningItems:completionHandler:", Flags = ObjCBindings.Method.Async)]
+	public partial void CompleteRequest (NSExtensionItem [] returningItems, Action<bool, string?>? completionHandler);
+	
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[Export<Method> ("completeRequestReturningItems:completionHandler:",
+		Flags = ObjCBindings.Method.Async,
+		ResultType = typeof((bool Success, string Name, string? Surname)))]
+	public partial void CompleteRequest (NSExtensionItem [] returningItems, Action<bool, string, string?>? completionHandler);
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedMethodsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedMethodsTests.cs
@@ -155,6 +155,46 @@ public partial class MethodTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public partial void CompleteRequest (global::Foundation.NSExtensionItem[] returningItems, global::System.Action<bool, string?>? completionHandler)
+	{
+		throw new NotImplementedException ();
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public partial global::System.Threading.Tasks.Task<(bool, string?)> CompleteRequestAsync (global::Foundation.NSExtensionItem[] returningItems)
+	{
+		throw new NotImplementedException ();
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public partial void CompleteRequest (global::Foundation.NSExtensionItem[] returningItems, global::System.Action<bool, string, string?>? completionHandler)
+	{
+		throw new NotImplementedException ();
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public partial global::System.Threading.Tasks.Task<(bool Success, string Name, string? Surname)> CompleteRequestAsync (global::Foundation.NSExtensionItem[] returningItems)
+	{
+		throw new NotImplementedException ();
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	public partial global::Foundation.NSArray Filter (global::Foundation.NSPredicate predicate)
 	{
 		throw new NotImplementedException ();

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/DelegateInfoTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/DelegateInfoTests.cs
@@ -46,6 +46,7 @@ namespace NS {
 							type: ReturnTypeForAction (
 								delegateInfo: new (
 									name: "Invoke",
+									delegateType: "System.Action",
 									returnType: ReturnTypeForVoid (),
 									parameters: []
 								)
@@ -84,6 +85,7 @@ namespace NS {
 							type: ReturnTypeForAction (
 								delegateInfo: new (
 									name: "Invoke",
+									delegateType: "System.Action<string>",
 									returnType: ReturnTypeForVoid (),
 									parameters: [
 										new (
@@ -128,6 +130,7 @@ namespace NS {
 							type: ReturnTypeForAction (
 								delegateInfo: new (
 									name: "Invoke",
+									delegateType: "System.Action<string?>",
 									returnType: ReturnTypeForVoid (),
 									parameters: [
 										new (
@@ -172,6 +175,7 @@ namespace NS {
 							type: ReturnTypeForAction (
 								delegateInfo: new (
 									name: "Invoke",
+									delegateType: "System.Action<string, string>",
 									returnType: ReturnTypeForVoid (),
 									parameters: [
 										new (
@@ -221,6 +225,7 @@ namespace NS {
 							type: ReturnTypeForFunc (
 								delegateInfo: new (
 									name: "Invoke",
+									delegateType: "System.Func<string, string>",
 									returnType: ReturnTypeForString (),
 									parameters: [
 										new (
@@ -265,6 +270,7 @@ namespace NS {
 							type: ReturnTypeForFunc (
 								delegateInfo: new (
 									name: "Invoke",
+									delegateType: "System.Func<string, string, string>",
 									returnType: ReturnTypeForString (),
 									parameters: [
 										new (
@@ -317,6 +323,7 @@ namespace NS {
 								"NS.MyClass.Callback",
 								delegateInfo: new (
 									name: "Invoke",
+									delegateType: "NS.MyClass.Callback",
 									returnType: ReturnTypeForInt (isNullable: true),
 									parameters: [
 										new (
@@ -382,6 +389,7 @@ namespace NS {
 								"NS.MyClass.Callback",
 								delegateInfo: new (
 									name: "Invoke",
+									delegateType: "NS.MyClass.Callback",
 									returnType: ReturnTypeForInt (isNullable: true),
 									parameters: [
 										new (
@@ -438,6 +446,7 @@ namespace NS {
 								"NS.MyClass.Callback",
 								delegateInfo: new (
 									name: "Invoke",
+									delegateType: "NS.MyClass.Callback",
 									returnType: ReturnTypeForInt (isNullable: true),
 									parameters: [
 										new (
@@ -500,6 +509,7 @@ namespace NS {
 								"NS.MyClass.Callback",
 								delegateInfo: new (
 									name: "Invoke",
+									delegateType: "NS.MyClass.Callback",
 									returnType: ReturnTypeForInt (isNullable: true),
 									parameters: [
 										new (
@@ -555,6 +565,7 @@ namespace NS {
 								"NS.MyClass.Callback",
 								delegateInfo: new (
 									name: "Invoke",
+									delegateType: "NS.MyClass.Callback",
 									returnType: ReturnTypeForInt (isNullable: true),
 									parameters: [
 										new (
@@ -621,6 +632,7 @@ namespace NS {
 								"NS.MyClass.Callback",
 								delegateInfo: new (
 									name: "Invoke",
+									delegateType: "NS.MyClass.Callback",
 									returnType: ReturnTypeForInt (isNullable: true),
 									parameters: [
 										new (

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests/FromDeclarationTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests/FromDeclarationTests.cs
@@ -896,6 +896,22 @@ namespace NS {
 ";
 
 			yield return [simpleAsyncMethod];
+			
+			const string tupleAsyncMethod = @"
+using System;
+using ObjCBindings;
+using ObjCRuntime;
+
+namespace NS {
+	public class MyClass {
+
+		[Export<Method> (""completeRequestReturningItems:completionHandler:"", Flags = ObjCBindings.Method.Async)] 
+		public void MyMethod (string[]? input, Action<bool, string> callback) { }
+	}
+}
+";
+
+			yield return [tupleAsyncMethod];
 
 			const string asyncMethodWithName = @"
 using System;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests/FromDeclarationTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests/FromDeclarationTests.cs
@@ -896,7 +896,7 @@ namespace NS {
 ";
 
 			yield return [simpleAsyncMethod];
-			
+
 			const string tupleAsyncMethod = @"
 using System;
 using ObjCBindings;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/TypeInfoTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/TypeInfoTests.cs
@@ -384,6 +384,34 @@ namespace NS {
 					parameters: []
 				)
 			];
+			
+			const string namedTuple = @"
+using System;
+
+namespace NS {
+	public class MyClass {
+		public (string Name, string Surname) MyMethod () {}
+	}
+}
+";
+			yield return [
+				namedTuple,
+				new Method (
+					type: "NS.MyClass",
+					name: "MyMethod",
+					returnType: ReturnTypeForNamedTuple ([
+						new ("Name", ReturnTypeForString ()),
+						new ("Surname", ReturnTypeForString ()),
+					]),
+					symbolAvailability: new (),
+					exportMethodData: new (),
+					attributes: [],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					parameters: []
+				)
+			];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
@@ -705,10 +733,14 @@ namespace Example {
 	[PlatformInlineData (ApplePlatform.TVOS, "Action<int, NSError>", "Task<int>", "TaskCompletionSource<int>")]
 	[PlatformInlineData (ApplePlatform.MacCatalyst, "Action<int, NSError>", "Task<int>", "TaskCompletionSource<int>")]
 	[PlatformInlineData (ApplePlatform.MacOSX, "Action<int, NSError>", "Task<int>", "TaskCompletionSource<int>")]
-	[PlatformInlineData (ApplePlatform.iOS, "Action<int, string>", "Task<int, string>", "TaskCompletionSource<int, string>")]
-	[PlatformInlineData (ApplePlatform.TVOS, "Action<int, string>", "Task<int, string>", "TaskCompletionSource<int, string>")]
-	[PlatformInlineData (ApplePlatform.MacCatalyst, "Action<int, string>", "Task<int, string>", "TaskCompletionSource<int, string>")]
-	[PlatformInlineData (ApplePlatform.MacOSX, "Action<int, string>", "Task<int, string>", "TaskCompletionSource<int, string>")]
+	[PlatformInlineData (ApplePlatform.iOS, "Action<int, string>", "Task<(int, string)>", "TaskCompletionSource<(int, string)>")]
+	[PlatformInlineData (ApplePlatform.TVOS, "Action<int, string>", "Task<(int, string)>", "TaskCompletionSource<(int, string)>")]
+	[PlatformInlineData (ApplePlatform.MacCatalyst, "Action<int, string>", "Task<(int, string)>", "TaskCompletionSource<(int, string)>")]
+	[PlatformInlineData (ApplePlatform.MacOSX, "Action<int, string>", "Task<(int, string)>", "TaskCompletionSource<(int, string)>")]
+	[PlatformInlineData (ApplePlatform.iOS, "Action<int, string, NSError>", "Task<(int, string)>", "TaskCompletionSource<(int, string)>")]
+	[PlatformInlineData (ApplePlatform.TVOS, "Action<int, string, NSError>", "Task<(int, string)>", "TaskCompletionSource<(int, string)>")]
+	[PlatformInlineData (ApplePlatform.MacCatalyst, "Action<int, string, NSError>", "Task<(int, string)>", "TaskCompletionSource<(int, string)>")]
+	[PlatformInlineData (ApplePlatform.MacOSX, "Action<int, string, NSError>", "Task<(int, string)>", "TaskCompletionSource<(int, string)>")]
 	void TypeInfoToTask (ApplePlatform platform, string action, string expectedTask, string expectedCompletionSource)
 	{
 		var inputText = $@"
@@ -744,5 +776,45 @@ namespace NS {{
 		Assert.Equal ($"{Global ("System.Threading")}.Tasks.{expectedTask}", task.GetIdentifierSyntax ().ToString ());
 		var completionSource = task.ToTaskCompletionSource ();
 		Assert.Equal ($"{Global ("System.Threading")}.Tasks.{expectedCompletionSource}", completionSource.GetIdentifierSyntax ().ToString ());
+	}
+	
+	[Theory]
+	[AllSupportedPlatforms]
+	void TypeInfoToTaskNamedTuple (ApplePlatform platform)
+	{
+		var inputText = @"
+using System;
+using System.Threading.Tasks;
+using Foundation;
+using ObjCRuntime;
+using System.Collections.Generic;
+
+namespace NS {
+	public class MyClass {
+		delegate void Callback (string name, string surname, NSError error);
+		public void ProcessPointer (Callback myTask)
+		{
+			// do nothing
+		}
+	}
+}
+";
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
+		Assert.Single (syntaxTrees);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ().OfType<MethodDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		Assert.True (Method.TryCreate (declaration, semanticModel, out var changes));
+		Assert.NotNull (changes);
+		// ensure that the method has a single parameter
+		Assert.Single (changes.Value.Parameters);
+		var type = changes.Value.Parameters [0].Type;
+		var task = type.ToTask ();
+		Assert.NotEqual (type, task);
+		Assert.Equal ($"{Global ("System.Threading")}.Tasks.Task<(string Name, string Surname)>", task.GetIdentifierSyntax ().ToString ());
+		var completionSource = task.ToTaskCompletionSource ();
+		Assert.Equal ($"{Global ("System.Threading")}.Tasks.TaskCompletionSource<(string Name, string Surname)>", completionSource.GetIdentifierSyntax ().ToString ());
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/TypeInfoTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/TypeInfoTests.cs
@@ -384,7 +384,7 @@ namespace NS {
 					parameters: []
 				)
 			];
-			
+
 			const string namedTuple = @"
 using System;
 
@@ -777,7 +777,7 @@ namespace NS {{
 		var completionSource = task.ToTaskCompletionSource ();
 		Assert.Equal ($"{Global ("System.Threading")}.Tasks.{expectedCompletionSource}", completionSource.GetIdentifierSyntax ().ToString ());
 	}
-	
+
 	[Theory]
 	[AllSupportedPlatforms]
 	void TypeInfoToTaskNamedTuple (ApplePlatform platform)

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -509,15 +509,15 @@ public class BindingSyntaxFactoryRuntimeTests {
 				),
 				$"new {Global ("AudioToolbox.AudioBuffers")} (arg1, out arg2)"
 			];
-			
+
 			// named tuples
 			yield return [
 				ReturnTypeForNamedTuple (
-					new ("Name", ReturnTypeForString ()), 
+					new ("Name", ReturnTypeForString ()),
 					new ("Surname", ReturnTypeForString ())),
 				ImmutableArray.Create (
 					Argument (IdentifierName ("arg1"))
-						.WithNameColon (NameColon (IdentifierName("Name"))).NormalizeWhitespace (),
+						.WithNameColon (NameColon (IdentifierName ("Name"))).NormalizeWhitespace (),
 					Argument (IdentifierName ("arg2"))
 						.WithNameColon (NameColon (IdentifierName ("Surname"))).NormalizeWhitespace ()
 				),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -509,6 +509,20 @@ public class BindingSyntaxFactoryRuntimeTests {
 				),
 				$"new {Global ("AudioToolbox.AudioBuffers")} (arg1, out arg2)"
 			];
+			
+			// named tuples
+			yield return [
+				ReturnTypeForNamedTuple (
+					new ("Name", ReturnTypeForString ()), 
+					new ("Surname", ReturnTypeForString ())),
+				ImmutableArray.Create (
+					Argument (IdentifierName ("arg1"))
+						.WithNameColon (NameColon (IdentifierName("Name"))).NormalizeWhitespace (),
+					Argument (IdentifierName ("arg2"))
+						.WithNameColon (NameColon (IdentifierName ("Surname"))).NormalizeWhitespace ()
+				),
+				"(Name: arg1, Surname: arg2)",
+			];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
@@ -519,6 +533,7 @@ public class BindingSyntaxFactoryRuntimeTests {
 	void NewTests (TypeInfo typeInfo, ImmutableArray<ArgumentSyntax> arguments, string expectedDeclaration)
 	{
 		var declaration = New (typeInfo, arguments);
+		var x = declaration.ToString ();
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -533,7 +533,6 @@ public class BindingSyntaxFactoryRuntimeTests {
 	void NewTests (TypeInfo typeInfo, ImmutableArray<ArgumentSyntax> arguments, string expectedDeclaration)
 	{
 		var declaration = New (typeInfo, arguments);
-		var x = declaration.ToString ();
 		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.Macios.Generator.DataModel;
 using Microsoft.Macios.Generator.Formatters;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
@@ -2,8 +2,13 @@
 // Licensed under the MIT License.
 
 #pragma warning disable APL0003
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.Macios.Generator.DataModel;
+using Microsoft.Macios.Generator.Formatters;
 using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
 
 namespace Microsoft.Macios.Generator.Tests;
@@ -649,4 +654,35 @@ static class TestDataFactory {
 				"Foundation.INSObjectFactory"
 			]
 		};
+	
+	public static TypeInfo ReturnTypeForNamedTuple (params KeyValuePair<string, TypeInfo> [] fields)
+	{
+		var dataMembers= string.Join (", ", fields.Select (x => $"{x.Value.GetIdentifierSyntax ()} {x.Key}"));
+		var genericMembers = string.Join (", ", fields.Select (x => $"{x.Value.GetIdentifierSyntax ()}"));
+		var tupleFields = ImmutableArray.CreateBuilder<KeyValuePair<string, string>> (fields.Length);
+		foreach (var (name, typeInfo) in fields) {
+			tupleFields.Add (new (name, typeInfo.GetIdentifierSyntax ().ToString ()));
+		}
+		var type = new TypeInfo (
+			name: $"({dataMembers})",
+			isNullable: false,
+			isBlittable: false,
+			isArray: false,
+			isReferenceType: false,
+			isStruct: true
+		) {
+			IsNamedTuple = true,
+			NamedTupleFields = tupleFields.ToImmutable (),
+			Parents = ["System.ValueType", "object"],
+			Interfaces = [
+				"System.Collections.IStructuralComparable",
+				"System.Collections.IStructuralEquatable",
+				"System.IComparable",
+				$"System.IComparable<({genericMembers})>",
+				$"System.IEquatable<({genericMembers})>",
+				"System.Runtime.CompilerServices.ITuple"
+			]
+		};
+		return type;
+	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
@@ -654,10 +654,10 @@ static class TestDataFactory {
 				"Foundation.INSObjectFactory"
 			]
 		};
-	
+
 	public static TypeInfo ReturnTypeForNamedTuple (params KeyValuePair<string, TypeInfo> [] fields)
 	{
-		var dataMembers= string.Join (", ", fields.Select (x => $"{x.Value.GetIdentifierSyntax ()} {x.Key}"));
+		var dataMembers = string.Join (", ", fields.Select (x => $"{x.Value.GetIdentifierSyntax ()} {x.Key}"));
 		var genericMembers = string.Join (", ", fields.Select (x => $"{x.Value.GetIdentifierSyntax ()}"));
 		var tupleFields = ImmutableArray.CreateBuilder<KeyValuePair<string, string>> (fields.Length);
 		foreach (var (name, typeInfo) in fields) {


### PR DESCRIPTION
When a binding has an async method we give the developer the freedom to provide a ResultType or a ResultTypeName to generate a class. This works when we want some kind of specialization, for example overriding the Initialize method.

In most cases we do not add any extra Initialize method implementation to async return types so adding that extra parameter in the ExportAttribute is error prone (new commers tend to forget). Rgen with this commit will generate async methods that will use Tuples or NamedTuples when generating the code.

- Tuples: If the delegate was created using an Action<T> we do not want to use the default names, since they are arg1, arg2, etc.. In that case, we use a Tuple.
- Named Tuples: This are used when we use a delegate with logical named parameters.

If a user was to use an Action with a named tupled, they can pass the named tuple definitions as part of the async export attribute.