### PR TITLE
[msbuild] Don't warn about repeated files when looking for duplicated resources.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1600,4 +1600,13 @@
             {1}: path to a file name (of a resource)
         </comment>
     </data>
+
+    <data name="E7158" xml:space="preserve">
+        <value>The {0} item '{1}' has been included more than once, with different 'LogicalName' metadata: {2}, {3}.</value>
+        <comment>
+            {0}: the name of the MSBuild item in question (BundleResource, ImageAsset, SceneKitAsset, etc.).
+            {1}: path to a file name (of a resource)
+            {2} and {3}: the different LogicalName metadata
+        </comment>
+    </data>
 </root>

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CollectBundleResources.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CollectBundleResources.cs
@@ -98,7 +98,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			bundleResources.AddRange (UnpackedResources);
 
-			var distinctBundleResources = VerifyLogicalNameUniqueness (Log, bundleResources, "BundleResource");
+			var distinctBundleResources = VerifyLogicalNameUniqueness (this, bundleResources, "BundleResource");
 
 			BundleResourcesWithLogicalNames = distinctBundleResources.ToArray ();
 
@@ -106,39 +106,64 @@ namespace Xamarin.MacDev.Tasks {
 		}
 
 		[return: NotNullIfNotNull (nameof (items))]
-		public static ITaskItem []? VerifyLogicalNameUniqueness (TaskLoggingHelper Log, IEnumerable<ITaskItem>? items, string itemName)
+		public static ITaskItem []? VerifyLogicalNameUniqueness<T> (T task, IEnumerable<ITaskItem>? items, string itemName) where T: Task, IHasProjectDir, IHasResourcePrefix, IHasSessionId
 		{
 			if (items is null)
 				return null;
 
+			var log = task.Log;
+
 			var rv = new List<ITaskItem> ();
-			var groupedBundleResources = items.GroupBy (item => item.GetMetadata ("LogicalName"));
+
+			var isRemoteBuild = !string.IsNullOrEmpty (task.SessionId);
+
+			// Remove identical items (based on filename)
+			var distinctItemInfos = new Dictionary<string, (ITaskItem Item, string LogicalName)> ();
+			foreach (var item in items) {
+				var logicalName = BundleResource.GetLogicalName<T> (task, item);
+
+				// Canonicalize the input path
+				var fullItemSpec = Path.GetFullPath (item.ItemSpec);
+				if (!isRemoteBuild)
+					fullItemSpec = PathUtils.ResolveSymbolicLinks (fullItemSpec);
+
+				// Check if we have another ITaskItem for the same path, and ignore if that's the case.
+				if (distinctItemInfos.TryGetValue (fullItemSpec, out var otherItemInfo)) {
+					if (otherItemInfo.LogicalName != logicalName)
+						log.LogWarning (7158, item.ItemSpec, MSBStrings.E7158 /* The {0} item '{1}' has been included more than once, with different 'LogicalName' metadata: {2}, {3}. */, itemName, item.ItemSpec, logicalName, otherItemInfo.LogicalName);
+					continue;
+				}
+
+				distinctItemInfos.Add (fullItemSpec, (item, logicalName));
+			}
+
+			var groupedBundleResources = distinctItemInfos.Values.GroupBy (item => item.LogicalName);
 			var reportedItems = new HashSet<string> (); // Keep track of items we've shown warnings for, to not show multiple warnings.
 
 			foreach (var group in groupedBundleResources) {
 				// No/empty LogicalName is not OK.
 				if (string.IsNullOrEmpty (group.Key)) {
 					foreach (var item in group)
-						Log.LogError (7157, item.ItemSpec, MSBStrings.E7157 /* The {0} item '{0}' does not have a 'LogicalName' metadata. */, itemName, item.ItemSpec);
+						log.LogError (7157, item.Item.ItemSpec, MSBStrings.E7157 /* The {0} item '{0}' does not have a 'LogicalName' metadata. */, itemName, item.Item.ItemSpec);
 					continue;
 				}
 
 				// One item per LogicalName is OK.
 				if (group.Count () == 1) {
-					rv.AddRange (group);
+					rv.AddRange (group.Select (v => v.Item));
 					continue;
 				}
 
 				// More than one item per LogicalName is not good at all.
-				var notBundledInAssembly = group.Where (item => string.IsNullOrEmpty (item.GetMetadata ("BundledInAssembly"))).ToArray ();
-				var bundledInAssembly = group.Where (item => !string.IsNullOrEmpty (item.GetMetadata ("BundledInAssembly"))).ToArray ();
+				var notBundledInAssembly = group.Select (v => v.Item).Where (item => string.IsNullOrEmpty (item.GetMetadata ("BundledInAssembly"))).ToArray ();
+				var bundledInAssembly = group.Select (v => v.Item).Where (item => !string.IsNullOrEmpty (item.GetMetadata ("BundledInAssembly"))).ToArray ();
 				if (notBundledInAssembly.Length == 1) {
 					// Only one not from a library
 					rv.AddRange (notBundledInAssembly);
 					// warn about ignoring all the other imported ones.
 					foreach (var item in bundledInAssembly) {
 						if (reportedItems.Add (item.ItemSpec)) {
-							Log.LogWarning (7154, item.ItemSpec, MSBStrings.W7154 /* The {0} item '{1}' imported from '{2}' was ignored, because there's already an existing item from the current project with the same LogicalName ('{3}'). */, itemName, item.ItemSpec, item.GetMetadata ("BundledInAssembly"), group.Key);
+							log.LogWarning (7154, item.ItemSpec, MSBStrings.W7154 /* The {0} item '{1}' imported from '{2}' was ignored, because there's already an existing item from the current project with the same LogicalName ('{3}'). */, itemName, item.ItemSpec, item.GetMetadata ("BundledInAssembly"), group.Key);
 						}
 					}
 					continue;
@@ -151,7 +176,7 @@ namespace Xamarin.MacDev.Tasks {
 											Where (i => !object.ReferenceEquals (i, item)).
 											Select (i => Path.GetFileName (i.GetMetadata ("BundledInAssembly"))).
 											ToArray ();
-							Log.LogWarning (7155, item.ItemSpec, MSBStrings.W7155 /* The {0} item '{1}' imported from '{2}' was ignored, because there's another item from a different assembly ({4}) with the same LogicalName ('{3}'). */, itemName, item.ItemSpec, item.GetMetadata ("BundledInAssembly"), group.Key, string.Join (", ", others));
+							log.LogWarning (7155, item.ItemSpec, MSBStrings.W7155 /* The {0} item '{1}' imported from '{2}' was ignored, because there's another item from a different assembly ({4}) with the same LogicalName ('{3}'). */, itemName, item.ItemSpec, item.GetMetadata ("BundledInAssembly"), group.Key, string.Join (", ", others));
 						}
 					}
 					continue;
@@ -161,7 +186,7 @@ namespace Xamarin.MacDev.Tasks {
 					// warn about them all.
 					foreach (var item in notBundledInAssembly) {
 						if (reportedItems.Add (item.ItemSpec)) {
-							Log.LogWarning (7156, item.ItemSpec, MSBStrings.W7156 /* The {0} item '{1}' was ignored, because there's another item with the same LogicalName ('{2}'). */, itemName, item.ItemSpec, group.Key);
+							log.LogWarning (7156, item.ItemSpec, MSBStrings.W7156 /* The {0} item '{1}' was ignored, because there's another item with the same LogicalName ('{2}'). */, itemName, item.ItemSpec, group.Key);
 						}
 					}
 				}
@@ -181,7 +206,7 @@ namespace Xamarin.MacDev.Tasks {
 				var logicalName = BundleResource.GetLogicalName (task, item);
 				item.SetMetadata ("LogicalName", logicalName);
 			}
-			return VerifyLogicalNameUniqueness (task.Log, items, itemName);
+			return VerifyLogicalNameUniqueness (task, items, itemName);
 		}
 
 		public static bool TryCreateItemWithLogicalName<T> (T task, ITaskItem item, [NotNullWhen (true)] out TaskItem? itemWithLogicalName) where T : Task, IHasProjectDir, IHasResourcePrefix, IHasSessionId

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/IBTool.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/IBTool.cs
@@ -427,7 +427,7 @@ namespace Xamarin.MacDev.Tasks {
 				var bundleName = GetBundleRelativeOutputPath (item);
 				item.SetMetadata ("LogicalName", bundleName);
 			}
-			var interfaceDefinitions = CollectBundleResources.VerifyLogicalNameUniqueness (this.Log, InterfaceDefinitions, "InterfaceDefinition").ToArray ();
+			var interfaceDefinitions = CollectBundleResources.VerifyLogicalNameUniqueness (this, InterfaceDefinitions, "InterfaceDefinition").ToArray ();
 
 			if (interfaceDefinitions.Length > 0) {
 				Directory.CreateDirectory (ibtoolManifestDir);

--- a/tests/dotnet/AppWithDuplicatedResources/shared.csproj
+++ b/tests/dotnet/AppWithDuplicatedResources/shared.csproj
@@ -19,24 +19,66 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(IncludeFirstExecutableResources)' == 'true'">
-		<BundleResource Include="../../SecondLibraryWithResources/$(_PlatformName)/$(_ResourcePrefix)/B.otf" RegisterFont="true" Link="B.otf" />
+		<BundleResource Include="../../LibraryWithResources/$(_PlatformName)/$(_ResourcePrefix)/B.otf" RegisterFont="true" Link="B.otf" />
 
-		<PartialAppManifest Include="../../SecondLibraryWithResources/shared.plist" />
+		<PartialAppManifest Include="../../LibraryWithResources/shared.plist" />
 
-		<ImageAsset Include="../../SecondLibraryWithResources/$(_PlatformName)/**/*.xcassets/**/*.*" Exclude="../../SecondLibraryWithResources/$(_PlatformName)/**/*.xcassets/**/*.DS_Store">
-			<Link>$([MSBuild]::MakeRelative ('../../SecondLibraryWithResources/$(_PlatformName)/Resources', '%(FullPath)'))</Link>
+		<ImageAsset Include="../../LibraryWithResources/$(_PlatformName)/**/*.xcassets/**/*.*" Exclude="../../LibraryWithResources/$(_PlatformName)/**/*.xcassets/**/*.DS_Store">
+			<Link>$([MSBuild]::MakeRelative ('../../LibraryWithResources/$(_PlatformName)/Resources', '%(FullPath)'))</Link>
 		</ImageAsset>
 
-		<InterfaceDefinition Include="../../SecondLibraryWithResources/$(_PlatformName)/**/*.storyboard;../../SecondLibraryWithResources/$(_PlatformName)/**/*.xib" Condition="'$(DisableFirstExecutableInterfaceDefinition)' != 'true'" >
-			<Link>$([MSBuild]::MakeRelative ('../../SecondLibraryWithResources/$(_PlatformName)/Resources', '%(FullPath)'))</Link>
+		<InterfaceDefinition Include="../../LibraryWithResources/$(_PlatformName)/**/*.storyboard;../../LibraryWithResources/$(_PlatformName)/**/*.xib" Condition="'$(DisableFirstExecutableInterfaceDefinition)' != 'true'" >
+			<Link>$([MSBuild]::MakeRelative ('../../LibraryWithResources/$(_PlatformName)/Resources', '%(FullPath)'))</Link>
 		</InterfaceDefinition>
 
-		<SceneKitAsset Include="../../SecondLibraryWithResources/*.scnassets/*" Link="%(RecursiveDir)%(FileName)%(Extension)" />
-		<SceneKitAsset Include="../../SecondLibraryWithResources/*/linkedArt.scnassets/*" Link="%(RecursiveDir)%(FileName)%(Extension)" />
+		<SceneKitAsset Include="../../LibraryWithResources/*.scnassets/*" Link="%(RecursiveDir)%(FileName)%(Extension)" />
+		<SceneKitAsset Include="../../LibraryWithResources/*/linkedArt.scnassets/*" Link="%(RecursiveDir)%(FileName)%(Extension)" />
 
-		<Collada Include="../../SecondLibraryWithResources/*.dae" Link="%(FileName)%(Extension)" />
-		<AtlasTexture Include="../../SecondLibraryWithResources/*.atlas/**/*" Link="%(RecursiveDir)%(FileName)%(Extension)" />
-		<CoreMLModel Include="../../SecondLibraryWithResources/*.mlmodel" Link="%(FileName)%(Extension)" />
+		<Collada Include="../../LibraryWithResources/*.dae" Link="%(FileName)%(Extension)" />
+		<AtlasTexture Include="../../LibraryWithResources/*.atlas/**/*" Link="%(RecursiveDir)%(FileName)%(Extension)" />
+		<CoreMLModel Include="../../LibraryWithResources/*.mlmodel" Link="%(FileName)%(Extension)" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(IncludeFirstExecutableResourcesAgain)' == 'true'">
+		<BundleResource Include="../../LibraryWithResources/$(_PlatformName)/$(_ResourcePrefix)/B.otf" RegisterFont="true" Link="B.otf" />
+
+		<PartialAppManifest Include="../../LibraryWithResources/shared.plist" />
+
+		<ImageAsset Include="../../LibraryWithResources/$(_PlatformName)/**/*.xcassets/**/*.*" Exclude="../../LibraryWithResources/$(_PlatformName)/**/*.xcassets/**/*.DS_Store">
+			<Link>$([MSBuild]::MakeRelative ('../../LibraryWithResources/$(_PlatformName)/Resources', '%(FullPath)'))</Link>
+		</ImageAsset>
+
+		<InterfaceDefinition Include="../../LibraryWithResources/$(_PlatformName)/**/*.storyboard;../../LibraryWithResources/$(_PlatformName)/**/*.xib" Condition="'$(DisableFirstExecutableInterfaceDefinition)' != 'true'" >
+			<Link>$([MSBuild]::MakeRelative ('../../LibraryWithResources/$(_PlatformName)/Resources', '%(FullPath)'))</Link>
+		</InterfaceDefinition>
+
+		<SceneKitAsset Include="../../LibraryWithResources/*.scnassets/*" Link="%(RecursiveDir)%(FileName)%(Extension)" />
+		<SceneKitAsset Include="../../LibraryWithResources/*/linkedArt.scnassets/*" Link="%(RecursiveDir)%(FileName)%(Extension)" />
+
+		<Collada Include="../../LibraryWithResources/*.dae" Link="%(FileName)%(Extension)" />
+		<AtlasTexture Include="../../LibraryWithResources/*.atlas/**/*" Link="%(RecursiveDir)%(FileName)%(Extension)" />
+		<CoreMLModel Include="../../LibraryWithResources/*.mlmodel" Link="%(FileName)%(Extension)" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(IncludeFirstExecutableResourcesAgainWithDifferentMetadata)' == 'true'">
+		<BundleResource Include="../../LibraryWithResources/$(_PlatformName)/$(_ResourcePrefix)/B.otf" RegisterFont="true" Link="B-other.otf" />
+
+		<PartialAppManifest Include="../../LibraryWithResources/shared.plist" />
+
+		<ImageAsset Include="../../LibraryWithResources/$(_PlatformName)/**/*.xcassets/**/*.*" Exclude="../../LibraryWithResources/$(_PlatformName)/**/*.xcassets/**/*.DS_Store">
+			<Link>$([MSBuild]::MakeRelative ('../../LibraryWithResources/$(_PlatformName)/Resources', '%(FullPath)'))-other</Link>
+		</ImageAsset>
+
+		<InterfaceDefinition Include="../../LibraryWithResources/$(_PlatformName)/**/*.storyboard;../../LibraryWithResources/$(_PlatformName)/**/*.xib" Condition="'$(DisableFirstExecutableInterfaceDefinition)' != 'true'" >
+			<Link>$([MSBuild]::MakeRelative ('../../LibraryWithResources/$(_PlatformName)/Resources', '%(FullPath)'))-other</Link>
+		</InterfaceDefinition>
+
+		<SceneKitAsset Include="../../LibraryWithResources/*.scnassets/*" Link="%(RecursiveDir)%(FileName)%(Extension)-other" />
+		<SceneKitAsset Include="../../LibraryWithResources/*/linkedArt.scnassets/*" Link="%(RecursiveDir)%(FileName)%(Extension)-other" />
+
+		<Collada Include="../../LibraryWithResources/*.dae" Link="%(FileName)%(Extension)-other" />
+		<AtlasTexture Include="../../LibraryWithResources/*.atlas/**/*" Link="%(RecursiveDir)%(FileName)%(Extension)-other" />
+		<CoreMLModel Include="../../LibraryWithResources/*.mlmodel" Link="%(FileName)%(Extension)-other" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(IncludeSecondExecutableResources)' == 'true'">

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1107,6 +1107,8 @@ namespace Xamarin.Tests {
 			FirstLibraryAndSecondLibrary,
 			FirstLibraryAndExecutable,
 			ExecutableAndExecutable,
+			IdenticalInExecutable,
+			IdenticalInExecutableDifferentMetadata,
 		}
 
 		[TestCase (ApplePlatform.iOS, "iossimulator-x64", true, DuplicatedResourcesScenarios.FirstLibraryAndSecondLibrary)]
@@ -1115,6 +1117,8 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.iOS, "ios-arm64", false, DuplicatedResourcesScenarios.FirstLibraryAndExecutable)]
 		[TestCase (ApplePlatform.iOS, "iossimulator-x64", true, DuplicatedResourcesScenarios.ExecutableAndExecutable)]
 		[TestCase (ApplePlatform.iOS, "iossimulator-arm64", false, DuplicatedResourcesScenarios.ExecutableAndExecutable)]
+		[TestCase (ApplePlatform.iOS, "iossimulator-arm64", true, DuplicatedResourcesScenarios.IdenticalInExecutable)]
+		[TestCase (ApplePlatform.iOS, "iossimulator-arm64", true, DuplicatedResourcesScenarios.IdenticalInExecutableDifferentMetadata)]
 
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64", true, DuplicatedResourcesScenarios.FirstLibraryAndSecondLibrary)]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64", false, DuplicatedResourcesScenarios.FirstLibraryAndSecondLibrary)]
@@ -1122,6 +1126,8 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64", false, DuplicatedResourcesScenarios.FirstLibraryAndExecutable)]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64", true, DuplicatedResourcesScenarios.ExecutableAndExecutable)]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64;maccatalyst-arm64", false, DuplicatedResourcesScenarios.ExecutableAndExecutable)]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64", true, DuplicatedResourcesScenarios.IdenticalInExecutable)]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64", true, DuplicatedResourcesScenarios.IdenticalInExecutableDifferentMetadata)]
 
 		[TestCase (ApplePlatform.TVOS, "tvossimulator-x64", true, DuplicatedResourcesScenarios.FirstLibraryAndSecondLibrary)]
 		[TestCase (ApplePlatform.TVOS, "tvossimulator-arm64", false, DuplicatedResourcesScenarios.FirstLibraryAndSecondLibrary)]
@@ -1129,6 +1135,8 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.TVOS, "tvossimulator-arm64", false, DuplicatedResourcesScenarios.FirstLibraryAndExecutable)]
 		[TestCase (ApplePlatform.TVOS, "tvossimulator-x64", true, DuplicatedResourcesScenarios.ExecutableAndExecutable)]
 		[TestCase (ApplePlatform.TVOS, "tvos-arm64", false, DuplicatedResourcesScenarios.ExecutableAndExecutable)]
+		[TestCase (ApplePlatform.TVOS, "tvos-arm64", true, DuplicatedResourcesScenarios.IdenticalInExecutable)]
+		[TestCase (ApplePlatform.TVOS, "tvos-arm64", true, DuplicatedResourcesScenarios.IdenticalInExecutableDifferentMetadata)]
 
 		[TestCase (ApplePlatform.MacOSX, "osx-x64;osx-arm64", true, DuplicatedResourcesScenarios.FirstLibraryAndSecondLibrary)]
 		[TestCase (ApplePlatform.MacOSX, "osx-arm64", false, DuplicatedResourcesScenarios.FirstLibraryAndSecondLibrary)]
@@ -1136,6 +1144,8 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.MacOSX, "osx-arm64;osx-x64", false, DuplicatedResourcesScenarios.FirstLibraryAndExecutable)]
 		[TestCase (ApplePlatform.MacOSX, "osx-x64", true, DuplicatedResourcesScenarios.ExecutableAndExecutable)]
 		[TestCase (ApplePlatform.MacOSX, "osx-arm64", false, DuplicatedResourcesScenarios.ExecutableAndExecutable)]
+		[TestCase (ApplePlatform.MacOSX, "osx-arm64", true, DuplicatedResourcesScenarios.IdenticalInExecutable)]
+		[TestCase (ApplePlatform.MacOSX, "osx-arm64", true, DuplicatedResourcesScenarios.IdenticalInExecutableDifferentMetadata)]
 		public void AppWithDuplicatedResources (ApplePlatform platform, string runtimeIdentifiers, bool bundleOriginalResources, DuplicatedResourcesScenarios scenario)
 		{
 			var project = "AppWithDuplicatedResources";
@@ -1161,11 +1171,19 @@ namespace Xamarin.Tests {
 				break;
 			case DuplicatedResourcesScenarios.FirstLibraryAndExecutable:
 				properties ["IncludeLibraryWithResources"] = "true";
-				properties ["IncludeFirstExecutableResources"] = "true";
+				properties ["IncludeSecondExecutableResources"] = "true";
 				break;
 			case DuplicatedResourcesScenarios.ExecutableAndExecutable:
 				properties ["IncludeFirstExecutableResources"] = "true";
 				properties ["IncludeSecondExecutableResources"] = "true";
+				break;
+			case DuplicatedResourcesScenarios.IdenticalInExecutable:
+				properties ["IncludeFirstExecutableResources"] = "true";
+				properties ["IncludeFirstExecutableResourcesAgain"] = "true";
+				break;
+			case DuplicatedResourcesScenarios.IdenticalInExecutableDifferentMetadata:
+				properties ["IncludeFirstExecutableResources"] = "true";
+				properties ["IncludeFirstExecutableResourcesAgainWithDifferentMetadata"] = "true";
 				break;
 			default:
 				throw new NotImplementedException (scenario.ToString ());
@@ -1261,6 +1279,29 @@ namespace Xamarin.Tests {
 					break;
 				case DuplicatedResourcesScenarios.ExecutableAndExecutable:
 					expectedWarnings = new ExpectedBuildMessage [] {
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0001.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0001.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0001.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0002.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0002.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0002.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0003.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0003.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0003.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0004.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0004.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0004.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0005.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0005.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0005.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0006.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0006.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0006.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0007.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0007.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0007.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0008.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0008.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0008.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0009.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0009.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0009.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0010.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0010.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0010.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/art.scnassets/scene.scn", $"The SceneKitAsset item '../../LibraryWithResources/art.scnassets/scene.scn' was ignored, because there's another item with the same LogicalName ('art.scnassets/scene.scn')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/art.scnassets/texture.png", $"The SceneKitAsset item '../../LibraryWithResources/art.scnassets/texture.png' was ignored, because there's another item with the same LogicalName ('art.scnassets/texture.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/DirWithResources/linkedArt.scnassets/scene.scn", $"The SceneKitAsset item '../../LibraryWithResources/DirWithResources/linkedArt.scnassets/scene.scn' was ignored, because there's another item with the same LogicalName ('DirWithResources/linkedArt.scnassets/scene.scn')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/DirWithResources/linkedArt.scnassets/texture.png", $"The SceneKitAsset item '../../LibraryWithResources/DirWithResources/linkedArt.scnassets/texture.png' was ignored, because there's another item with the same LogicalName ('DirWithResources/linkedArt.scnassets/texture.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/{platform.AsString ()}/Main.storyboard", $"The InterfaceDefinition item '../../LibraryWithResources/{platform.AsString ()}/Main.storyboard' was ignored, because there's another item with the same LogicalName ('Main.storyboardc')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/{platform.AsString ()}/Resources/B.otf", $"The BundleResource item '../../LibraryWithResources/{platform.AsString ()}/Resources/B.otf' was ignored, because there's another item with the same LogicalName ('B.otf')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Contents.json", $"The ImageAsset item '../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Contents.json' was ignored, because there's another item with the same LogicalName ('Images.xcassets/Contents.json')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Contents.json", $"The ImageAsset item '../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Contents.json' was ignored, because there's another item with the same LogicalName ('Images.xcassets/Image.imageset/Contents.json')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Icon16.png", $"The ImageAsset item '../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Icon16.png' was ignored, because there's another item with the same LogicalName ('Images.xcassets/Image.imageset/Icon16.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Icon32.png", $"The ImageAsset item '../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Icon32.png' was ignored, because there's another item with the same LogicalName ('Images.xcassets/Image.imageset/Icon32.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Icon64.png", $"The ImageAsset item '../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Icon64.png' was ignored, because there's another item with the same LogicalName ('Images.xcassets/Image.imageset/Icon64.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/scene.dae", $"The Collada item '../../LibraryWithResources/scene.dae' was ignored, because there's another item with the same LogicalName ('scene.dae')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/SqueezeNet.mlmodel", $"The CoreMLModel item '../../LibraryWithResources/SqueezeNet.mlmodel' was ignored, because there's another item with the same LogicalName ('SqueezeNet.mlmodel')"),
 						new ExpectedBuildMessage ($"../../SecondLibraryWithResources/Archer_Attack.atlas/archer_attack_0001.png", $"The AtlasTexture item '../../SecondLibraryWithResources/Archer_Attack.atlas/archer_attack_0001.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0001.png')"),
 						new ExpectedBuildMessage ($"../../SecondLibraryWithResources/Archer_Attack.atlas/archer_attack_0002.png", $"The AtlasTexture item '../../SecondLibraryWithResources/Archer_Attack.atlas/archer_attack_0002.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0002.png')"),
 						new ExpectedBuildMessage ($"../../SecondLibraryWithResources/Archer_Attack.atlas/archer_attack_0003.png", $"The AtlasTexture item '../../SecondLibraryWithResources/Archer_Attack.atlas/archer_attack_0003.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0003.png')"),
@@ -1284,6 +1325,35 @@ namespace Xamarin.Tests {
 						new ExpectedBuildMessage ($"../../SecondLibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Icon64.png", $"The ImageAsset item '../../SecondLibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Icon64.png' was ignored, because there's another item with the same LogicalName ('Images.xcassets/Image.imageset/Icon64.png')"),
 						new ExpectedBuildMessage ($"../../SecondLibraryWithResources/scene.dae", $"The Collada item '../../SecondLibraryWithResources/scene.dae' was ignored, because there's another item with the same LogicalName ('scene.dae')"),
 						new ExpectedBuildMessage ($"../../SecondLibraryWithResources/SqueezeNet.mlmodel", $"The CoreMLModel item '../../SecondLibraryWithResources/SqueezeNet.mlmodel' was ignored, because there's another item with the same LogicalName ('SqueezeNet.mlmodel')"),
+					};
+
+					break;
+				case DuplicatedResourcesScenarios.IdenticalInExecutable:
+					break;
+				case DuplicatedResourcesScenarios.IdenticalInExecutableDifferentMetadata:
+					expectedWarnings = new ExpectedBuildMessage [] {
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0001.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0001.png' has been included more than once, with different 'LogicalName' metadata: Archer_Attack.atlas/archer_attack_0001.png-other, Archer_Attack.atlas/archer_attack_0001.png."),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0002.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0002.png' has been included more than once, with different 'LogicalName' metadata: Archer_Attack.atlas/archer_attack_0002.png-other, Archer_Attack.atlas/archer_attack_0002.png."),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0003.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0003.png' has been included more than once, with different 'LogicalName' metadata: Archer_Attack.atlas/archer_attack_0003.png-other, Archer_Attack.atlas/archer_attack_0003.png."),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0004.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0004.png' has been included more than once, with different 'LogicalName' metadata: Archer_Attack.atlas/archer_attack_0004.png-other, Archer_Attack.atlas/archer_attack_0004.png."),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0005.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0005.png' has been included more than once, with different 'LogicalName' metadata: Archer_Attack.atlas/archer_attack_0005.png-other, Archer_Attack.atlas/archer_attack_0005.png."),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0006.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0006.png' has been included more than once, with different 'LogicalName' metadata: Archer_Attack.atlas/archer_attack_0006.png-other, Archer_Attack.atlas/archer_attack_0006.png."),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0007.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0007.png' has been included more than once, with different 'LogicalName' metadata: Archer_Attack.atlas/archer_attack_0007.png-other, Archer_Attack.atlas/archer_attack_0007.png."),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0008.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0008.png' has been included more than once, with different 'LogicalName' metadata: Archer_Attack.atlas/archer_attack_0008.png-other, Archer_Attack.atlas/archer_attack_0008.png."),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0009.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0009.png' has been included more than once, with different 'LogicalName' metadata: Archer_Attack.atlas/archer_attack_0009.png-other, Archer_Attack.atlas/archer_attack_0009.png."),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0010.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0010.png' has been included more than once, with different 'LogicalName' metadata: Archer_Attack.atlas/archer_attack_0010.png-other, Archer_Attack.atlas/archer_attack_0010.png."),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/art.scnassets/scene.scn", $"The SceneKitAsset item '../../LibraryWithResources/art.scnassets/scene.scn' has been included more than once, with different 'LogicalName' metadata: art.scnassets/scene.scn-other, art.scnassets/scene.scn."),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/art.scnassets/texture.png", $"The SceneKitAsset item '../../LibraryWithResources/art.scnassets/texture.png' has been included more than once, with different 'LogicalName' metadata: art.scnassets/texture.png-other, art.scnassets/texture.png."),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/DirWithResources/linkedArt.scnassets/scene.scn", $"The SceneKitAsset item '../../LibraryWithResources/DirWithResources/linkedArt.scnassets/scene.scn' has been included more than once, with different 'LogicalName' metadata: DirWithResources/linkedArt.scnassets/scene.scn-other, DirWithResources/linkedArt.scnassets/scene.scn."),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/DirWithResources/linkedArt.scnassets/texture.png", $"The SceneKitAsset item '../../LibraryWithResources/DirWithResources/linkedArt.scnassets/texture.png' has been included more than once, with different 'LogicalName' metadata: DirWithResources/linkedArt.scnassets/texture.png-other, DirWithResources/linkedArt.scnassets/texture.png."),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/{platform.AsString ()}/Resources/B.otf", $"The BundleResource item '../../LibraryWithResources/{platform.AsString ()}/Resources/B.otf' has been included more than once, with different 'LogicalName' metadata: B-other.otf, B.otf."),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Contents.json", $"The ImageAsset item '../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Contents.json' has been included more than once, with different 'LogicalName' metadata: Images.xcassets/Contents.json-other, Images.xcassets/Contents.json."),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Contents.json", $"The ImageAsset item '../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Contents.json' has been included more than once, with different 'LogicalName' metadata: Images.xcassets/Image.imageset/Contents.json-other, Images.xcassets/Image.imageset/Contents.json."),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Icon16.png", $"The ImageAsset item '../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Icon16.png' has been included more than once, with different 'LogicalName' metadata: Images.xcassets/Image.imageset/Icon16.png-other, Images.xcassets/Image.imageset/Icon16.png."),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Icon32.png", $"The ImageAsset item '../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Icon32.png' has been included more than once, with different 'LogicalName' metadata: Images.xcassets/Image.imageset/Icon32.png-other, Images.xcassets/Image.imageset/Icon32.png."),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Icon64.png", $"The ImageAsset item '../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Icon64.png' has been included more than once, with different 'LogicalName' metadata: Images.xcassets/Image.imageset/Icon64.png-other, Images.xcassets/Image.imageset/Icon64.png."),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/scene.dae", $"The Collada item '../../LibraryWithResources/scene.dae' has been included more than once, with different 'LogicalName' metadata: scene.dae-other, scene.dae."),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/SqueezeNet.mlmodel", $"The CoreMLModel item '../../LibraryWithResources/SqueezeNet.mlmodel' has been included more than once, with different 'LogicalName' metadata: SqueezeNet.mlmodel-other, SqueezeNet.mlmodel."),
 					};
 					break;
 				default:
@@ -1399,6 +1469,29 @@ namespace Xamarin.Tests {
 					break;
 				case DuplicatedResourcesScenarios.ExecutableAndExecutable:
 					expectedWarnings = new ExpectedBuildMessage [] {
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0001.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0001.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0001.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0002.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0002.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0002.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0003.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0003.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0003.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0004.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0004.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0004.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0005.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0005.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0005.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0006.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0006.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0006.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0007.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0007.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0007.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0008.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0008.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0008.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0009.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0009.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0009.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0010.png", $"The AtlasTexture item '../../LibraryWithResources/Archer_Attack.atlas/archer_attack_0010.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0010.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/art.scnassets/scene.scn", $"The SceneKitAsset item '../../LibraryWithResources/art.scnassets/scene.scn' was ignored, because there's another item with the same LogicalName ('art.scnassets/scene.scn')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/art.scnassets/texture.png", $"The SceneKitAsset item '../../LibraryWithResources/art.scnassets/texture.png' was ignored, because there's another item with the same LogicalName ('art.scnassets/texture.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/DirWithResources/linkedArt.scnassets/scene.scn", $"The SceneKitAsset item '../../LibraryWithResources/DirWithResources/linkedArt.scnassets/scene.scn' was ignored, because there's another item with the same LogicalName ('DirWithResources/linkedArt.scnassets/scene.scn')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/DirWithResources/linkedArt.scnassets/texture.png", $"The SceneKitAsset item '../../LibraryWithResources/DirWithResources/linkedArt.scnassets/texture.png' was ignored, because there's another item with the same LogicalName ('DirWithResources/linkedArt.scnassets/texture.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/{platform.AsString ()}/Main.storyboard", $"The InterfaceDefinition item '../../LibraryWithResources/{platform.AsString ()}/Main.storyboard' was ignored, because there's another item with the same LogicalName ('Main.storyboardc')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/{platform.AsString ()}/Resources/B.otf", $"The BundleResource item '../../LibraryWithResources/{platform.AsString ()}/Resources/B.otf' was ignored, because there's another item with the same LogicalName ('B.otf')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Contents.json", $"The ImageAsset item '../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Contents.json' was ignored, because there's another item with the same LogicalName ('Images.xcassets/Contents.json')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Contents.json", $"The ImageAsset item '../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Contents.json' was ignored, because there's another item with the same LogicalName ('Images.xcassets/Image.imageset/Contents.json')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Icon16.png", $"The ImageAsset item '../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Icon16.png' was ignored, because there's another item with the same LogicalName ('Images.xcassets/Image.imageset/Icon16.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Icon32.png", $"The ImageAsset item '../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Icon32.png' was ignored, because there's another item with the same LogicalName ('Images.xcassets/Image.imageset/Icon32.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Icon64.png", $"The ImageAsset item '../../LibraryWithResources/{platform.AsString ()}/Resources/Images.xcassets/Image.imageset/Icon64.png' was ignored, because there's another item with the same LogicalName ('Images.xcassets/Image.imageset/Icon64.png')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/scene.dae", $"The Collada item '../../LibraryWithResources/scene.dae' was ignored, because there's another item with the same LogicalName ('scene.dae')"),
+						new ExpectedBuildMessage ($"../../LibraryWithResources/SqueezeNet.mlmodel", $"The CoreMLModel item '../../LibraryWithResources/SqueezeNet.mlmodel' was ignored, because there's another item with the same LogicalName ('SqueezeNet.mlmodel')"),
 						new ExpectedBuildMessage ($"../../SecondLibraryWithResources/Archer_Attack.atlas/archer_attack_0001.png", $"The AtlasTexture item '../../SecondLibraryWithResources/Archer_Attack.atlas/archer_attack_0001.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0001.png')"),
 						new ExpectedBuildMessage ($"../../SecondLibraryWithResources/Archer_Attack.atlas/archer_attack_0002.png", $"The AtlasTexture item '../../SecondLibraryWithResources/Archer_Attack.atlas/archer_attack_0002.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0002.png')"),
 						new ExpectedBuildMessage ($"../../SecondLibraryWithResources/Archer_Attack.atlas/archer_attack_0003.png", $"The AtlasTexture item '../../SecondLibraryWithResources/Archer_Attack.atlas/archer_attack_0003.png' was ignored, because there's another item with the same LogicalName ('Archer_Attack.atlas/archer_attack_0003.png')"),
@@ -1424,6 +1517,8 @@ namespace Xamarin.Tests {
 						new ExpectedBuildMessage ($"../../SecondLibraryWithResources/SqueezeNet.mlmodel", $"The CoreMLModel item '../../SecondLibraryWithResources/SqueezeNet.mlmodel' was ignored, because there's another item with the same LogicalName ('SqueezeNet.mlmodel')"),
 					};
 					break;
+				case DuplicatedResourcesScenarios.IdenticalInExecutable: // didn't add test cases for this
+				case DuplicatedResourcesScenarios.IdenticalInExecutableDifferentMetadata: // didn't add test cases for this
 				default:
 					throw new NotImplementedException (scenario.ToString ());
 				}
@@ -1436,17 +1531,18 @@ namespace Xamarin.Tests {
 								});
 			warnings.AssertWarnings (expectedWarnings);
 
-			if (bundleOriginalResources) {
+			if (bundleOriginalResources && expectedWarnings.Length > 0) {
 				// Assert that all the resource types are mentioned in at least one warning message.
-				var allResourceTypesWithDuplicates = new string [] {
+				var allResourceTypesWithDuplicates = new List<string> {
 					"AtlasTexture",
 					"BundleResource",
 					"Collada",
 					"CoreMLModel",
 					"ImageAsset",
-					"InterfaceDefinition",
 					"SceneKitAsset",
 				};
+				if (scenario != DuplicatedResourcesScenarios.IdenticalInExecutableDifferentMetadata)
+					allResourceTypesWithDuplicates.Add ("InterfaceDefinition");
 				Assert.Multiple (() => {
 					foreach (var rt in allResourceTypesWithDuplicates)
 						Assert.That (warnings.Any (v => v.Message?.Contains (rt) == true), $"Didn't find any warnings about {rt}");


### PR DESCRIPTION
When detecting duplicated resources, make sure to ignore repeated files, we
only want to warn about duplicated resources when they come from different
files.

This fixes an issue where we'd warn about (and not add to the app) a resource
if it was added more than once to the build.