### PR TITLE
[Rgen] Generate sync methods.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Availability;
@@ -104,7 +105,7 @@ readonly partial struct Method {
 	public static bool TryCreate (MethodDeclarationSyntax declaration, RootContext context,
 		[NotNullWhen (true)] out Method? change)
 	{
-		if (context.SemanticModel.GetDeclaredSymbol (declaration) is not IMethodSymbol method) {
+		if (ModelExtensions.GetDeclaredSymbol (context.SemanticModel, declaration) is not IMethodSymbol method) {
 			change = null;
 			return false;
 		}
@@ -172,6 +173,10 @@ readonly partial struct Method {
 			Parameters = [.. Parameters.SkipLast (1)],
 			// update the return type to be a task
 			ReturnType = resultType,
+			// remove the unsafe modifier if present since our async methods are not unsafe
+			Modifiers =  [
+				..Modifiers .Where(m => !m.IsKind(SyntaxKind.UnsafeKeyword))
+			]
 		};
 	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
@@ -174,8 +174,8 @@ readonly partial struct Method {
 			// update the return type to be a task
 			ReturnType = resultType,
 			// remove the unsafe modifier if present since our async methods are not unsafe
-			Modifiers =  [
-				..Modifiers .Where(m => !m.IsKind(SyntaxKind.UnsafeKeyword))
+			Modifiers = [
+				.. Modifiers.Where (m => !m.IsKind (SyntaxKind.UnsafeKeyword))
 			]
 		};
 	}

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ArgumentInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ArgumentInfo.cs
@@ -114,7 +114,7 @@ readonly record struct ArgumentInfo {
 	/// <param name="parameter">The property to convert.</param>
 	public static implicit operator ArgumentInfo (in Property parameter)
 		=> new (parameter);
-	
+
 	/// <summary>
 	/// Creates a new instance of <see cref="ArgumentInfo"/> with the specified reference kind.
 	/// </summary>
@@ -126,7 +126,7 @@ readonly record struct ArgumentInfo {
 			return this;
 
 		return this with {
-			ReferenceKind = referenceKind, 
+			ReferenceKind = referenceKind,
 			IsByRef = referenceKind != ReferenceKind.None,
 		};
 	}

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ArgumentInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ArgumentInfo.cs
@@ -114,4 +114,20 @@ readonly record struct ArgumentInfo {
 	/// <param name="parameter">The property to convert.</param>
 	public static implicit operator ArgumentInfo (in Property parameter)
 		=> new (parameter);
+	
+	/// <summary>
+	/// Creates a new instance of <see cref="ArgumentInfo"/> with the specified reference kind.
+	/// </summary>
+	/// <param name="referenceKind">The new reference kind.</param>
+	/// <returns>A new <see cref="ArgumentInfo"/> instance with the updated reference kind.</returns>
+	public ArgumentInfo WithRef (ReferenceKind referenceKind)
+	{
+		if (ReferenceKind == referenceKind)
+			return this;
+
+		return this with {
+			ReferenceKind = referenceKind, 
+			IsByRef = referenceKind != ReferenceKind.None,
+		};
+	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Arguments.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Arguments.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.DataModel;
+using Microsoft.Macios.Generator.Formatters;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using static Microsoft.Macios.Generator.Nomenclator;
 using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
@@ -67,6 +68,111 @@ static partial class BindingSyntaxFactory {
 		// decide the type of conversion we need to do based on the type of the parameter
 #pragma warning disable format
 		return parameter switch { 
+			// String handle to string
+			{ IsByRef: true, Type.IsArray: false, Type.IsNullable: true, Type.SpecialType: SpecialType.System_String }
+				=> [
+					// set the string from the aux pointer
+					VariableAssigment (
+						variableName: parameter.Name, 
+						value: StringFromHandle (
+							[
+								Argument (IdentifierName (GetNameForVariableType (parameter.Name, VariableType.NSString)!)), 
+								BoolArgument (false)
+							])
+					),
+				],
+			
+			// string handle to string not null
+			{ IsByRef: true, Type.IsArray: false, Type.IsNullable: false, Type.SpecialType: SpecialType.System_String }
+				=> [
+					// set the string from the aux pointer
+					VariableAssigment (
+						variableName: parameter.Name, 
+						value: SuppressNullableWarning (StringFromHandle (
+						[
+							Argument (IdentifierName (GetNameForVariableType (parameter.Name, VariableType.NSString)!)), 
+							BoolArgument (false)
+						]))
+					),
+				],
+			
+			// nothing to do for enums
+			{ IsByRef: true, Type.IsEnum: true, Type.IsSmartEnum: false} => [],
+			
+			// nothing other types that are not objects
+			{ IsByRef: true, Type.SpecialType: not SpecialType.None } => [], 
+			
+			// nothing to do with pointers
+			{ IsByRef: true, Type.IsStruct: true} => [],
+			
+			{ IsByRef: true, Type.IsArray: false, Type.IsINativeObject: true, Type.IsNSObject: false}
+				=> [
+					// set the nsobject from the aux pointer
+					VariableAssigment (
+						variableName: parameter.Name,
+						value: GetINativeObject (
+							nsObjectType: parameter.Type.WithNullable (isNullable: false).GetIdentifierSyntax (), 
+							args: [
+								Argument (IdentifierName (GetNameForVariableType (parameter.Name, VariableType.Handle)!)),
+							], 
+							suppressNullableWarning: !parameter.Type.IsNullable
+						)
+					),
+				],
+			
+			// nsobject or inative object need a native handle to pass to the native code by ref
+			{ IsByRef: true, Type.IsArray: false, Type.IsNSObject: true }
+				=> [
+					// set the nsobject from the aux pointer
+					VariableAssigment (
+						variableName: parameter.Name,
+						value: GetNSObject (
+							nsObjectType: parameter.Type.WithNullable (isNullable: false).GetIdentifierSyntax (), 
+							args: [
+								Argument (IdentifierName (GetNameForVariableType (parameter.Name, VariableType.Handle)!)),
+							],
+							suppressNullableWarning: !parameter.Type.IsNullable)
+					)
+				],
+			
+			// get the string array that is nullable
+			{ IsByRef: true, Type.IsArray: true, Type.IsNullable: true, Type.ArrayElementType: SpecialType.System_String }
+				=> [
+					VariableAssigment (
+						variableName: parameter.Name,
+						value: StringArrayFromHandle ([
+							Argument (IdentifierName (GetNameForVariableType (parameter.Name, VariableType.NSArray)!)),
+							BoolArgument (false)
+						])
+					),
+				],
+			
+			// get non-nullable string array
+			{ IsByRef: true, Type.IsArray: true, Type.IsNullable: false, Type.ArrayElementType: SpecialType.System_String }
+				=> [
+					VariableAssigment (
+						variableName: parameter.Name,
+						value: SuppressNullableWarning (StringArrayFromHandle ([
+							Argument (IdentifierName (GetNameForVariableType (parameter.Name, VariableType.NSArray)!)),
+							BoolArgument (false)
+						]))
+					),
+				],
+			
+			// by ref we need to create a native handle for the NSArray 
+			{ IsByRef: true, Type.IsArray: true, Type.ArrayElementTypeIsWrapped: true }
+				=> [
+					VariableAssigment (
+ 						variableName: parameter.Name,
+					    value: GetCFArrayFromHandle (
+						    nsObjectType: parameter.Type.ToArrayElementType ().WithNullable (isNullable: false).GetIdentifierSyntax (), 
+						    args: [ 
+							    Argument (IdentifierName(GetNameForVariableType (parameter.Name, VariableType.NSArray)!)) 
+						    ], 
+						    suppressNullableWarning: !parameter.Type.IsNullable) 
+					)
+				],
+			
 			// BindAs
 			{ BindAs: not null } => [
 				ExpressionStatement (
@@ -155,7 +261,7 @@ static partial class BindingSyntaxFactory {
 		// if the parameter does not allow the object to be null and it is a reference type, we need to add the null check
 		// otherwise ignore it. We do not want this check for INativeObjects (includes NSObject) because the GetNonNullableHandle
 		// will throw an exception if the object is null.
-		if (argumentInfo.Type is { IsReferenceType: true, IsINativeObject: false, IsNullable: false }) {
+		if (argumentInfo.Type is { IsReferenceType: true, IsINativeObject: false, IsNullable: false} && !argumentInfo.IsByRef) {
 			builder.Add (ThrowIfNull (argumentInfo.Name));
 		}
 
@@ -163,6 +269,54 @@ static partial class BindingSyntaxFactory {
 		// which is the lower type of the parameter
 #pragma warning disable format
 		ImmutableArray<SyntaxNode> conversions = argumentInfo switch {
+			// by ref we need to create a native handle for the NSString
+			{ IsByRef: true, Type.IsArray: false, Type.SpecialType: SpecialType.System_String }
+				=> [
+					VariableInitialization (
+						variableName: GetNameForVariableType (argumentInfo.Name, VariableType.NSString)!, 
+						type: NativeHandle)
+				],
+			
+			// enums that are not smart enums arse going to be passed as pointers
+			{ IsByRef: true, Type.IsEnum: true, Type.IsSmartEnum: false} => [],
+			
+			// other types that are not objects
+			{ IsByRef: true, Type.SpecialType: not SpecialType.None } => [], 
+
+			// structs just need the pointer
+			{ IsByRef: true, Type.IsStruct: true} => [],
+			
+			{ IsByRef: true, Type.IsArray: false, Type.IsINativeObject: true, Type.IsNSObject: false }
+				=> [
+					VariableInitialization (
+						variableName: GetNameForVariableType (argumentInfo.Name, VariableType.Handle)!, 
+						type: NativeHandle)
+				],
+			
+			// nsobject or interface need a native handle to pass to the native code by ref
+			{ IsByRef: true, Type.IsArray: false, Type.IsWrapped: true}
+				=> [
+					VariableInitialization (
+						variableName: GetNameForVariableType (argumentInfo.Name, VariableType.Handle)!, 
+						type: NativeHandle)
+				],
+			
+			// by ref we need to create a native handle for the NSArray 
+			{ IsByRef: true, Type.IsArray: true, Type.ArrayElementType: SpecialType.System_String }
+				=> [
+					VariableInitialization (
+						variableName: GetNameForVariableType (argumentInfo.Name, VariableType.NSArray)!, 
+						type: NativeHandle)
+				],
+			
+			// by ref we need to create a native handle for the NSArray 
+			{ IsByRef: true, Type.IsArray: true, Type.ArrayElementIsINativeObject: true }
+				=> [
+					VariableInitialization (
+						variableName: GetNameForVariableType (argumentInfo.Name, VariableType.NSArray)!, 
+						type: NativeHandle)
+				],
+			
 			// pointer parameter 
 			{ Type.IsPointer: true } => [],
 			
@@ -309,9 +463,44 @@ static partial class BindingSyntaxFactory {
 		var parameterIdentifier = IdentifierName (argumentInfo.Name);
 #pragma warning disable format
 		var expression = (Type: parameterType, Parameter: argumentInfo ) switch {
-			// ref parameters have to be converted to a pointer
-			{ Parameter.IsByRef: true } => AsPointer (parameterType, [ArgumentForParameter (argumentInfo.Name, ReferenceKind.Ref)]),
-
+			
+			// if it is by ref AND a string, using the handle of the nsstring aux variable
+			{ Parameter.IsByRef: true, Type.IsArray: false, Type.SpecialType: SpecialType.System_String }
+				=> PrefixUnaryExpression (
+					SyntaxKind.AddressOfExpression, 
+					IdentifierName (GetNameForVariableType (argumentInfo.Name, VariableType.NSString)!)), 
+			
+			// enums that are not smart enums arse going to be passed as pointers
+			{ Parameter.IsByRef: true, Type.IsEnum: true, Type.IsSmartEnum: false} 
+				=> AsPointer (parameterType, [ArgumentForParameter (argumentInfo.Name, ReferenceKind.Ref)]),
+			
+			// ref parameters have to be converted to a pointer in they are not a wrapped type, int, byte etc..
+			{ Parameter.IsByRef: true, Type.SpecialType: not SpecialType.None } 
+				=> AsPointer (parameterType, [ArgumentForParameter (argumentInfo.Name, ReferenceKind.Ref)]),
+			
+			// structs are passed as pointers
+			// ref parameters have to be converted to a pointer in they are not a wrapped type, int, byte etc..
+			{ Parameter.IsByRef: true, Type.IsStruct: true} 
+				=> AsPointer (parameterType, [ArgumentForParameter (argumentInfo.Name, ReferenceKind.Ref)]),
+			
+			// ref parameters that are wrapped types, we need to use the native handle of the wrapped type
+			{ Parameter.IsByRef: true, Type.IsArray: false, Type.IsWrapped: true } 
+				=> PrefixUnaryExpression (
+					SyntaxKind.AddressOfExpression, 
+					IdentifierName (GetNameForVariableType (argumentInfo.Name, VariableType.Handle)!)), 
+			
+			// deal with arrays of string
+			{ Parameter.IsByRef: true, Type.IsArray: true, Type.ArrayElementType: SpecialType.System_String }
+				=> PrefixUnaryExpression ( 
+					SyntaxKind.AddressOfExpression, 
+					IdentifierName (GetNameForVariableType (argumentInfo.Name, VariableType.NSArray)!)), 
+			
+			// deal with arrays of INativeObjects
+			{ Parameter.IsByRef: true, Type.IsArray: true, Type.ArrayElementIsINativeObject: true }
+				=> PrefixUnaryExpression ( 
+					SyntaxKind.AddressOfExpression, 
+			IdentifierName (GetNameForVariableType (argumentInfo.Name, VariableType.NSArray)!)), 
+			
 			// delegate parameter, c callback
 			// System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<ParameterType> (ParameterName)
 			{ Type.IsDelegate: true, Parameter.IsCCallback: true } 

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Arguments.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Arguments.cs
@@ -48,7 +48,8 @@ static partial class BindingSyntaxFactory {
 		// decide the type of conversion we need to do based on the type of the parameter
 #pragma warning disable format
 		return argumentInfo switch { 
-			{ IsByRef: true, ReferenceKind: ReferenceKind.Out} => GetNativeInitializationByRefArgument (argumentInfo.Name),
+			{ IsByRef: true, ReferenceKind: ReferenceKind.Out, Type.IsReferenceType: false, Type.SpecialType: not SpecialType.System_Boolean} 
+				=> GetNativeInitializationByRefArgument (argumentInfo.Name),
 			_ => []
 		};
 #pragma warning restore format

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Arguments.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Arguments.cs
@@ -524,7 +524,7 @@ static partial class BindingSyntaxFactory {
     
 			// smart enums must use the aux variable
 			{ Type.IsSmartEnum: true} 
-				=> IdentifierName (GetNameForVariableType (argumentInfo.Name, VariableType.BindFrom)!),
+				=> GetHandleMember (IdentifierName (GetNameForVariableType (argumentInfo.Name, VariableType.BindFrom)!)),
 			
 			// native enum, return the conversion expression to the native type
 			{ Type.IsNativeEnum: true} 
@@ -538,16 +538,16 @@ static partial class BindingSyntaxFactory {
 			
 			// use the native handle of the array
 			{ Type.IsArray: true, Type.ArrayElementTypeIsWrapped: true } =>
-				IdentifierName (GetNameForVariableType (argumentInfo.Name, VariableType.NSArray)!),
+				GetHandleMember (IdentifierName (GetNameForVariableType (argumentInfo.Name, VariableType.NSArray)!)),
 			
 			// NSArray.ArrayFromHandle<{0}> ({1})!
 			{ Type.IsArray: true, Type.ArrayElementIsINativeObject: true } =>
-				IdentifierName (GetNameForVariableType (argumentInfo.Name, VariableType.NSArray)!),
+				GetHandleMember (IdentifierName (GetNameForVariableType (argumentInfo.Name, VariableType.NSArray)!)),
 			
 			// string[]
 			// CFArray.StringArrayFromHandle (ParameterName)!
 			{ Type.IsArray: true, Type.ArrayElementType: SpecialType.System_String } =>
-				IdentifierName (GetNameForVariableType (argumentInfo.Name, VariableType.NSArray)!),
+				GetHandleMember (IdentifierName (GetNameForVariableType (argumentInfo.Name, VariableType.NSArray)!)),
 			
 			// string
 			// CFString.FromHandle (ParameterName)!

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Arguments.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Arguments.cs
@@ -261,7 +261,7 @@ static partial class BindingSyntaxFactory {
 		// if the parameter does not allow the object to be null and it is a reference type, we need to add the null check
 		// otherwise ignore it. We do not want this check for INativeObjects (includes NSObject) because the GetNonNullableHandle
 		// will throw an exception if the object is null.
-		if (argumentInfo.Type is { IsReferenceType: true, IsINativeObject: false, IsNullable: false} && !argumentInfo.IsByRef) {
+		if (argumentInfo.Type is { IsReferenceType: true, IsINativeObject: false, IsNullable: false } && !argumentInfo.IsByRef) {
 			builder.Add (ThrowIfNull (argumentInfo.Name));
 		}
 

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Arguments.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Arguments.cs
@@ -72,7 +72,7 @@ static partial class BindingSyntaxFactory {
 			{ IsByRef: true, Type.IsArray: false, Type.IsNullable: true, Type.SpecialType: SpecialType.System_String }
 				=> [
 					// set the string from the aux pointer
-					VariableAssigment (
+					VariableAssignment (
 						variableName: parameter.Name, 
 						value: StringFromHandle (
 							[
@@ -86,7 +86,7 @@ static partial class BindingSyntaxFactory {
 			{ IsByRef: true, Type.IsArray: false, Type.IsNullable: false, Type.SpecialType: SpecialType.System_String }
 				=> [
 					// set the string from the aux pointer
-					VariableAssigment (
+					VariableAssignment (
 						variableName: parameter.Name, 
 						value: SuppressNullableWarning (StringFromHandle (
 						[
@@ -108,7 +108,7 @@ static partial class BindingSyntaxFactory {
 			{ IsByRef: true, Type.IsArray: false, Type.IsINativeObject: true, Type.IsNSObject: false}
 				=> [
 					// set the nsobject from the aux pointer
-					VariableAssigment (
+					VariableAssignment (
 						variableName: parameter.Name,
 						value: GetINativeObject (
 							nsObjectType: parameter.Type.WithNullable (isNullable: false).GetIdentifierSyntax (), 
@@ -124,7 +124,7 @@ static partial class BindingSyntaxFactory {
 			{ IsByRef: true, Type.IsArray: false, Type.IsNSObject: true }
 				=> [
 					// set the nsobject from the aux pointer
-					VariableAssigment (
+					VariableAssignment (
 						variableName: parameter.Name,
 						value: GetNSObject (
 							nsObjectType: parameter.Type.WithNullable (isNullable: false).GetIdentifierSyntax (), 
@@ -138,7 +138,7 @@ static partial class BindingSyntaxFactory {
 			// get the string array that is nullable
 			{ IsByRef: true, Type.IsArray: true, Type.IsNullable: true, Type.ArrayElementType: SpecialType.System_String }
 				=> [
-					VariableAssigment (
+					VariableAssignment (
 						variableName: parameter.Name,
 						value: StringArrayFromHandle ([
 							Argument (IdentifierName (GetNameForVariableType (parameter.Name, VariableType.NSArray)!)),
@@ -150,7 +150,7 @@ static partial class BindingSyntaxFactory {
 			// get non-nullable string array
 			{ IsByRef: true, Type.IsArray: true, Type.IsNullable: false, Type.ArrayElementType: SpecialType.System_String }
 				=> [
-					VariableAssigment (
+					VariableAssignment (
 						variableName: parameter.Name,
 						value: SuppressNullableWarning (StringArrayFromHandle ([
 							Argument (IdentifierName (GetNameForVariableType (parameter.Name, VariableType.NSArray)!)),
@@ -162,7 +162,7 @@ static partial class BindingSyntaxFactory {
 			// by ref we need to create a native handle for the NSArray 
 			{ IsByRef: true, Type.IsArray: true, Type.ArrayElementTypeIsWrapped: true }
 				=> [
-					VariableAssigment (
+					VariableAssignment (
  						variableName: parameter.Name,
 					    value: GetCFArrayFromHandle (
 						    nsObjectType: parameter.Type.ToArrayElementType ().WithNullable (isNullable: false).GetIdentifierSyntax (), 

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Methods.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Methods.cs
@@ -25,8 +25,8 @@ static partial class BindingSyntaxFactory {
 		var send = GetObjCMessageSendMethodName (
 			exportData: method.ExportMethodData,
 			returnType: returnType,
-			parameters: method.Parameters, 
-			isSuper: isSuper, 
+			parameters: method.Parameters,
+			isSuper: isSuper,
 			isStret: returnType.NeedsStret
 		);
 		if (send is null || method.ExportMethodData.Selector is null) {
@@ -58,7 +58,7 @@ static partial class BindingSyntaxFactory {
 			argumentsTransformations.Add (trampolineSyntax);
 			argumentSyntax.Add (trampolineSyntax.ArgumentSyntax);
 		}
-		
+
 		// calculate the send expressions, we use the export data information to determine the selector
 		var args = argumentSyntax.ToImmutable ();
 		return new MethodInvocations () {

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Methods.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Methods.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.DataModel;
+using static Microsoft.Macios.Generator.Nomenclator;
+
+namespace Microsoft.Macios.Generator.Emitters;
+
+static partial class BindingSyntaxFactory {
+
+	/// <summary>
+	/// Generates an invocation expression for sending an Objective-C message.
+	/// </summary>
+	/// <param name="method">The method to generate the invocation for.</param>
+	/// <param name="arguments">The arguments to pass to the method.</param>
+	/// <param name="isSuper">A boolean value indicating whether to call the superclass implementation.</param>
+	/// <returns>An expression syntax representing the message send invocation.</returns>
+	internal static ExpressionSyntax GetSendInvocation (in Method method,
+		in ImmutableArray<ArgumentSyntax> arguments, bool isSuper)
+	{
+		// calculate the send expressions, we use the export data information to determine the selector
+		var returnType = method.BindAs?.Type ?? method.ReturnType;
+		var send = GetObjCMessageSendMethodName (
+			exportData: method.ExportMethodData,
+			returnType: returnType,
+			parameters: method.Parameters, 
+			isSuper: isSuper, 
+			isStret: returnType.NeedsStret
+		);
+		if (send is null || method.ExportMethodData.Selector is null) {
+			return ThrowNotImplementedException ();
+		}
+		var invocation = MessagingInvocation (send, method.ExportMethodData.Selector, arguments);
+		if (method.ReturnType.IsVoid)
+			return invocation;
+		// we need to convert the return type to the managed type and assign it to the return variable
+		return AssignVariable (GetReturnVariableName (), ConvertToManaged (method, invocation)!);
+	}
+
+	/// <summary>
+	/// Generates the necessary invocations and argument transformations for a given method.
+	/// </summary>
+	/// <param name="method">The method for which to generate invocations.</param>
+	/// <returns>A <see cref="MethodInvocations"/> struct containing the argument transformations and the send invocations.</returns>
+	internal static MethodInvocations GetInvocations (in Method method)
+	{
+		// calculate all the needed transformations for the method parameters
+		var argumentsTransformations = ImmutableArray.CreateBuilder<TrampolineArgumentSyntax> (method.Parameters.Length);
+		var argumentSyntax = ImmutableArray.CreateBuilder<ArgumentSyntax> (method.Parameters.Length);
+		foreach (var param in method.Parameters) {
+			var trampolineSyntax = new TrampolineArgumentSyntax (GetNativeInvokeArgument (param)) {
+				Initializers = GetNativeInvokeArgumentInitializations (param),
+				PreCallConversion = GetPreNativeInvokeArgumentConversions (param),
+				PostCallConversion = GetPostNativeInvokeArgumentConversions (param),
+			};
+			argumentsTransformations.Add (trampolineSyntax);
+			argumentSyntax.Add (trampolineSyntax.ArgumentSyntax);
+		}
+		
+		// calculate the send expressions, we use the export data information to determine the selector
+		var args = argumentSyntax.ToImmutable ();
+		return new MethodInvocations () {
+			Arguments = argumentsTransformations.ToImmutable (),
+			Send = GetSendInvocation (method, args, false),
+			SendSuper = GetSendInvocation (method, args, true)
+		};
+
+	}
+}

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -308,7 +308,7 @@ static partial class BindingSyntaxFactory {
 			SyntaxKind.SimpleMemberAccessExpression,
 			variable,
 			IdentifierName ("Handle"));
-	
+
 	/// <summary>
 	/// Generates a local variable declaration for an auxiliary handle (IntPtr).
 	/// This is a convenience overload for <see cref="GetHandleAuxVariable(string, in TypeInfo)"/>.

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -298,6 +298,18 @@ static partial class BindingSyntaxFactory {
 	}
 
 	/// <summary>
+	/// Generates a member access expression to get the Handle property of a variable.
+	/// This is used to access the native handle (IntPtr) from NSObject or INativeObject instances.
+	/// </summary>
+	/// <param name="variable">The expression representing the variable to access the Handle property from.</param>
+	/// <returns>A <see cref="MemberAccessExpressionSyntax"/> representing variable.Handle.</returns>
+	internal static ExpressionSyntax GetHandleMember (ExpressionSyntax variable)
+		=> MemberAccessExpression (
+			SyntaxKind.SimpleMemberAccessExpression,
+			variable,
+			IdentifierName ("Handle"));
+	
+	/// <summary>
 	/// Generates a local variable declaration for an auxiliary handle (IntPtr).
 	/// This is a convenience overload for <see cref="GetHandleAuxVariable(string, in TypeInfo)"/>.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Property.cs
@@ -98,8 +98,8 @@ static partial class BindingSyntaxFactory {
 	{
 		var argument = new TrampolineArgumentSyntax (GetNativeInvokeArgument (property)) {
 			Initializers = GetNativeInvokeArgumentInitializations (property),
-			PreDelegateCallConversion = GetPreNativeInvokeArgumentConversions (property),
-			PostDelegateCallConversion = GetPostNativeInvokeArgumentConversions (property),
+			PreCallConversion = GetPreNativeInvokeArgumentConversions (property),
+			PostCallConversion = GetPostNativeInvokeArgumentConversions (property),
 		};
 		// if any of the methods is null, return a throw statement for both
 		if (selector is null || sendMethod is null || superSendMethod is null) {

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
@@ -686,8 +686,8 @@ static partial class BindingSyntaxFactory {
 		foreach (var parameter in delegateInfo.Parameters) {
 			var argument = new TrampolineArgumentSyntax (GetTrampolineInvokeArgument (trampolineName, parameter)) {
 				Initializers = GetTrampolineInvokeArgumentInitializations (parameter),
-				PreDelegateCallConversion = GetTrampolinePreInvokeArgumentConversions (parameter),
-				PostDelegateCallConversion = GetTrampolinePostInvokeArgumentConversions (trampolineName, parameter),
+				PreCallConversion = GetTrampolinePreInvokeArgumentConversions (parameter),
+				PostCallConversion = GetTrampolinePostInvokeArgumentConversions (trampolineName, parameter),
 			};
 			bucket.Add (argument);
 		}
@@ -903,8 +903,8 @@ static partial class BindingSyntaxFactory {
 		foreach (var parameter in delegateInfo.Parameters) {
 			var argument = new TrampolineArgumentSyntax (GetNativeInvokeArgument (parameter)) {
 				Initializers = GetNativeInvokeArgumentInitializations (parameter),
-				PreDelegateCallConversion = GetPreNativeInvokeArgumentConversions (parameter),
-				PostDelegateCallConversion = GetPostNativeInvokeArgumentConversions (parameter),
+				PreCallConversion = GetPreNativeInvokeArgumentConversions (parameter),
+				PostCallConversion = GetPostNativeInvokeArgumentConversions (parameter),
 			};
 			bucket.Add (argument);
 		}

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
@@ -635,7 +635,8 @@ static partial class BindingSyntaxFactory {
 	internal static ImmutableArray<SyntaxNode> GetTrampolineInvokeArgumentInitializations (in DelegateParameter parameter)
 	{
 		// decide the type of conversion we need to do based on the type of the parameter
-		return parameter switch { { IsByRef: true } => GetTrampolineInitializationByRefArgument (parameter),
+		return parameter switch { { IsByRef: true, Type.IsReferenceType: false, Type.SpecialType: not SpecialType.System_Boolean} 
+				=> GetTrampolineInitializationByRefArgument (parameter),
 			_ => []
 		};
 	}

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
@@ -635,7 +635,7 @@ static partial class BindingSyntaxFactory {
 	internal static ImmutableArray<SyntaxNode> GetTrampolineInvokeArgumentInitializations (in DelegateParameter parameter)
 	{
 		// decide the type of conversion we need to do based on the type of the parameter
-		return parameter switch { { IsByRef: true, Type.IsReferenceType: false, Type.SpecialType: not SpecialType.System_Boolean} 
+		return parameter switch { { IsByRef: true, Type.IsReferenceType: false, Type.SpecialType: not SpecialType.System_Boolean }
 				=> GetTrampolineInitializationByRefArgument (parameter),
 			_ => []
 		};

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
@@ -119,13 +119,18 @@ static partial class BindingSyntaxFactory {
 	static InvocationExpressionSyntax MemberInvocationExpression (string instanceVariable, string methodName)
 		=> MemberInvocationExpression (IdentifierName (instanceVariable), methodName, ImmutableArray<ArgumentSyntax>.Empty);
 
+	static ExpressionStatementSyntax VariableAssigment (string variableName, ExpressionSyntax value)
+		=> ExpressionStatement ( AssignmentExpression (SyntaxKind.SimpleAssignmentExpression,
+				IdentifierName (variableName).WithTrailingTrivia (Space),
+				value.WithLeadingTrivia (Space)));
+
 	/// <summary>
 	/// Creates a variable declarator with an assignment to the provided value.
 	/// </summary>
 	/// <param name="variableName">The name of the variable.</param>
 	/// <param name="value">The expression to assign to the variable.</param>
 	/// <returns>A variable declarator syntax with the assignment.</returns>
-	static VariableDeclaratorSyntax VariableAssignment (string variableName, ExpressionSyntax value)
+	static VariableDeclaratorSyntax VariableInitializationAssignment (string variableName, ExpressionSyntax value)
 		=> VariableDeclarator (Identifier (variableName))
 			.WithInitializer (EqualsValueClause (value.WithLeadingTrivia (Space))
 				.WithLeadingTrivia (Space));
@@ -160,7 +165,18 @@ static partial class BindingSyntaxFactory {
 	/// <returns>A variable declaration syntax with initialization.</returns>
 	static LocalDeclarationStatementSyntax VariableInitialization (string variableName, ExpressionSyntax value,
 		TypeSyntax? withType = null)
-		=> VariableInitialization (VariableAssignment (variableName, value), withType);
+		=> VariableInitialization (VariableInitializationAssignment (variableName, value), withType);
+
+
+	/// <summary>
+	/// Creates a local variable declaration without an initial value.
+	/// </summary>
+	/// <param name="variableName">The name of the variable to declare.</param>
+	/// <param name="type">The type of the variable.</param>
+	/// <returns>A local declaration statement syntax.</returns>
+	static LocalDeclarationStatementSyntax VariableInitialization (string variableName, TypeSyntax type)
+		=> LocalDeclarationStatement (VariableDeclaration (type.WithTrailingTrivia (Space))
+				.WithVariables (SingletonSeparatedList (VariableDeclarator (Identifier (variableName)))));
 
 	static ExpressionSyntax ThrowException (string type, string? message = null)
 	{
@@ -332,7 +348,7 @@ static partial class BindingSyntaxFactory {
 		};
 #pragma warning restore format
 		return AsPointer (
-			objectType: objectType.GetIdentifierSyntax (),
+			objectType: objectType.WithNullable (isNullable: false).GetIdentifierSyntax (),
 			arguments: arguments,
 			castType: castType);
 	}

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
@@ -119,7 +119,7 @@ static partial class BindingSyntaxFactory {
 	static InvocationExpressionSyntax MemberInvocationExpression (string instanceVariable, string methodName)
 		=> MemberInvocationExpression (IdentifierName (instanceVariable), methodName, ImmutableArray<ArgumentSyntax>.Empty);
 
-	static ExpressionStatementSyntax VariableAssigment (string variableName, ExpressionSyntax value)
+	static ExpressionStatementSyntax VariableAssignment (string variableName, ExpressionSyntax value)
 		=> ExpressionStatement ( AssignmentExpression (SyntaxKind.SimpleAssignmentExpression,
 				IdentifierName (variableName).WithTrailingTrivia (Space),
 				value.WithLeadingTrivia (Space)));

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
@@ -120,7 +120,7 @@ static partial class BindingSyntaxFactory {
 		=> MemberInvocationExpression (IdentifierName (instanceVariable), methodName, ImmutableArray<ArgumentSyntax>.Empty);
 
 	static ExpressionStatementSyntax VariableAssignment (string variableName, ExpressionSyntax value)
-		=> ExpressionStatement ( AssignmentExpression (SyntaxKind.SimpleAssignmentExpression,
+		=> ExpressionStatement (AssignmentExpression (SyntaxKind.SimpleAssignmentExpression,
 				IdentifierName (variableName).WithTrailingTrivia (Space),
 				value.WithLeadingTrivia (Space)));
 

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
@@ -298,13 +298,13 @@ if (!(value is null) && rvalue is null) {{
 	/// <param name="methodBlock">The writer for the method block.</param>
 	void EmitVoidMethodBody (in Method method, in MethodInvocations invocations, TabbedWriter<StringWriter> methodBlock)
 	{
-		
+
 		// init the needed temp variables
 		foreach (var argument in invocations.Arguments) {
 			methodBlock.Write (argument.Initializers, verifyTrivia: false);
 			methodBlock.Write (argument.PreCallConversion, verifyTrivia: false);
 		}
-		
+
 		// simply call the send or sendSuper accordingly
 		methodBlock.WriteRaw (
 $@"if (IsDirectBinding) {{
@@ -314,7 +314,7 @@ $@"if (IsDirectBinding) {{
 }}
 {ExpressionStatement (KeepAlive ("this"))}
 ");
-		
+
 		// before we leave the methods, do any post operations
 		foreach (var argument in invocations.Arguments) {
 			methodBlock.Write (argument.PostCallConversion, verifyTrivia: false);
@@ -332,13 +332,13 @@ $@"if (IsDirectBinding) {{
 		// similar to the void method but we need to create a temp variable to store the return value
 		// and do any conversions that might be needed for the return value, for example byte to bool
 		var (tempVar, tempDeclaration) = GetReturnValueAuxVariable (method.ReturnType);
-		
+
 		// init the needed temp variables
 		foreach (var argument in invocations.Arguments) {
 			methodBlock.Write (argument.Initializers, verifyTrivia: false);
 			methodBlock.Write (argument.PreCallConversion, verifyTrivia: false);
 		}
-		
+
 		methodBlock.WriteRaw (
 $@"{tempDeclaration}
 if (IsDirectBinding) {{
@@ -354,7 +354,7 @@ if (IsDirectBinding) {{
 		}
 		methodBlock.WriteLine ($"return {tempVar};");
 	}
-	
+
 	/// <summary>
 	/// Emit the code for all the methods in the class.
 	/// </summary>
@@ -375,11 +375,11 @@ if (IsDirectBinding) {{
 					methodBlock.WriteLine (uiThreadCheck.ToString ());
 					methodBlock.WriteLine ();
 				}
-				
+
 				// retrieve the method invocation via the factory, this will generate the necessary arguments
 				// transformations and the invocation
 				var invocations = GetInvocations (method);
-				
+
 				if (method.ReturnType.IsVoid) {
 					EmitVoidMethodBody (method, invocations, methodBlock);
 				} else {

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
@@ -16,6 +16,7 @@ using Microsoft.Macios.Generator.IO;
 using ObjCBindings;
 using static Microsoft.Macios.Generator.Emitters.BindingSyntaxFactory;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using Method = Microsoft.Macios.Generator.DataModel.Method;
 using Property = Microsoft.Macios.Generator.DataModel.Property;
 
 namespace Microsoft.Macios.Generator.Emitters;
@@ -235,7 +236,7 @@ if (IsDirectBinding) {{
 					}
 					// init the needed temp variables
 					setterBlock.Write (invocations.Setter.Value.Argument.Initializers, verifyTrivia: false);
-					setterBlock.Write (invocations.Setter.Value.Argument.PreDelegateCallConversion, verifyTrivia: false);
+					setterBlock.Write (invocations.Setter.Value.Argument.PreCallConversion, verifyTrivia: false);
 
 					// perform the invocation
 					setterBlock.WriteRaw (
@@ -248,7 +249,7 @@ $@"if (IsDirectBinding) {{
 ");
 					// perform the post delegate call conversion, this might include the GC.KeepAlive calls to keep
 					// the native object alive
-					setterBlock.Write (invocations.Setter.Value.Argument.PostDelegateCallConversion, verifyTrivia: false);
+					setterBlock.Write (invocations.Setter.Value.Argument.PostCallConversion, verifyTrivia: false);
 					// mark property as dirty if needed
 					if (property.RequiresDirtyCheck || property.IsWeakDelegate) {
 						setterBlock.WriteLine ("MarkDirty ();");
@@ -290,20 +291,100 @@ if (!(value is null) && rvalue is null) {{
 	}
 
 	/// <summary>
+	/// Emits the body for a method that does not return a value.
+	/// </summary>
+	/// <param name="method">The method for which to generate the body.</param>
+	/// <param name="invocations">The method invocations and argument transformations.</param>
+	/// <param name="methodBlock">The writer for the method block.</param>
+	void EmitVoidMethodBody (in Method method, in MethodInvocations invocations, TabbedWriter<StringWriter> methodBlock)
+	{
+		
+		// init the needed temp variables
+		foreach (var argument in invocations.Arguments) {
+			methodBlock.Write (argument.Initializers, verifyTrivia: false);
+			methodBlock.Write (argument.PreCallConversion, verifyTrivia: false);
+		}
+		
+		// simply call the send or sendSuper accordingly
+		methodBlock.WriteRaw (
+$@"if (IsDirectBinding) {{
+	{ExpressionStatement (invocations.Send)}
+}} else {{
+	{ExpressionStatement (invocations.SendSuper)}
+}}
+{ExpressionStatement (KeepAlive ("this"))}
+");
+		
+		// before we leave the methods, do any post operations
+		foreach (var argument in invocations.Arguments) {
+			methodBlock.Write (argument.PostCallConversion, verifyTrivia: false);
+		}
+	}
+
+	/// <summary>
+	/// Emits the body for a method that returns a value.
+	/// </summary>
+	/// <param name="method">The method for which to generate the body.</param>
+	/// <param name="invocations">The method invocations and argument transformations.</param>
+	/// <param name="methodBlock">The writer for the method block.</param>
+	void EmitReturnMethodBody (in Method method, in MethodInvocations invocations, TabbedWriter<StringWriter> methodBlock)
+	{
+		// similar to the void method but we need to create a temp variable to store the return value
+		// and do any conversions that might be needed for the return value, for example byte to bool
+		var (tempVar, tempDeclaration) = GetReturnValueAuxVariable (method.ReturnType);
+		
+		// init the needed temp variables
+		foreach (var argument in invocations.Arguments) {
+			methodBlock.Write (argument.Initializers, verifyTrivia: false);
+			methodBlock.Write (argument.PreCallConversion, verifyTrivia: false);
+		}
+		
+		methodBlock.WriteRaw (
+$@"{tempDeclaration}
+if (IsDirectBinding) {{
+	{ExpressionStatement (invocations.Send)}
+}} else {{
+	{ExpressionStatement (invocations.SendSuper)}
+}}
+{ExpressionStatement (KeepAlive ("this"))}
+");
+		// before returning the value, we need to do the post operations for the temp vars
+		foreach (var argument in invocations.Arguments) {
+			methodBlock.Write (argument.PostCallConversion, verifyTrivia: false);
+		}
+		methodBlock.WriteLine ($"return {tempVar};");
+	}
+	
+	/// <summary>
 	/// Emit the code for all the methods in the class.
 	/// </summary>
 	/// <param name="context">The current binding context.</param>
 	/// <param name="classBlock">Current class block.</param>
 	void EmitMethods (in BindingContext context, TabbedWriter<StringWriter> classBlock)
 	{
+		var uiThreadCheck = (context.NeedsThreadChecks)
+			? EnsureUiThread (context.RootContext.CurrentPlatform) : null;
 		foreach (var method in context.Changes.Methods.OrderBy (m => m.Name)) {
-
 			classBlock.WriteLine ();
 			classBlock.AppendMemberAvailability (method.SymbolAvailability);
 			classBlock.AppendGeneratedCodeAttribute (optimizable: true);
 
 			using (var methodBlock = classBlock.CreateBlock (method.ToDeclaration ().ToString (), block: true)) {
-				methodBlock.WriteLine ("throw new NotImplementedException ();");
+				// write any possible thread check at the beginning of the method
+				if (uiThreadCheck is not null) {
+					methodBlock.WriteLine (uiThreadCheck.ToString ());
+					methodBlock.WriteLine ();
+				}
+				
+				// retrieve the method invocation via the factory, this will generate the necessary arguments
+				// transformations and the invocation
+				var invocations = GetInvocations (method);
+				
+				if (method.ReturnType.IsVoid) {
+					EmitVoidMethodBody (method, invocations, methodBlock);
+				} else {
+					EmitReturnMethodBody (method, invocations, methodBlock);
+				}
 			}
 
 			if (!method.IsAsync)

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/MethodInvocations.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/MethodInvocations.cs
@@ -15,12 +15,12 @@ readonly record struct MethodInvocations {
 	/// Gets the transformations and initializations for the method arguments.
 	/// </summary>
 	public ImmutableArray<TrampolineArgumentSyntax> Arguments { get; init; }
-	
+
 	/// <summary>
 	/// Gets the expression syntax for a standard message send invocation.
 	/// </summary>
 	public ExpressionSyntax Send { get; init; }
-	
+
 	/// <summary>
 	/// Gets the expression syntax for a message send invocation to the superclass implementation.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/MethodInvocations.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/MethodInvocations.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.Macios.Generator.Emitters;
+
+/// <summary>
+/// Represents the various syntax components required to invoke a method.
+/// </summary>
+readonly record struct MethodInvocations {
+
+	/// <summary>
+	/// Gets the transformations and initializations for the method arguments.
+	/// </summary>
+	public ImmutableArray<TrampolineArgumentSyntax> Arguments { get; init; }
+	
+	/// <summary>
+	/// Gets the expression syntax for a standard message send invocation.
+	/// </summary>
+	public ExpressionSyntax Send { get; init; }
+	
+	/// <summary>
+	/// Gets the expression syntax for a message send invocation to the superclass implementation.
+	/// </summary>
+	public ExpressionSyntax SendSuper { get; init; }
+}

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ReturnInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ReturnInfo.cs
@@ -46,6 +46,16 @@ readonly record struct ReturnInfo {
 	}
 
 	/// <summary>
+	/// Initializes a new instance of the <see cref="ReturnInfo"/> struct from a <see cref="Method"/>.
+	/// </summary>
+	/// <param name="method">The method to create the return info from.</param>
+	public ReturnInfo (in Method method)
+	{
+		Type = method.ReturnType;
+		BindAs = method.BindAs;
+	}
+
+	/// <summary>
 	/// Implicitly converts a <see cref="Property"/> to a <see cref="ReturnInfo"/>.
 	/// </summary>
 	/// <param name="property">The property to convert.</param>
@@ -58,4 +68,11 @@ readonly record struct ReturnInfo {
 	/// <param name="delegateInfo">The delegate info to convert.</param>
 	public static implicit operator ReturnInfo (in DelegateInfo delegateInfo)
 		=> new (delegateInfo);
+
+	/// <summary>
+	/// Implicitly converts a <see cref="Method"/> to a <see cref="ReturnInfo"/>.
+	/// </summary>
+	/// <param name="method">The method to convert.</param>
+	public static implicit operator ReturnInfo (in Method method)
+		=> new (method);
 }

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/TrampolineArgumentSyntax.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/TrampolineArgumentSyntax.cs
@@ -25,10 +25,10 @@ readonly record struct TrampolineArgumentSyntax (ArgumentSyntax ArgumentSyntax) 
 	/// <summary>
 	/// Collection of expressions that need to be called before the delegate call.
 	/// </summary>
-	public ImmutableArray<SyntaxNode> PreDelegateCallConversion { get; init; } = [];
+	public ImmutableArray<SyntaxNode> PreCallConversion { get; init; } = [];
 
 	/// <summary>
 	/// Collection of expressions that need to be called after the delegate call.
 	/// </summary>
-	public ImmutableArray<SyntaxNode> PostDelegateCallConversion { get; init; } = [];
+	public ImmutableArray<SyntaxNode> PostCallConversion { get; init; } = [];
 }

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/TrampolineEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/TrampolineEmitter.cs
@@ -62,14 +62,14 @@ $@"if ({delegateVariableName} is null)
 
 				// build any needed pre conversion operations before calling the delegate
 				foreach (var argument in argumentSyntax) {
-					invokeMethod.Write (argument.PreDelegateCallConversion);
+					invokeMethod.Write (argument.PreCallConversion);
 				}
 
 				invokeMethod.WriteLine ($"{CallTrampolineDelegate (typeInfo.Delegate!, argumentSyntax)}");
 
 				// build any needed post conversion operations after calling the delegate
 				foreach (var argument in argumentSyntax) {
-					invokeMethod.Write (argument.PostDelegateCallConversion);
+					invokeMethod.Write (argument.PostCallConversion);
 				}
 
 				// perform any return conversions needed
@@ -143,7 +143,7 @@ public unsafe static {delegateIdentifier}? Create (IntPtr block)
 				var argumentSyntax = GetTrampolineNativeInvokeArguments (typeInfo.Delegate!);
 				// write the conversion code for the arguments
 				foreach (var argument in argumentSyntax) {
-					invokeBlock.Write (argument.PreDelegateCallConversion, verifyTrivia: false);
+					invokeBlock.Write (argument.PreCallConversion, verifyTrivia: false);
 				}
 
 				// execute the native invoker delegate
@@ -151,7 +151,7 @@ public unsafe static {delegateIdentifier}? Create (IntPtr block)
 
 				// build any needed post conversion operations after calling the delegate
 				foreach (var argument in argumentSyntax) {
-					invokeBlock.Write (argument.PostDelegateCallConversion, verifyTrivia: false);
+					invokeBlock.Write (argument.PostCallConversion, verifyTrivia: false);
 				}
 
 				// perform any return conversions needed

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedMethodsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedMethodsTests.cs
@@ -42,6 +42,10 @@ public partial class MethodTests
 	static readonly global::ObjCRuntime.NativeHandle selFilteredArrayUsingPredicate_XHandle = global::ObjCRuntime.Selector.GetHandle ("filteredArrayUsingPredicate:");
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selFilteredArrayUsingStrings_X = "filteredArrayUsingStrings:";
+	static readonly global::ObjCRuntime.NativeHandle selFilteredArrayUsingStrings_XHandle = global::ObjCRuntime.Selector.GetHandle ("filteredArrayUsingStrings:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	const string selLoadFromHTMLWithRequest_Options_CompletionHandler_X = "loadFromHTMLWithRequest:options:completionHandler:";
 	static readonly global::ObjCRuntime.NativeHandle selLoadFromHTMLWithRequest_Options_CompletionHandler_XHandle = global::ObjCRuntime.Selector.GetHandle ("loadFromHTMLWithRequest:options:completionHandler:");
 
@@ -147,9 +151,9 @@ public partial class MethodTests
 		using var block_completionHandler = global::ObjCRuntime.Trampolines.SDActionArity1bool.CreateNullableBlock (completionHandler);
 		global::ObjCRuntime.BlockLiteral* block_ptr_completionHandler = completionHandler is not null ? &block_completionHandler : null;
 		if (IsDirectBinding) {
-			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems.Handle, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
 		} else {
-			global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+			global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems.Handle, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
 		}
 		global::System.GC.KeepAlive (this);
 		global::System.GC.KeepAlive (nsa_returningItems);
@@ -178,9 +182,9 @@ public partial class MethodTests
 		using var block_completionHandler = global::ObjCRuntime.Trampolines.SDActionArity2boolstring?.CreateNullableBlock (completionHandler);
 		global::ObjCRuntime.BlockLiteral* block_ptr_completionHandler = completionHandler is not null ? &block_completionHandler : null;
 		if (IsDirectBinding) {
-			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems.Handle, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
 		} else {
-			global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+			global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems.Handle, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
 		}
 		global::System.GC.KeepAlive (this);
 		global::System.GC.KeepAlive (nsa_returningItems);
@@ -209,9 +213,9 @@ public partial class MethodTests
 		using var block_completionHandler = global::ObjCRuntime.Trampolines.SDActionArity3boolstringstring?.CreateNullableBlock (completionHandler);
 		global::ObjCRuntime.BlockLiteral* block_ptr_completionHandler = completionHandler is not null ? &block_completionHandler : null;
 		if (IsDirectBinding) {
-			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems.Handle, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
 		} else {
-			global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+			global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems.Handle, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
 		}
 		global::System.GC.KeepAlive (this);
 		global::System.GC.KeepAlive (nsa_returningItems);
@@ -243,6 +247,27 @@ public partial class MethodTests
 		}
 		global::System.GC.KeepAlive (this);
 		global::System.GC.KeepAlive (predicate);
+		return ret;
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public virtual unsafe partial global::Foundation.NSArray FilterStrings (string[] predicate)
+	{
+		if (predicate is null)
+			global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (predicate));
+		using var nsa_predicate = global::Foundation.NSArray.FromStrings (predicate);
+		global::Foundation.NSArray ret;
+		if (IsDirectBinding) {
+			ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSArray> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("filteredArrayUsingStrings:"), nsa_predicate.Handle))!;
+		} else {
+			ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSArray> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("filteredArrayUsingStrings:"), nsa_predicate.Handle))!;
+		}
+		global::System.GC.KeepAlive (this);
+		global::System.GC.KeepAlive (nsa_predicate);
 		return ret;
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedMethodsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedMethodsTests.cs
@@ -54,6 +54,10 @@ public partial class MethodTests
 	static readonly global::ObjCRuntime.NativeHandle selCompleteRequestReturningItems_CompletionHandler_XHandle = global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:");
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selBookmarkDataWithContentsOfURL_Error_X = "bookmarkDataWithContentsOfURL:error:";
+	static readonly global::ObjCRuntime.NativeHandle selBookmarkDataWithContentsOfURL_Error_XHandle = global::ObjCRuntime.Selector.GetHandle ("bookmarkDataWithContentsOfURL:error:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	static readonly global::ObjCRuntime.NativeHandle class_ptr = global::ObjCRuntime.Class.GetHandle ("MethodTests");
 
 	/// <summary>The Objective-C class handle for this class.</summary>
@@ -289,6 +293,27 @@ public partial class MethodTests
 		}
 		global::System.GC.KeepAlive (this);
 		global::CoreFoundation.CFString.ReleaseNative (nspath);
+		return ret;
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public static unsafe partial global::Foundation.NSData GetBookmarkData (global::Foundation.NSUrl bookmarkFileUrl, out global::Foundation.NSError? error)
+	{
+		var bookmarkFileUrl__handle__ = bookmarkFileUrl!.GetNonNullHandle (nameof (bookmarkFileUrl));
+		global::ObjCRuntime.NativeHandle error__handle__;
+		global::Foundation.NSData ret;
+		if (IsDirectBinding) {
+			ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSData> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("bookmarkDataWithContentsOfURL:error:"), bookmarkFileUrl__handle__, &error__handle__))!;
+		} else {
+			ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSData> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("bookmarkDataWithContentsOfURL:error:"), bookmarkFileUrl__handle__, &error__handle__))!;
+		}
+		global::System.GC.KeepAlive (this);
+		global::System.GC.KeepAlive (bookmarkFileUrl);
+		error = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSError> (error__handle__);
 		return ret;
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedMethodsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedMethodsTests.cs
@@ -139,7 +139,28 @@ public partial class MethodTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial void CompleteRequest (global::Foundation.NSExtensionItem[] returningItems, global::System.Action<bool>? completionHandler)
+	public virtual unsafe partial void CompleteRequest (global::Foundation.NSExtensionItem[] returningItems, global::System.Action<bool>? completionHandler)
+	{
+		if (returningItems is null)
+			global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (returningItems));
+		using var nsa_returningItems = global::Foundation.NSArray.FromNSObjects (returningItems);
+		using var block_completionHandler = global::ObjCRuntime.Trampolines.SDActionArity1bool.CreateNullableBlock (completionHandler);
+		global::ObjCRuntime.BlockLiteral* block_ptr_completionHandler = completionHandler is not null ? &block_completionHandler : null;
+		if (IsDirectBinding) {
+			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+		} else {
+			global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+		}
+		global::System.GC.KeepAlive (this);
+		global::System.GC.KeepAlive (nsa_returningItems);
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public virtual partial global::System.Threading.Tasks.Task<bool> CompleteRequestAsync (global::Foundation.NSExtensionItem[] returningItems)
 	{
 		throw new NotImplementedException ();
 	}
@@ -149,7 +170,28 @@ public partial class MethodTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial global::System.Threading.Tasks.Task<bool> CompleteRequestAsync (global::Foundation.NSExtensionItem[] returningItems)
+	public virtual unsafe partial void CompleteRequest (global::Foundation.NSExtensionItem[] returningItems, global::System.Action<bool, string?>? completionHandler)
+	{
+		if (returningItems is null)
+			global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (returningItems));
+		using var nsa_returningItems = global::Foundation.NSArray.FromNSObjects (returningItems);
+		using var block_completionHandler = global::ObjCRuntime.Trampolines.SDActionArity2boolstring?.CreateNullableBlock (completionHandler);
+		global::ObjCRuntime.BlockLiteral* block_ptr_completionHandler = completionHandler is not null ? &block_completionHandler : null;
+		if (IsDirectBinding) {
+			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+		} else {
+			global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+		}
+		global::System.GC.KeepAlive (this);
+		global::System.GC.KeepAlive (nsa_returningItems);
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public virtual partial global::System.Threading.Tasks.Task<(bool, string?)> CompleteRequestAsync (global::Foundation.NSExtensionItem[] returningItems)
 	{
 		throw new NotImplementedException ();
 	}
@@ -159,7 +201,28 @@ public partial class MethodTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial void CompleteRequest (global::Foundation.NSExtensionItem[] returningItems, global::System.Action<bool, string?>? completionHandler)
+	public virtual unsafe partial void CompleteRequest (global::Foundation.NSExtensionItem[] returningItems, global::System.Action<bool, string, string?>? completionHandler)
+	{
+		if (returningItems is null)
+			global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (returningItems));
+		using var nsa_returningItems = global::Foundation.NSArray.FromNSObjects (returningItems);
+		using var block_completionHandler = global::ObjCRuntime.Trampolines.SDActionArity3boolstringstring?.CreateNullableBlock (completionHandler);
+		global::ObjCRuntime.BlockLiteral* block_ptr_completionHandler = completionHandler is not null ? &block_completionHandler : null;
+		if (IsDirectBinding) {
+			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+		} else {
+			global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+		}
+		global::System.GC.KeepAlive (this);
+		global::System.GC.KeepAlive (nsa_returningItems);
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public virtual partial global::System.Threading.Tasks.Task<(bool Success, string Name, string? Surname)> CompleteRequestAsync (global::Foundation.NSExtensionItem[] returningItems)
 	{
 		throw new NotImplementedException ();
 	}
@@ -169,9 +232,18 @@ public partial class MethodTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial global::System.Threading.Tasks.Task<(bool, string?)> CompleteRequestAsync (global::Foundation.NSExtensionItem[] returningItems)
+	public virtual unsafe partial global::Foundation.NSArray Filter (global::Foundation.NSPredicate predicate)
 	{
-		throw new NotImplementedException ();
+		var predicate__handle__ = predicate!.GetNonNullHandle (nameof (predicate));
+		global::Foundation.NSArray ret;
+		if (IsDirectBinding) {
+			ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSArray> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("filteredArrayUsingPredicate:"), predicate__handle__))!;
+		} else {
+			ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSArray> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("filteredArrayUsingPredicate:"), predicate__handle__))!;
+		}
+		global::System.GC.KeepAlive (this);
+		global::System.GC.KeepAlive (predicate);
+		return ret;
 	}
 
 	[SupportedOSPlatform ("macos")]
@@ -179,39 +251,20 @@ public partial class MethodTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial void CompleteRequest (global::Foundation.NSExtensionItem[] returningItems, global::System.Action<bool, string, string?>? completionHandler)
+	public virtual unsafe partial static global::Foundation.NSArray FromFile (string path)
 	{
-		throw new NotImplementedException ();
-	}
-
-	[SupportedOSPlatform ("macos")]
-	[SupportedOSPlatform ("ios")]
-	[SupportedOSPlatform ("tvos")]
-	[SupportedOSPlatform ("maccatalyst13.1")]
-	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial global::System.Threading.Tasks.Task<(bool Success, string Name, string? Surname)> CompleteRequestAsync (global::Foundation.NSExtensionItem[] returningItems)
-	{
-		throw new NotImplementedException ();
-	}
-
-	[SupportedOSPlatform ("macos")]
-	[SupportedOSPlatform ("ios")]
-	[SupportedOSPlatform ("tvos")]
-	[SupportedOSPlatform ("maccatalyst13.1")]
-	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial global::Foundation.NSArray Filter (global::Foundation.NSPredicate predicate)
-	{
-		throw new NotImplementedException ();
-	}
-
-	[SupportedOSPlatform ("macos")]
-	[SupportedOSPlatform ("ios")]
-	[SupportedOSPlatform ("tvos")]
-	[SupportedOSPlatform ("maccatalyst13.1")]
-	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial static global::Foundation.NSArray FromFile (string path)
-	{
-		throw new NotImplementedException ();
+		if (path is null)
+			global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (path));
+		var nspath = global::CoreFoundation.CFString.CreateNative (path);
+		global::Foundation.NSArray ret;
+		if (IsDirectBinding) {
+			ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSArray> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("arrayWithContentsOfFile:"), nspath))!;
+		} else {
+			ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSArray> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("arrayWithContentsOfFile:"), nspath))!;
+		}
+		global::System.GC.KeepAlive (this);
+		global::CoreFoundation.CFString.ReleaseNative (nspath);
+		return ret;
 	}
 
 	[SupportedOSPlatform ("macos")]
@@ -221,7 +274,20 @@ public partial class MethodTests
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	public partial static void LoadFromHtml (global::Foundation.NSUrlRequest request, global::Foundation.NSDictionary options, global::Foundation.NSAttributedStringCompletionHandler completionHandler)
 	{
-		throw new NotImplementedException ();
+		var request__handle__ = request!.GetNonNullHandle (nameof (request));
+		var options__handle__ = options!.GetNonNullHandle (nameof (options));
+		if (completionHandler is null)
+			global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (completionHandler));
+		using var block_completionHandler = global::ObjCRuntime.Trampolines.SDNSAttributedStringCompletionHandler.CreateNullableBlock (completionHandler);
+		global::ObjCRuntime.BlockLiteral* block_ptr_completionHandler = completionHandler is not null ? &block_completionHandler : null;
+		if (IsDirectBinding) {
+			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("loadFromHTMLWithRequest:options:completionHandler:"), request__handle__, options__handle__, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+		} else {
+			global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("loadFromHTMLWithRequest:options:completionHandler:"), request__handle__, options__handle__, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+		}
+		global::System.GC.KeepAlive (this);
+		global::System.GC.KeepAlive (request);
+		global::System.GC.KeepAlive (options);
 	}
 
 	[SupportedOSPlatform ("macos")]
@@ -241,7 +307,20 @@ public partial class MethodTests
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	public partial static void LoadFromHtmlNoName (global::Foundation.NSUrlRequest request, global::Foundation.NSDictionary options, global::Foundation.NSAttributedStringCompletionHandler completionHandler)
 	{
-		throw new NotImplementedException ();
+		var request__handle__ = request!.GetNonNullHandle (nameof (request));
+		var options__handle__ = options!.GetNonNullHandle (nameof (options));
+		if (completionHandler is null)
+			global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (completionHandler));
+		using var block_completionHandler = global::ObjCRuntime.Trampolines.SDNSAttributedStringCompletionHandler.CreateNullableBlock (completionHandler);
+		global::ObjCRuntime.BlockLiteral* block_ptr_completionHandler = completionHandler is not null ? &block_completionHandler : null;
+		if (IsDirectBinding) {
+			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("loadFromHTMLWithRequest:options:completionHandler:"), request__handle__, options__handle__, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+		} else {
+			global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("loadFromHTMLWithRequest:options:completionHandler:"), request__handle__, options__handle__, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+		}
+		global::System.GC.KeepAlive (this);
+		global::System.GC.KeepAlive (request);
+		global::System.GC.KeepAlive (options);
 	}
 
 	[SupportedOSPlatform ("macos")]
@@ -259,9 +338,18 @@ public partial class MethodTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial void SetValueForKey (global::Foundation.NSObject value, global::Foundation.NSString key)
+	public virtual unsafe partial void SetValueForKey (global::Foundation.NSObject value, global::Foundation.NSString key)
 	{
-		throw new NotImplementedException ();
+		var value__handle__ = value!.GetNonNullHandle (nameof (value));
+		var key__handle__ = key!.GetNonNullHandle (nameof (key));
+		if (IsDirectBinding) {
+			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setValue:forKey:"), value__handle__, key__handle__);
+		} else {
+			global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setValue:forKey:"), value__handle__, key__handle__);
+		}
+		global::System.GC.KeepAlive (this);
+		global::System.GC.KeepAlive (value);
+		global::System.GC.KeepAlive (key);
 	}
 
 	[SupportedOSPlatform ("macos")]
@@ -269,9 +357,20 @@ public partial class MethodTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial global::Foundation.NSArray Sort (global::Foundation.NSComparator cmptr)
+	public virtual unsafe partial global::Foundation.NSArray Sort (global::Foundation.NSComparator cmptr)
 	{
-		throw new NotImplementedException ();
+		if (cmptr is null)
+			global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (cmptr));
+		using var block_cmptr = global::ObjCRuntime.Trampolines.SDNSComparator.CreateNullableBlock (cmptr);
+		global::ObjCRuntime.BlockLiteral* block_ptr_cmptr = cmptr is not null ? &block_cmptr : null;
+		global::Foundation.NSArray ret;
+		if (IsDirectBinding) {
+			ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSArray> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("sortedArrayUsingComparator:"), (global::ObjCRuntime.NativeHandle) block_ptr_cmptr))!;
+		} else {
+			ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSArray> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("sortedArrayUsingComparator:"), (global::ObjCRuntime.NativeHandle) block_ptr_cmptr))!;
+		}
+		global::System.GC.KeepAlive (this);
+		return ret;
 	}
 
 	[SupportedOSPlatform ("macos")]
@@ -279,9 +378,20 @@ public partial class MethodTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial bool WriteToFile (string path, bool useAuxiliaryFile)
+	public virtual unsafe partial bool WriteToFile (string path, bool useAuxiliaryFile)
 	{
-		throw new NotImplementedException ();
+		if (path is null)
+			global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (path));
+		var nspath = global::CoreFoundation.CFString.CreateNative (path);
+		bool ret;
+		if (IsDirectBinding) {
+			ret = global::ObjCRuntime.Messaging.bool_objc_msgSend_NativeHandle_bool (this.Handle, global::ObjCRuntime.Selector.GetHandle ("writeToFile:atomically:"), nspath, useAuxiliaryFile ? (byte) 1 : (byte) 0) != 0;
+		} else {
+			ret = global::ObjCRuntime.Messaging.bool_objc_msgSendSuper_NativeHandle_bool (this.Handle, global::ObjCRuntime.Selector.GetHandle ("writeToFile:atomically:"), nspath, useAuxiliaryFile ? (byte) 1 : (byte) 0) != 0;
+		}
+		global::System.GC.KeepAlive (this);
+		global::CoreFoundation.CFString.ReleaseNative (nspath);
+		return ret;
 	}
 	// TODO: add binding code here
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
@@ -57,6 +57,13 @@ public partial class MethodTests {
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[Export<Method> ("filteredArrayUsingPredicate:")]
 	public virtual unsafe partial NSArray Filter (NSPredicate predicate);
+	
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[Export<Method> ("filteredArrayUsingStrings:")]
+	public virtual unsafe partial NSArray FilterStrings (string [] predicate);
 
 #if !__TVOS__
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
@@ -57,7 +57,7 @@ public partial class MethodTests {
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[Export<Method> ("filteredArrayUsingPredicate:")]
 	public virtual unsafe partial NSArray Filter (NSPredicate predicate);
-	
+
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("macos")]
@@ -108,7 +108,7 @@ public partial class MethodTests {
 		Flags = ObjCBindings.Method.Async,
 		ResultType = typeof ((bool Success, string Name, string? Surname)))]
 	public virtual unsafe partial void CompleteRequest (NSExtensionItem [] returningItems, Action<bool, string, string?>? completionHandler);
-	
+
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("macos")]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
@@ -21,42 +21,42 @@ public partial class MethodTests {
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[Export<Method> ("valueForKey:", Flags: Method.MarshalNativeExceptions)]
-	public partial NSObject ValueForKey (NSString key);
+	public virtual unsafe partial NSObject ValueForKey (NSString key);
 
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[Export<Method> ("setValue:forKey:")]
-	public partial void SetValueForKey (NSObject value, NSString key);
+	public virtual unsafe partial void SetValueForKey (NSObject value, NSString key);
 
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[Export<Method> ("writeToFile:atomically:")]
-	public partial bool WriteToFile (string path, bool useAuxiliaryFile);
+	public virtual unsafe partial bool WriteToFile (string path, bool useAuxiliaryFile);
 
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[Export<Method> ("arrayWithContentsOfFile:")]
-	public partial static NSArray FromFile (string path);
+	public virtual unsafe partial static NSArray FromFile (string path);
 
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[Export<Method> ("sortedArrayUsingComparator:")]
-	public partial NSArray Sort (NSComparator cmptr);
+	public virtual unsafe partial NSArray Sort (NSComparator cmptr);
 
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[Export<Method> ("filteredArrayUsingPredicate:")]
-	public partial NSArray Filter (NSPredicate predicate);
+	public virtual unsafe partial NSArray Filter (NSPredicate predicate);
 
 #if !__TVOS__
 
@@ -84,14 +84,14 @@ public partial class MethodTests {
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[Export<Method> ("completeRequestReturningItems:completionHandler:", Flags = ObjCBindings.Method.Async)]
-	public partial void CompleteRequest (NSExtensionItem [] returningItems, Action<bool>? completionHandler);
+	public virtual unsafe partial void CompleteRequest (NSExtensionItem [] returningItems, Action<bool>? completionHandler);
 
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[Export<Method> ("completeRequestReturningItems:completionHandler:", Flags = ObjCBindings.Method.Async)]
-	public partial void CompleteRequest (NSExtensionItem [] returningItems, Action<bool, string?>? completionHandler);
+	public virtual unsafe partial void CompleteRequest (NSExtensionItem [] returningItems, Action<bool, string?>? completionHandler);
 
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]
@@ -100,5 +100,5 @@ public partial class MethodTests {
 	[Export<Method> ("completeRequestReturningItems:completionHandler:",
 		Flags = ObjCBindings.Method.Async,
 		ResultType = typeof ((bool Success, string Name, string? Surname)))]
-	public partial void CompleteRequest (NSExtensionItem [] returningItems, Action<bool, string, string?>? completionHandler);
+	public virtual unsafe partial void CompleteRequest (NSExtensionItem [] returningItems, Action<bool, string, string?>? completionHandler);
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
@@ -108,4 +108,11 @@ public partial class MethodTests {
 		Flags = ObjCBindings.Method.Async,
 		ResultType = typeof ((bool Success, string Name, string? Surname)))]
 	public virtual unsafe partial void CompleteRequest (NSExtensionItem [] returningItems, Action<bool, string, string?>? completionHandler);
+	
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[Export<Method> ("bookmarkDataWithContentsOfURL:error:")]
+	public static unsafe partial NSData GetBookmarkData (NSUrl bookmarkFileUrl, out NSError? error);
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
@@ -762,9 +762,9 @@ public partial class PropertyTests
 				global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value));
 			using var nsa_value = global::Foundation.NSArray.FromStrings (value);
 			if (IsDirectBinding) {
-				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setSurnames:"), nsa_value);
+				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setSurnames:"), nsa_value.Handle);
 			} else {
-				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setSurnames:"), nsa_value);
+				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setSurnames:"), nsa_value.Handle);
 			}
 			global::System.GC.KeepAlive (this);
 			global::System.GC.KeepAlive (nsa_value);
@@ -890,9 +890,9 @@ public partial class PropertyTests
 				global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value));
 			using var nsa_value = global::Foundation.NSArray.FromNSObjects (value);
 			if (IsDirectBinding) {
-				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setResults:"), nsa_value);
+				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setResults:"), nsa_value.Handle);
 			} else {
-				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setResults:"), nsa_value);
+				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setResults:"), nsa_value.Handle);
 			}
 			global::System.GC.KeepAlive (this);
 			global::System.GC.KeepAlive (nsa_value);

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
@@ -762,9 +762,9 @@ public partial class PropertyTests
 				global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value));
 			using var nsa_value = global::Foundation.NSArray.FromStrings (value);
 			if (IsDirectBinding) {
-				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setSurnames:"), nsa_value);
+				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setSurnames:"), nsa_value.Handle);
 			} else {
-				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setSurnames:"), nsa_value);
+				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setSurnames:"), nsa_value.Handle);
 			}
 			global::System.GC.KeepAlive (this);
 			global::System.GC.KeepAlive (nsa_value);
@@ -890,9 +890,9 @@ public partial class PropertyTests
 				global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value));
 			using var nsa_value = global::Foundation.NSArray.FromNSObjects (value);
 			if (IsDirectBinding) {
-				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setResults:"), nsa_value);
+				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setResults:"), nsa_value.Handle);
 			} else {
-				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setResults:"), nsa_value);
+				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setResults:"), nsa_value.Handle);
 			}
 			global::System.GC.KeepAlive (this);
 			global::System.GC.KeepAlive (nsa_value);

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedMethodsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedMethodsTests.cs
@@ -42,6 +42,10 @@ public partial class MethodTests
 	static readonly global::ObjCRuntime.NativeHandle selFilteredArrayUsingPredicate_XHandle = global::ObjCRuntime.Selector.GetHandle ("filteredArrayUsingPredicate:");
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selFilteredArrayUsingStrings_X = "filteredArrayUsingStrings:";
+	static readonly global::ObjCRuntime.NativeHandle selFilteredArrayUsingStrings_XHandle = global::ObjCRuntime.Selector.GetHandle ("filteredArrayUsingStrings:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	const string selCompleteRequestReturningItems_CompletionHandler_X = "completeRequestReturningItems:completionHandler:";
 	static readonly global::ObjCRuntime.NativeHandle selCompleteRequestReturningItems_CompletionHandler_XHandle = global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:");
 
@@ -143,9 +147,9 @@ public partial class MethodTests
 		using var block_completionHandler = global::ObjCRuntime.Trampolines.SDActionArity1bool.CreateNullableBlock (completionHandler);
 		global::ObjCRuntime.BlockLiteral* block_ptr_completionHandler = completionHandler is not null ? &block_completionHandler : null;
 		if (IsDirectBinding) {
-			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems.Handle, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
 		} else {
-			global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+			global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems.Handle, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
 		}
 		global::System.GC.KeepAlive (this);
 		global::System.GC.KeepAlive (nsa_returningItems);
@@ -174,9 +178,9 @@ public partial class MethodTests
 		using var block_completionHandler = global::ObjCRuntime.Trampolines.SDActionArity2boolstring?.CreateNullableBlock (completionHandler);
 		global::ObjCRuntime.BlockLiteral* block_ptr_completionHandler = completionHandler is not null ? &block_completionHandler : null;
 		if (IsDirectBinding) {
-			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems.Handle, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
 		} else {
-			global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+			global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems.Handle, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
 		}
 		global::System.GC.KeepAlive (this);
 		global::System.GC.KeepAlive (nsa_returningItems);
@@ -205,9 +209,9 @@ public partial class MethodTests
 		using var block_completionHandler = global::ObjCRuntime.Trampolines.SDActionArity3boolstringstring?.CreateNullableBlock (completionHandler);
 		global::ObjCRuntime.BlockLiteral* block_ptr_completionHandler = completionHandler is not null ? &block_completionHandler : null;
 		if (IsDirectBinding) {
-			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems.Handle, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
 		} else {
-			global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+			global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems.Handle, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
 		}
 		global::System.GC.KeepAlive (this);
 		global::System.GC.KeepAlive (nsa_returningItems);
@@ -239,6 +243,27 @@ public partial class MethodTests
 		}
 		global::System.GC.KeepAlive (this);
 		global::System.GC.KeepAlive (predicate);
+		return ret;
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public virtual unsafe partial global::Foundation.NSArray FilterStrings (string[] predicate)
+	{
+		if (predicate is null)
+			global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (predicate));
+		using var nsa_predicate = global::Foundation.NSArray.FromStrings (predicate);
+		global::Foundation.NSArray ret;
+		if (IsDirectBinding) {
+			ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSArray> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("filteredArrayUsingStrings:"), nsa_predicate.Handle))!;
+		} else {
+			ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSArray> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("filteredArrayUsingStrings:"), nsa_predicate.Handle))!;
+		}
+		global::System.GC.KeepAlive (this);
+		global::System.GC.KeepAlive (nsa_predicate);
 		return ret;
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedMethodsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedMethodsTests.cs
@@ -50,6 +50,10 @@ public partial class MethodTests
 	static readonly global::ObjCRuntime.NativeHandle selCompleteRequestReturningItems_CompletionHandler_XHandle = global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:");
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selBookmarkDataWithContentsOfURL_Error_X = "bookmarkDataWithContentsOfURL:error:";
+	static readonly global::ObjCRuntime.NativeHandle selBookmarkDataWithContentsOfURL_Error_XHandle = global::ObjCRuntime.Selector.GetHandle ("bookmarkDataWithContentsOfURL:error:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	static readonly global::ObjCRuntime.NativeHandle class_ptr = global::ObjCRuntime.Class.GetHandle ("MethodTests");
 
 	/// <summary>The Objective-C class handle for this class.</summary>
@@ -285,6 +289,27 @@ public partial class MethodTests
 		}
 		global::System.GC.KeepAlive (this);
 		global::CoreFoundation.CFString.ReleaseNative (nspath);
+		return ret;
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public static unsafe partial global::Foundation.NSData GetBookmarkData (global::Foundation.NSUrl bookmarkFileUrl, out global::Foundation.NSError? error)
+	{
+		var bookmarkFileUrl__handle__ = bookmarkFileUrl!.GetNonNullHandle (nameof (bookmarkFileUrl));
+		global::ObjCRuntime.NativeHandle error__handle__;
+		global::Foundation.NSData ret;
+		if (IsDirectBinding) {
+			ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSData> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("bookmarkDataWithContentsOfURL:error:"), bookmarkFileUrl__handle__, &error__handle__))!;
+		} else {
+			ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSData> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("bookmarkDataWithContentsOfURL:error:"), bookmarkFileUrl__handle__, &error__handle__))!;
+		}
+		global::System.GC.KeepAlive (this);
+		global::System.GC.KeepAlive (bookmarkFileUrl);
+		error = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSError> (error__handle__);
 		return ret;
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedMethodsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedMethodsTests.cs
@@ -135,7 +135,28 @@ public partial class MethodTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial void CompleteRequest (global::Foundation.NSExtensionItem[] returningItems, global::System.Action<bool>? completionHandler)
+	public virtual unsafe partial void CompleteRequest (global::Foundation.NSExtensionItem[] returningItems, global::System.Action<bool>? completionHandler)
+	{
+		if (returningItems is null)
+			global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (returningItems));
+		using var nsa_returningItems = global::Foundation.NSArray.FromNSObjects (returningItems);
+		using var block_completionHandler = global::ObjCRuntime.Trampolines.SDActionArity1bool.CreateNullableBlock (completionHandler);
+		global::ObjCRuntime.BlockLiteral* block_ptr_completionHandler = completionHandler is not null ? &block_completionHandler : null;
+		if (IsDirectBinding) {
+			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+		} else {
+			global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+		}
+		global::System.GC.KeepAlive (this);
+		global::System.GC.KeepAlive (nsa_returningItems);
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public virtual partial global::System.Threading.Tasks.Task<bool> CompleteRequestAsync (global::Foundation.NSExtensionItem[] returningItems)
 	{
 		throw new NotImplementedException ();
 	}
@@ -145,7 +166,28 @@ public partial class MethodTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial global::System.Threading.Tasks.Task<bool> CompleteRequestAsync (global::Foundation.NSExtensionItem[] returningItems)
+	public virtual unsafe partial void CompleteRequest (global::Foundation.NSExtensionItem[] returningItems, global::System.Action<bool, string?>? completionHandler)
+	{
+		if (returningItems is null)
+			global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (returningItems));
+		using var nsa_returningItems = global::Foundation.NSArray.FromNSObjects (returningItems);
+		using var block_completionHandler = global::ObjCRuntime.Trampolines.SDActionArity2boolstring?.CreateNullableBlock (completionHandler);
+		global::ObjCRuntime.BlockLiteral* block_ptr_completionHandler = completionHandler is not null ? &block_completionHandler : null;
+		if (IsDirectBinding) {
+			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+		} else {
+			global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+		}
+		global::System.GC.KeepAlive (this);
+		global::System.GC.KeepAlive (nsa_returningItems);
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public virtual partial global::System.Threading.Tasks.Task<(bool, string?)> CompleteRequestAsync (global::Foundation.NSExtensionItem[] returningItems)
 	{
 		throw new NotImplementedException ();
 	}
@@ -155,7 +197,28 @@ public partial class MethodTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial void CompleteRequest (global::Foundation.NSExtensionItem[] returningItems, global::System.Action<bool, string?>? completionHandler)
+	public virtual unsafe partial void CompleteRequest (global::Foundation.NSExtensionItem[] returningItems, global::System.Action<bool, string, string?>? completionHandler)
+	{
+		if (returningItems is null)
+			global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (returningItems));
+		using var nsa_returningItems = global::Foundation.NSArray.FromNSObjects (returningItems);
+		using var block_completionHandler = global::ObjCRuntime.Trampolines.SDActionArity3boolstringstring?.CreateNullableBlock (completionHandler);
+		global::ObjCRuntime.BlockLiteral* block_ptr_completionHandler = completionHandler is not null ? &block_completionHandler : null;
+		if (IsDirectBinding) {
+			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+		} else {
+			global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("completeRequestReturningItems:completionHandler:"), nsa_returningItems, (global::ObjCRuntime.NativeHandle) block_ptr_completionHandler);
+		}
+		global::System.GC.KeepAlive (this);
+		global::System.GC.KeepAlive (nsa_returningItems);
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public virtual partial global::System.Threading.Tasks.Task<(bool Success, string Name, string? Surname)> CompleteRequestAsync (global::Foundation.NSExtensionItem[] returningItems)
 	{
 		throw new NotImplementedException ();
 	}
@@ -165,9 +228,18 @@ public partial class MethodTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial global::System.Threading.Tasks.Task<(bool, string?)> CompleteRequestAsync (global::Foundation.NSExtensionItem[] returningItems)
+	public virtual unsafe partial global::Foundation.NSArray Filter (global::Foundation.NSPredicate predicate)
 	{
-		throw new NotImplementedException ();
+		var predicate__handle__ = predicate!.GetNonNullHandle (nameof (predicate));
+		global::Foundation.NSArray ret;
+		if (IsDirectBinding) {
+			ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSArray> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("filteredArrayUsingPredicate:"), predicate__handle__))!;
+		} else {
+			ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSArray> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("filteredArrayUsingPredicate:"), predicate__handle__))!;
+		}
+		global::System.GC.KeepAlive (this);
+		global::System.GC.KeepAlive (predicate);
+		return ret;
 	}
 
 	[SupportedOSPlatform ("macos")]
@@ -175,9 +247,20 @@ public partial class MethodTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial void CompleteRequest (global::Foundation.NSExtensionItem[] returningItems, global::System.Action<bool, string, string?>? completionHandler)
+	public virtual unsafe partial static global::Foundation.NSArray FromFile (string path)
 	{
-		throw new NotImplementedException ();
+		if (path is null)
+			global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (path));
+		var nspath = global::CoreFoundation.CFString.CreateNative (path);
+		global::Foundation.NSArray ret;
+		if (IsDirectBinding) {
+			ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSArray> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("arrayWithContentsOfFile:"), nspath))!;
+		} else {
+			ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSArray> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("arrayWithContentsOfFile:"), nspath))!;
+		}
+		global::System.GC.KeepAlive (this);
+		global::CoreFoundation.CFString.ReleaseNative (nspath);
+		return ret;
 	}
 
 	[SupportedOSPlatform ("macos")]
@@ -185,9 +268,18 @@ public partial class MethodTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial global::System.Threading.Tasks.Task<(bool Success, string Name, string? Surname)> CompleteRequestAsync (global::Foundation.NSExtensionItem[] returningItems)
+	public virtual unsafe partial void SetValueForKey (global::Foundation.NSObject value, global::Foundation.NSString key)
 	{
-		throw new NotImplementedException ();
+		var value__handle__ = value!.GetNonNullHandle (nameof (value));
+		var key__handle__ = key!.GetNonNullHandle (nameof (key));
+		if (IsDirectBinding) {
+			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setValue:forKey:"), value__handle__, key__handle__);
+		} else {
+			global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setValue:forKey:"), value__handle__, key__handle__);
+		}
+		global::System.GC.KeepAlive (this);
+		global::System.GC.KeepAlive (value);
+		global::System.GC.KeepAlive (key);
 	}
 
 	[SupportedOSPlatform ("macos")]
@@ -195,9 +287,20 @@ public partial class MethodTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial global::Foundation.NSArray Filter (global::Foundation.NSPredicate predicate)
+	public virtual unsafe partial global::Foundation.NSArray Sort (global::Foundation.NSComparator cmptr)
 	{
-		throw new NotImplementedException ();
+		if (cmptr is null)
+			global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (cmptr));
+		using var block_cmptr = global::ObjCRuntime.Trampolines.SDNSComparator.CreateNullableBlock (cmptr);
+		global::ObjCRuntime.BlockLiteral* block_ptr_cmptr = cmptr is not null ? &block_cmptr : null;
+		global::Foundation.NSArray ret;
+		if (IsDirectBinding) {
+			ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSArray> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("sortedArrayUsingComparator:"), (global::ObjCRuntime.NativeHandle) block_ptr_cmptr))!;
+		} else {
+			ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSArray> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("sortedArrayUsingComparator:"), (global::ObjCRuntime.NativeHandle) block_ptr_cmptr))!;
+		}
+		global::System.GC.KeepAlive (this);
+		return ret;
 	}
 
 	[SupportedOSPlatform ("macos")]
@@ -205,39 +308,20 @@ public partial class MethodTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial static global::Foundation.NSArray FromFile (string path)
+	public virtual unsafe partial bool WriteToFile (string path, bool useAuxiliaryFile)
 	{
-		throw new NotImplementedException ();
-	}
-
-	[SupportedOSPlatform ("macos")]
-	[SupportedOSPlatform ("ios")]
-	[SupportedOSPlatform ("tvos")]
-	[SupportedOSPlatform ("maccatalyst13.1")]
-	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial void SetValueForKey (global::Foundation.NSObject value, global::Foundation.NSString key)
-	{
-		throw new NotImplementedException ();
-	}
-
-	[SupportedOSPlatform ("macos")]
-	[SupportedOSPlatform ("ios")]
-	[SupportedOSPlatform ("tvos")]
-	[SupportedOSPlatform ("maccatalyst13.1")]
-	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial global::Foundation.NSArray Sort (global::Foundation.NSComparator cmptr)
-	{
-		throw new NotImplementedException ();
-	}
-
-	[SupportedOSPlatform ("macos")]
-	[SupportedOSPlatform ("ios")]
-	[SupportedOSPlatform ("tvos")]
-	[SupportedOSPlatform ("maccatalyst13.1")]
-	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public partial bool WriteToFile (string path, bool useAuxiliaryFile)
-	{
-		throw new NotImplementedException ();
+		if (path is null)
+			global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (path));
+		var nspath = global::CoreFoundation.CFString.CreateNative (path);
+		bool ret;
+		if (IsDirectBinding) {
+			ret = global::ObjCRuntime.Messaging.bool_objc_msgSend_NativeHandle_bool (this.Handle, global::ObjCRuntime.Selector.GetHandle ("writeToFile:atomically:"), nspath, useAuxiliaryFile ? (byte) 1 : (byte) 0) != 0;
+		} else {
+			ret = global::ObjCRuntime.Messaging.bool_objc_msgSendSuper_NativeHandle_bool (this.Handle, global::ObjCRuntime.Selector.GetHandle ("writeToFile:atomically:"), nspath, useAuxiliaryFile ? (byte) 1 : (byte) 0) != 0;
+		}
+		global::System.GC.KeepAlive (this);
+		global::CoreFoundation.CFString.ReleaseNative (nspath);
+		return ret;
 	}
 	// TODO: add binding code here
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
@@ -762,9 +762,9 @@ public partial class PropertyTests
 				global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value));
 			using var nsa_value = global::Foundation.NSArray.FromStrings (value);
 			if (IsDirectBinding) {
-				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setSurnames:"), nsa_value);
+				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setSurnames:"), nsa_value.Handle);
 			} else {
-				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setSurnames:"), nsa_value);
+				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setSurnames:"), nsa_value.Handle);
 			}
 			global::System.GC.KeepAlive (this);
 			global::System.GC.KeepAlive (nsa_value);
@@ -890,9 +890,9 @@ public partial class PropertyTests
 				global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value));
 			using var nsa_value = global::Foundation.NSArray.FromNSObjects (value);
 			if (IsDirectBinding) {
-				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setResults:"), nsa_value);
+				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setResults:"), nsa_value.Handle);
 			} else {
-				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setResults:"), nsa_value);
+				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setResults:"), nsa_value.Handle);
 			}
 			global::System.GC.KeepAlive (this);
 			global::System.GC.KeepAlive (nsa_value);

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryArgumentsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryArgumentsTests.cs
@@ -327,6 +327,236 @@ namespace NS {
 				nullableINativeArrayParameter,
 				$"{Global ("System.GC")}.KeepAlive (nsa_inativeArray);\n"
 			];
+			
+			// byref string parameter
+			
+			var byrefStringParam = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback (out string outString);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				byrefStringParam,
+				$"outString = {Global ("CoreFoundation")}.CFString.FromHandle (nsoutString, false)!;\n",
+			];
+			
+			// byref string parameter nullable
+			
+			var nullableByrefStringParam = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback (out string? outNullableString);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				nullableByrefStringParam,
+				$"outNullableString = {Global ("CoreFoundation")}.CFString.FromHandle (nsoutNullableString, false);\n"
+			];
+			
+			// byref num not smart
+
+			var outNotSmartEnum = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCRuntime;
+
+namespace NS {
+	public MyEnum {
+		First = 0,
+		Last = 1,
+	}
+	public delegate void Callback (out MyEnum outNullableString);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				outNotSmartEnum,
+				string.Empty
+			];
+
+			// byref int
+
+			var outInt = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback (out int outNullableString);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				outInt,
+				string.Empty
+			];
+
+			// byref struct
+
+			var outStruct = @"
+using System;
+using AudioToolbox;
+using Foundation;
+using CoreMedia;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback (out AudioTimeStamp outStruct);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				outStruct,
+				string.Empty
+			];
+
+			// byref INativeObject
+
+			var outINativeObject = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCRuntime;
+using Security;
+
+namespace NS {
+	public delegate void Callback (out SecKey outINativeObject);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				outINativeObject,
+				$"outINativeObject = {Global ("ObjCRuntime")}.Runtime.GetINativeObject<global::Security.SecKey> (outINativeObject__handle__)!;\n"
+			];
+
+			// byref NSObject
+
+			var outNSObject = @"
+using System;
+using AVFoundation;
+using Foundation;
+using CoreMedia;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback (out NSObject outNSObject);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				outNSObject,
+				$"outNSObject = {Global ("ObjCRuntime")}.Runtime.GetNSObject<{Global ("Foundation")}.NSObject> (outNSObject__handle__)!;\n"
+			];
+
+			// byref string array
+
+			var outStringArray = @"
+using System;
+using AVFoundation;
+using Foundation;
+using CoreMedia;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback (out string[] outStringArray);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				outStringArray,
+				$"outStringArray = {Global ("CoreFoundation")}.CFArray.StringArrayFromHandle (nsa_outStringArray, false)!;\n"
+			];
+
+			// byref string array nullable
+
+			var outNullStringArray = @"
+using System;
+using AVFoundation;
+using Foundation;
+using CoreMedia;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback (out string[]? outNullStringArray);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				outNullStringArray,
+				$"outNullStringArray = {Global ("CoreFoundation")}.CFArray.StringArrayFromHandle (nsa_outNullStringArray, false);\n"
+			];
+			
+			// byref array of INativeObject
+
+			var outINativeObjectArray = @"
+using System;
+using AVFoundation;
+using Foundation;
+using CoreMedia;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback (out AVAsset[] outINativeObjectArray);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				outINativeObjectArray,
+				$"outINativeObjectArray = {Global ("CoreFoundation")}.CFArray.ArrayFromHandle<{Global ("AVFoundation")}.AVAsset> (nsa_outINativeObjectArray)!;\n",
+			];
+			// byref array of NSObject
+
+			var outNSObjectArray = @"
+using System;
+using AVFoundation;
+using Foundation;
+using CoreMedia;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback (out NSObject[] outNSObject);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				outNSObjectArray,
+				$"outNSObject = {Global ("CoreFoundation")}.CFArray.ArrayFromHandle<{Global ("Foundation")}.NSObject> (nsa_outNSObject)!;\n"
+			];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
@@ -756,6 +986,237 @@ namespace NS {
 				@$"using var block_callbackParameter = {Global ("ObjCRuntime.Trampolines.")}{Nomenclator.GetTrampolineClassName ("Action", Nomenclator.TrampolineClassType.StaticBridgeClass)}.CreateNullableBlock (callbackParameter);
 {Global ("ObjCRuntime")}.BlockLiteral* block_ptr_callbackParameter = callbackParameter is not null ? &block_callbackParameter : null;
 ",
+			];
+			
+			// byref string parameter
+			
+			var byrefStringParam = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback (out string outString);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				byrefStringParam,
+				$"{Global ("ObjCRuntime")}.NativeHandle nsoutString;\n"
+			];
+
+			// byref string parameter nullable
+
+			var nullableByrefStringParam = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback (out string? outNullableString);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				nullableByrefStringParam,
+				"global::ObjCRuntime.NativeHandle nsoutNullableString;\n"
+			];
+
+			// byref num not smart
+
+			var outNotSmartEnum = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCRuntime;
+
+namespace NS {
+	public MyEnum {
+		First = 0,
+		Last = 1,
+	}
+	public delegate void Callback (out MyEnum outNullableString);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				outNotSmartEnum,
+				string.Empty
+			];
+
+			// byref int
+
+			var outInt = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback (out int outNullableString);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				outInt,
+				string.Empty
+			];
+
+			// byref struct
+
+			var outStruct = @"
+using System;
+using AudioToolbox;
+using Foundation;
+using CoreMedia;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback (out AudioTimeStamp outStruct);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				outStruct,
+				string.Empty
+			];
+
+			// byref INativeObject
+
+			var outINativeObject = @"
+using System;
+using Foundation;
+using CoreMedia;
+using ObjCRuntime;
+using Security;
+
+namespace NS {
+	public delegate void Callback (out SecKey outINativeObject);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				outINativeObject,
+				$"{Global ("ObjCRuntime")}.NativeHandle outINativeObject__handle__;\n",
+			];
+
+			// byref NSObject
+
+			var outNSObject = @"
+using System;
+using AVFoundation;
+using Foundation;
+using CoreMedia;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback (out NSObject outNSObject);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				outNSObject,
+				$"{Global ("ObjCRuntime")}.NativeHandle outNSObject__handle__;\n",
+			];
+
+			// byref string array
+
+			var outStringArray = @"
+using System;
+using AVFoundation;
+using Foundation;
+using CoreMedia;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback (out string[] outStringArray);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				outStringArray,
+				$"{Global ("ObjCRuntime")}.NativeHandle nsa_outStringArray;\n",
+			];
+
+			// byref string array nullable
+
+			var outNullStringArray = @"
+using System;
+using AVFoundation;
+using Foundation;
+using CoreMedia;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback (out string[]? outNullStringArray);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				outNullStringArray,
+				$"{Global ("ObjCRuntime")}.NativeHandle nsa_outNullStringArray;\n",
+			];
+
+			// byref array of INativeObject
+
+			var outINativeObjectArray = @"
+using System;
+using AVFoundation;
+using Foundation;
+using CoreMedia;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback (out AVAsset[] outINativeObjectArray);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				outINativeObjectArray,
+				"global::ObjCRuntime.NativeHandle nsa_outINativeObjectArray;\n"
+			];
+
+			// byref array of NSObject
+
+			var outNSObjectArray = @"
+using System;
+using AVFoundation;
+using Foundation;
+using CoreMedia;
+using ObjCRuntime;
+
+namespace NS {
+	public delegate void Callback (out NSObject[] outNSObject);
+	public class MyClass {
+		public void MyMethod (Callback cb) {}
+	}
+}
+";
+			yield return [
+				outNSObjectArray,
+				$"{Global ("ObjCRuntime")}.NativeHandle nsa_outNSObject;\n",
 			];
 		}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryArgumentsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryArgumentsTests.cs
@@ -327,9 +327,9 @@ namespace NS {
 				nullableINativeArrayParameter,
 				$"{Global ("System.GC")}.KeepAlive (nsa_inativeArray);\n"
 			];
-			
+
 			// byref string parameter
-			
+
 			var byrefStringParam = @"
 using System;
 using Foundation;
@@ -347,9 +347,9 @@ namespace NS {
 				byrefStringParam,
 				$"outString = {Global ("CoreFoundation")}.CFString.FromHandle (nsoutString, false)!;\n",
 			];
-			
+
 			// byref string parameter nullable
-			
+
 			var nullableByrefStringParam = @"
 using System;
 using Foundation;
@@ -367,7 +367,7 @@ namespace NS {
 				nullableByrefStringParam,
 				$"outNullableString = {Global ("CoreFoundation")}.CFString.FromHandle (nsoutNullableString, false);\n"
 			];
-			
+
 			// byref num not smart
 
 			var outNotSmartEnum = @"
@@ -516,7 +516,7 @@ namespace NS {
 				outNullStringArray,
 				$"outNullStringArray = {Global ("CoreFoundation")}.CFArray.StringArrayFromHandle (nsa_outNullStringArray, false);\n"
 			];
-			
+
 			// byref array of INativeObject
 
 			var outINativeObjectArray = @"
@@ -987,9 +987,9 @@ namespace NS {
 {Global ("ObjCRuntime")}.BlockLiteral* block_ptr_callbackParameter = callbackParameter is not null ? &block_callbackParameter : null;
 ",
 			];
-			
+
 			// byref string parameter
-			
+
 			var byrefStringParam = @"
 using System;
 using Foundation;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryArgumentsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryArgumentsTests.cs
@@ -1284,7 +1284,7 @@ namespace NS {
 
 			yield return [
 				outBoolean,
-				"outBool = default;\n",
+				string.Empty
 			];
 
 			var outNSObject = @"
@@ -1302,7 +1302,7 @@ namespace NS {
 
 			yield return [
 				outNSObject,
-				"outNSObject = default;\n",
+				string.Empty,
 			];
 
 			var refNSObject = @"
@@ -1389,7 +1389,7 @@ namespace NS {
 
 			yield return [
 				outBoolean,
-				"*outBool = default;\n",
+				string.Empty
 			];
 
 			var outNSObject = @"
@@ -1407,7 +1407,7 @@ namespace NS {
 
 			yield return [
 				outNSObject,
-				"*outNSObject = default;\n",
+				string.Empty
 			];
 		}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryMethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryMethodTests.cs
@@ -166,8 +166,8 @@ namespace NS {
 
 			yield return [
 				singleArrayParameterMethod,
-				$"ret = {Global ("CoreFoundation")}.CFString.FromHandle ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSend_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:\"), nsa_input), false)!",
-				$"ret = {Global ("CoreFoundation")}.CFString.FromHandle ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSendSuper_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:\"), nsa_input), false)!"
+				$"ret = {Global ("CoreFoundation")}.CFString.FromHandle ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSend_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:\"), nsa_input.Handle), false)!",
+				$"ret = {Global ("CoreFoundation")}.CFString.FromHandle ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSendSuper_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:\"), nsa_input.Handle), false)!"
 			];
 
 			const string nullableSingleArrayParameterMethod = @"
@@ -184,8 +184,8 @@ namespace NS {
 
 			yield return [
 				nullableSingleArrayParameterMethod,
-				$"ret = {Global ("CoreFoundation")}.CFString.FromHandle ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSend_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:\"), nsa_input), false)!",
-				$"ret = {Global ("CoreFoundation")}.CFString.FromHandle ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSendSuper_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:\"), nsa_input), false)!"
+				$"ret = {Global ("CoreFoundation")}.CFString.FromHandle ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSend_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:\"), nsa_input.Handle), false)!",
+				$"ret = {Global ("CoreFoundation")}.CFString.FromHandle ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSendSuper_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:\"), nsa_input.Handle), false)!"
 			];
 
 			const string customTypeParameter = @"

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryMethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryMethodTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 namespace Microsoft.Macios.Generator.Tests.Emitters;
 
 public class BindingSyntaxFactoryMethodTests : BaseGeneratorTestClass {
-	
+
 	class TestDataGetInvocationsTests : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -151,7 +151,7 @@ namespace NS {
 				$"ret = {Global ("CoreFoundation")}.CFString.FromHandle ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSend_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:\"), nsevent), false)!",
 				$"ret = {Global ("CoreFoundation")}.CFString.FromHandle ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSendSuper_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:\"), nsevent), false)!"
 			];
-	
+
 			const string singleArrayParameterMethod = @"
 using System;
 using ObjCBindings;
@@ -339,7 +339,7 @@ namespace NS {
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
-	
+
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataGetInvocationsTests>]
 	void GetInvocationsTests (ApplePlatform platform, string inputText, string expectedSend, string expectedSendSuper)
@@ -359,5 +359,5 @@ namespace NS {
 		Assert.Equal (expectedSend, invocations.Send.ToString ());
 		Assert.Equal (expectedSendSuper, invocations.SendSuper.ToString ());
 	}
-	
+
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryMethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryMethodTests.cs
@@ -1,0 +1,363 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.DataModel;
+using Microsoft.Macios.Generator.Emitters;
+using Xamarin.Tests;
+using Xamarin.Utils;
+using Xunit;
+
+namespace Microsoft.Macios.Generator.Tests.Emitters;
+
+public class BindingSyntaxFactoryMethodTests : BaseGeneratorTestClass {
+	
+	class TestDataGetInvocationsTests : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			const string voidMethodNoParamsExportData = @"
+using System;
+using ObjCBindings;
+
+namespace NS {
+	public class MyClass {
+		[Export<Method>(""myMethod"")]
+		public void MyMethod () {}
+	}
+}
+";
+
+			yield return [
+				voidMethodNoParamsExportData,
+				$"{Global ("ObjCRuntime")}.Messaging.void_objc_msgSend (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod\"))",
+				$"{Global ("ObjCRuntime")}.Messaging.void_objc_msgSendSuper (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod\"))"
+			];
+
+			const string asyncVoidMethodNoParamsExportDataMisingFlag = @"
+using System;
+using ObjCBindings;
+
+namespace NS {
+	public class MyClass {
+		[Export<Method>(""myMethod"", Flags = Method.Default | Method.Async)]
+		public void MyMethod (Action<int> completionHandler) {}
+	}
+}
+";
+
+			yield return [
+				asyncVoidMethodNoParamsExportDataMisingFlag,
+				$"{Global ("ObjCRuntime")}.Messaging.void_objc_msgSend_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod\"), ({Global ("ObjCRuntime")}.NativeHandle) block_ptr_completionHandler)",
+				$"{Global ("ObjCRuntime")}.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod\"), ({Global ("ObjCRuntime")}.NativeHandle) block_ptr_completionHandler)",
+			];
+
+			const string asyncVoidMethodNoParamsExportDataAsyncFlag = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public class MyClass {
+		[Export<Method>(""myMethod"", Flags = Method.Default | Method.Async,
+			ResultTypeName = ""MyAsyncResult"")]
+		public void MyMethod (Action<bool, string, NSError?> completionHandler) {}
+	}
+}
+";
+
+			yield return [
+				asyncVoidMethodNoParamsExportDataAsyncFlag,
+				$"{Global ("ObjCRuntime")}.Messaging.void_objc_msgSend_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod\"), ({Global ("ObjCRuntime")}.NativeHandle) block_ptr_completionHandler)",
+				$"{Global ("ObjCRuntime")}.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod\"), ({Global ("ObjCRuntime")}.NativeHandle) block_ptr_completionHandler)"
+			];
+
+			const string stringMethodNoParams = @"
+using System;
+using ObjCBindings;
+
+namespace NS {
+	public class MyClass {
+
+		[Export<Method>(""myMethod"", Flags = Method.Default)]
+		public string MyMethod () => string.Empty;
+	}
+}
+";
+
+			yield return [
+				stringMethodNoParams,
+				$"ret = {Global ("CoreFoundation")}.CFString.FromHandle ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSend (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod\")), false)!",
+				$"ret = {Global ("CoreFoundation")}.CFString.FromHandle ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod\")), false)!"
+			];
+
+			const string customTypeNoParams = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public class CustomType : NSObject {
+	}
+
+	public class MyClass {
+
+		[Export<Method>(""myMethod"", Flags = Method.Default)]
+		public CustomType MyMethod () => new ();
+	}
+}
+";
+
+			yield return [
+				customTypeNoParams,
+				$"ret = {Global ("ObjCRuntime")}.Runtime.GetNSObject<{Global ("NS")}.CustomType> ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSend (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod\")))!",
+				$"ret = {Global ("ObjCRuntime")}.Runtime.GetNSObject<{Global ("NS")}.CustomType> ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod\")))!"
+			];
+
+			const string singleParameterMethod = @"
+using System;
+using ObjCBindings;
+
+namespace NS {
+	public class MyClass {
+		[Export<Method>(""myMethod:"", Flags = Method.Default)]
+		public string MyMethod (string input) => $""{input}_test"";
+	}
+}
+";
+
+			yield return [
+				singleParameterMethod,
+				$"ret = {Global ("CoreFoundation")}.CFString.FromHandle ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSend_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:\"), nsinput), false)!",
+				$"ret = {Global ("CoreFoundation")}.CFString.FromHandle ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSendSuper_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:\"), nsinput), false)!"
+			];
+
+			const string singleParameterKeywordNameMethod = @"
+using System;
+using ObjCBindings;
+
+namespace NS {
+	public class MyClass {
+		[Export<Method>(""myMethod:"", Flags = Method.Default)]
+		public string MyMethod (string @event) => $""{@event}_test"";
+	}
+}
+";
+
+			yield return [
+				singleParameterKeywordNameMethod,
+				$"ret = {Global ("CoreFoundation")}.CFString.FromHandle ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSend_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:\"), nsevent), false)!",
+				$"ret = {Global ("CoreFoundation")}.CFString.FromHandle ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSendSuper_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:\"), nsevent), false)!"
+			];
+	
+			const string singleArrayParameterMethod = @"
+using System;
+using ObjCBindings;
+
+namespace NS {
+	public class MyClass {
+		[Export<Method>(""myMethod:"", Flags = Method.Default)]
+		public string MyMethod (string[] input) => $""{input}_test"";
+	}
+}
+";
+
+			yield return [
+				singleArrayParameterMethod,
+				$"ret = {Global ("CoreFoundation")}.CFString.FromHandle ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSend_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:\"), nsa_input), false)!",
+				$"ret = {Global ("CoreFoundation")}.CFString.FromHandle ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSendSuper_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:\"), nsa_input), false)!"
+			];
+
+			const string nullableSingleArrayParameterMethod = @"
+using System;
+using ObjCBindings;
+
+namespace NS {
+	public class MyClass {
+		[Export<Method>(""myMethod:"", Flags = Method.Default)]
+		public string MyMethod (string[]? input) => $""{input}_test"";
+	}
+}
+";
+
+			yield return [
+				nullableSingleArrayParameterMethod,
+				$"ret = {Global ("CoreFoundation")}.CFString.FromHandle ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSend_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:\"), nsa_input), false)!",
+				$"ret = {Global ("CoreFoundation")}.CFString.FromHandle ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSendSuper_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:\"), nsa_input), false)!"
+			];
+
+			const string customTypeParameter = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public class CustomType : NSObject {
+	}
+
+	public class MyClass {
+		[Export<Method>(""myMethod:"", Flags = Method.Default)]
+		public void MyMethod (CustomType input) {}
+	}
+}
+";
+
+			yield return [
+				customTypeParameter,
+				$"{Global ("ObjCRuntime")}.Messaging.void_objc_msgSend_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:\"), input__handle__)",
+				$"{Global ("ObjCRuntime")}.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:\"), input__handle__)"
+			];
+
+			const string severalParametersMethod = @"
+using System;
+using ObjCBindings;
+
+namespace NS {
+	public class MyClass {
+		[Export<Method>(""myMethod:withOption:"", Flags = Method.Default)]
+		public string MyMethod (string input, string? second) => $""{input}_test{second}"";
+	}
+}
+";
+
+			yield return [
+				severalParametersMethod,
+				$"ret = {Global ("CoreFoundation")}.CFString.FromHandle ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSend_NativeHandle_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:withOption:\"), nsinput, nssecond), false)!",
+				$"ret = {Global ("CoreFoundation")}.CFString.FromHandle ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSendSuper_NativeHandle_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:withOption:\"), nsinput, nssecond), false)!"
+			];
+
+			const string outParameterMethod = @"
+using System;
+using ObjCBindings;
+
+namespace NS {
+	public class MyClass {
+
+		[Export<Method>(""tryGet:"", Flags = Method.Default)]
+		public bool TryGetString (out string? example) {
+			example = null;
+			return false;
+		}
+	}
+}
+";
+			yield return [
+				outParameterMethod,
+				$"ret = {Global ("ObjCRuntime")}.Messaging.bool_objc_msgSend_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"tryGet:\"), &nsexample) != 0",
+				$"ret = {Global ("ObjCRuntime")}.Messaging.bool_objc_msgSendSuper_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"tryGet:\"), &nsexample) != 0"
+			];
+
+			const string outStructParameter = @"
+using System;
+using ObjCBindings;
+
+namespace NS {
+	public readonly struct MyStruct {
+		public string Name { get; }
+		public MyStruct(string name) {
+			Name = name;
+		}
+	}
+	public class MyClass {
+		[Export<Method>(""myMethod:"", Flags = Method.Default)]
+		public void MyMethod (out MyStruct data) {
+			data = new MyStruct (""test"");
+		}
+	}
+}
+";
+
+			yield return [
+				outStructParameter,
+				$"{Global ("ObjCRuntime")}.Messaging.void_objc_msgSend_MyStruct (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:\"), ({Global ("NS")}.MyStruct*) {Global ("System")}.Runtime.CompilerServices.Unsafe.AsPointer<{Global ("NS")}.MyStruct> (ref data))",
+				$"{Global ("ObjCRuntime")}.Messaging.void_objc_msgSendSuper_MyStruct (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:\"), ({Global ("NS")}.MyStruct*) {Global ("System")}.Runtime.CompilerServices.Unsafe.AsPointer<{Global ("NS")}.MyStruct> (ref data))"
+			];
+
+			const string outNSErrorMethod = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public class MyClass {
+
+		[Export<Method>(""tryGet:withError:"", Flags = Method.Default)]
+		public bool TryGetString (string data, out NSError? example) {
+			example = null;
+			return false;
+		}
+	}
+}
+";
+			yield return [
+				outNSErrorMethod,
+				$"ret = {Global ("ObjCRuntime")}.Messaging.bool_objc_msgSend_NativeHandle_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"tryGet:withError:\"), nsdata, &example__handle__) != 0",
+				$"ret = {Global ("ObjCRuntime")}.Messaging.bool_objc_msgSendSuper_NativeHandle_NativeHandle (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"tryGet:withError:\"), nsdata, &example__handle__) != 0",
+			];
+
+			const string returnTypeBindFromAttribute = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public class MyClass {
+		[Export<Method>(""myMethod"", Flags = Method.Default)]
+		[return: BindFrom (typeof(NSNumber))]
+		public int MyMethod () {}
+	}
+}
+";
+
+			yield return [
+				returnTypeBindFromAttribute,
+				$"ret = {Global ("Foundation")}.NSNumber.ToInt32 ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSend (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod\")))",
+				$"ret = {Global ("Foundation")}.NSNumber.ToInt32 ({Global ("ObjCRuntime")}.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod\")))",
+			];
+
+			const string parameterBindFromAttr = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public class MyClass {
+		[Export<Method>(""myMethod:"", Flags = Method.Default)]
+		public void MyMethod ([BindFrom (typeof(NSNumber))] int value) {}
+	}
+}
+";
+
+			yield return [
+				parameterBindFromAttr,
+				$"{Global ("ObjCRuntime")}.Messaging.void_objc_msgSend_int (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:\"), nsb_value__handle__)",
+				$"{Global ("ObjCRuntime")}.Messaging.void_objc_msgSendSuper_int (this.Handle, {Global ("ObjCRuntime")}.Selector.GetHandle (\"myMethod:\"), nsb_value__handle__)"
+			];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataGetInvocationsTests>]
+	void GetInvocationsTests (ApplePlatform platform, string inputText, string expectedSend, string expectedSendSuper)
+	{
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
+		Assert.Single (syntaxTrees);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ().OfType<MethodDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		Assert.True (Method.TryCreate (declaration, semanticModel, out var changes));
+		Assert.NotNull (changes);
+		var invocations = BindingSyntaxFactory.GetInvocations (changes.Value);
+		var x = invocations.Send.ToString ();
+		var y = invocations.SendSuper.ToString ();
+		Assert.Equal (expectedSend, invocations.Send.ToString ());
+		Assert.Equal (expectedSendSuper, invocations.SendSuper.ToString ());
+	}
+	
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryMethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryMethodTests.cs
@@ -354,8 +354,6 @@ namespace NS {
 		Assert.True (Method.TryCreate (declaration, semanticModel, out var changes));
 		Assert.NotNull (changes);
 		var invocations = BindingSyntaxFactory.GetInvocations (changes.Value);
-		var x = invocations.Send.ToString ();
-		var y = invocations.SendSuper.ToString ();
 		Assert.Equal (expectedSend, invocations.Send.ToString ());
 		Assert.Equal (expectedSendSuper, invocations.SendSuper.ToString ());
 	}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
@@ -999,4 +999,22 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 		Assert.Equal (expectedDeclaration, declaration?.ToString ());
 	}
 
+	class TestDataGetHandleMemberTests : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			yield return ["myParam", "myParam.Handle"];
+			yield return ["another_variable", "another_variable.Handle"];
+			yield return ["obj", "obj.Handle"];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[ClassData (typeof (TestDataGetHandleMemberTests))]
+	void GetHandleMemberTests (string variableName, string expectedDeclaration)
+	{
+		var expression = GetHandleMember (IdentifierName (variableName));
+		Assert.Equal (expectedDeclaration, expression.ToString ());
+	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryPropertyTests.cs
@@ -121,9 +121,9 @@ public class BindingSyntaxFactoryPropertyTests {
 				property,
 				$"ret = {Global ("CoreFoundation.CFArray")}.StringArrayFromHandle ({Global ("ObjCRuntime.Messaging")}.NativeHandle_objc_msgSend (this.Handle, {Global ("ObjCRuntime.Selector")}.GetHandle (\"myProperty\")), false)!",
 				$"ret = {Global ("CoreFoundation.CFArray")}.StringArrayFromHandle ({Global ("ObjCRuntime.Messaging")}.NativeHandle_objc_msgSendSuper (this.Handle, {Global ("ObjCRuntime.Selector")}.GetHandle (\"myProperty\")), false)!",
-				"nsa_value",
-				"global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"setMyProperty:\"), nsa_value)",
-				"global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"setMyProperty:\"), nsa_value)",
+				"nsa_value.Handle",
+				"global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"setMyProperty:\"), nsa_value.Handle)",
+				"global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"setMyProperty:\"), nsa_value.Handle)",
 			];
 
 			property = new Property (
@@ -156,9 +156,9 @@ public class BindingSyntaxFactoryPropertyTests {
 				property,
 				$"ret = {Global ("CoreFoundation.CFArray")}.StringArrayFromHandle ({Global ("ObjCRuntime.Messaging")}.NativeHandle_objc_msgSend (this.Handle, {Global ("ObjCRuntime.Selector")}.GetHandle (\"myProperty\")), false)",
 				$"ret = {Global ("CoreFoundation.CFArray")}.StringArrayFromHandle ({Global ("ObjCRuntime.Messaging")}.NativeHandle_objc_msgSendSuper (this.Handle, {Global ("ObjCRuntime.Selector")}.GetHandle (\"myProperty\")), false)",
-				"nsa_value",
-				"global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"setMyProperty:\"), nsa_value)",
-				"global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"setMyProperty:\"), nsa_value)",
+				"nsa_value.Handle",
+				"global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"setMyProperty:\"), nsa_value.Handle)",
+				"global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"setMyProperty:\"), nsa_value.Handle)",
 			];
 
 			property = new Property (
@@ -366,9 +366,9 @@ public class BindingSyntaxFactoryPropertyTests {
 				property,
 				$"ret = {Global ("CoreFoundation.CFArray")}.ArrayFromHandle<{Global ("Foundation.NSObject")}> ({Global ("ObjCRuntime.Messaging")}.NativeHandle_objc_msgSend (this.Handle, {Global ("ObjCRuntime.Selector")}.GetHandle (\"myProperty\")))!",
 				$"ret = {Global ("CoreFoundation.CFArray")}.ArrayFromHandle<{Global ("Foundation.NSObject")}> ({Global ("ObjCRuntime.Messaging")}.NativeHandle_objc_msgSendSuper (this.Handle, {Global ("ObjCRuntime.Selector")}.GetHandle (\"myProperty\")))!",
-				"nsa_value",
-				"global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"setMyProperty:\"), nsa_value)",
-				"global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"setMyProperty:\"), nsa_value)"
+				"nsa_value.Handle",
+				"global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"setMyProperty:\"), nsa_value.Handle)",
+				"global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle (\"setMyProperty:\"), nsa_value.Handle)"
 			];
 
 			property = new Property (

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/ReturnInfoTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/ReturnInfoTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 namespace Microsoft.Macios.Generator.Tests.Emitters;
 
 public class ReturnInfoTests {
-	
+
 	[Fact]
 	public void Constructor_WithProperty_SetsPropertiesCorrectly ()
 	{
@@ -31,9 +31,8 @@ public class ReturnInfoTests {
 					attributes: [],
 					modifiers: []
 				)
-			])
-		{
-			ExportPropertyData = new("name"),
+			]) {
+			ExportPropertyData = new ("name"),
 			BindAs = new BindFromData (new TypeInfo { Name = "NSString" })
 		};
 
@@ -63,9 +62,8 @@ public class ReturnInfoTests {
 					attributes: [],
 					modifiers: []
 				)
-			])
-		{
-			ExportPropertyData = new("name"),
+			]) {
+			ExportPropertyData = new ("name"),
 			BindAs = new BindFromData (new TypeInfo { Name = "NSString" })
 		};
 
@@ -82,7 +80,7 @@ public class ReturnInfoTests {
 		var delegateInfo = new DelegateInfo (
 			"TestDelegate",
 			"System.Action",
-			TypeInfo.Void, 
+			TypeInfo.Void,
 			ImmutableArray<DelegateParameter>.Empty
 		);
 
@@ -113,7 +111,7 @@ public class ReturnInfoTests {
 	[Fact]
 	public void Constructor_WithMethod_SetsPropertiesCorrectly ()
 	{
-		
+
 		var method = new Method (
 			type: "MyType",
 			name: "MyMethod",
@@ -137,7 +135,7 @@ public class ReturnInfoTests {
 	[Fact]
 	public void ImplicitConversion_FromMethod_ConvertsCorrectly ()
 	{
-		
+
 		var method = new Method (
 			type: "MyType",
 			name: "MyMethod",

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/ReturnInfoTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/ReturnInfoTests.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Macios.Generator.Attributes;
+using Microsoft.Macios.Generator.DataModel;
+using Microsoft.Macios.Generator.Emitters;
+using Xunit;
+
+namespace Microsoft.Macios.Generator.Tests.Emitters;
+
+public class ReturnInfoTests {
+	
+	[Fact]
+	public void Constructor_WithProperty_SetsPropertiesCorrectly ()
+	{
+		var property = new Property (
+			name: "FirstProperty",
+			returnType: new ("string"),
+			symbolAvailability: new (),
+			attributes: [],
+			modifiers: [
+				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+			],
+			accessors: [
+				new (
+					accessorKind: AccessorKind.Getter,
+					symbolAvailability: new (),
+					exportPropertyData: null,
+					attributes: [],
+					modifiers: []
+				)
+			])
+		{
+			ExportPropertyData = new("name"),
+			BindAs = new BindFromData (new TypeInfo { Name = "NSString" })
+		};
+
+		var returnInfo = new ReturnInfo (property);
+
+		Assert.Equal (property.ReturnType, returnInfo.Type);
+		Assert.Equal (property.BindAs, returnInfo.BindAs);
+		Assert.Null (returnInfo.ReleaseHandle);
+	}
+
+	[Fact]
+	public void ImplicitConversion_FromProperty_ConvertsCorrectly ()
+	{
+		var property = new Property (
+			name: "FirstProperty",
+			returnType: new ("string"),
+			symbolAvailability: new (),
+			attributes: [],
+			modifiers: [
+				SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+			],
+			accessors: [
+				new (
+					accessorKind: AccessorKind.Getter,
+					symbolAvailability: new (),
+					exportPropertyData: null,
+					attributes: [],
+					modifiers: []
+				)
+			])
+		{
+			ExportPropertyData = new("name"),
+			BindAs = new BindFromData (new TypeInfo { Name = "NSString" })
+		};
+
+		ReturnInfo returnInfo = property;
+
+		Assert.Equal (property.ReturnType, returnInfo.Type);
+		Assert.Equal (property.BindAs, returnInfo.BindAs);
+		Assert.Null (returnInfo.ReleaseHandle);
+	}
+
+	[Fact]
+	public void Constructor_WithDelegateInfo_SetsPropertiesCorrectly ()
+	{
+		var delegateInfo = new DelegateInfo (
+			"TestDelegate",
+			"System.Action",
+			TypeInfo.Void, 
+			ImmutableArray<DelegateParameter>.Empty
+		);
+
+		var returnInfo = new ReturnInfo (delegateInfo);
+
+		Assert.Equal (delegateInfo.ReturnType, returnInfo.Type);
+		Assert.Null (returnInfo.BindAs);
+		Assert.False (returnInfo.ReleaseHandle);
+	}
+
+	[Fact]
+	public void ImplicitConversion_FromDelegateInfo_ConvertsCorrectly ()
+	{
+		var delegateInfo = new DelegateInfo (
+			"TestDelegate",
+			"System.Action",
+			TestDataFactory.ReturnTypeForInt (),
+			ImmutableArray<DelegateParameter>.Empty
+		);
+
+		ReturnInfo returnInfo = delegateInfo;
+
+		Assert.Equal (delegateInfo.ReturnType, returnInfo.Type);
+		Assert.Null (returnInfo.BindAs);
+		Assert.False (returnInfo.ReleaseHandle);
+	}
+
+	[Fact]
+	public void Constructor_WithMethod_SetsPropertiesCorrectly ()
+	{
+		
+		var method = new Method (
+			type: "MyType",
+			name: "MyMethod",
+			returnType: TestDataFactory.ReturnTypeForEnum ("MyEnum", isSmartEnum: true),
+			symbolAvailability: new (),
+			exportMethodData: new (selector: "myMethod"),
+			attributes: [],
+			modifiers: [],
+			parameters: []
+		) {
+			BindAs = new BindFromData (TestDataFactory.ReturnTypeForNSString ()),
+		};
+
+		var returnInfo = new ReturnInfo (method);
+
+		Assert.Equal (method.ReturnType, returnInfo.Type);
+		Assert.Equal (method.BindAs, returnInfo.BindAs);
+		Assert.Null (returnInfo.ReleaseHandle);
+	}
+
+	[Fact]
+	public void ImplicitConversion_FromMethod_ConvertsCorrectly ()
+	{
+		
+		var method = new Method (
+			type: "MyType",
+			name: "MyMethod",
+			returnType: TestDataFactory.ReturnTypeForEnum ("MyEnum", isSmartEnum: true),
+			symbolAvailability: new (),
+			exportMethodData: new (selector: "myMethod"),
+			attributes: [],
+			modifiers: [],
+			parameters: []
+		) {
+			BindAs = new BindFromData (TestDataFactory.ReturnTypeForNSString ()),
+		};
+
+		ReturnInfo returnInfo = method;
+
+		Assert.Equal (method.ReturnType, returnInfo.Type);
+		Assert.Equal (method.BindAs, returnInfo.BindAs);
+		Assert.Null (returnInfo.ReleaseHandle);
+	}
+}


### PR DESCRIPTION
Adds the generation of the sync methods. This is a list of the needed changes:

1. Improved how we deal with out parameters. This were not correctly exercised in delegates and properties as we have some small bugs.
2. Generate the method calls for sync methods in the class emitter.
3. Updated the tests to make methods virtual (if not static) and usafe. The modifiers will be provided by the new sharpie.
4. For async methods, remove the unsafe modifiers.