### PR TITLE
[release/9.0.1xx] [msbuild] Improve diagnostics when we fail to process an xcframework.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -830,7 +830,19 @@
     </data>
 
     <data name="E0174" xml:space="preserve">
-        <value>The xcframework {0} has an incorrect or unknown format and cannot be processed.</value>
+        <value>Failed to resolve the xcframework {0} in {1} due to an unexpected error: {2}</value>
+    </data>
+
+    <data name="E0174a" xml:space="preserve">
+        <value>The xcframework {0} has an incorrect or unknown format and cannot be processed: expected the value for 'CFBundlePackageType' to be 'XFWK' in the xcframework's Info.plist, but it's '{1}'.</value>
+    </data>
+
+    <data name="E0174b" xml:space="preserve">
+        <value>The xcframework {0} has an incorrect or unknown format and cannot be processed: there's no 'AvailableLibraries' entry in the xcframework's Info.plist.</value>
+    </data>
+
+    <data name="E0174c" xml:space="preserve">
+        <value>The xcframework {0} has an incorrect or unknown format and cannot be processed: expected some 'AvailableLibraries' entries in the xcframework's Info.plist, but found 0 entries.</value>
     </data>
 
     <data name="E0175" xml:space="preserve">


### PR DESCRIPTION
"body": null,

Backport of #23252.