### PR TITLE
[release/9.0.1xx] [devops] There's no need to run the job to re-enable macOS bots from Windows, so do it from Ubuntu instead.

### DIFF
--- a/tools/devops/automation/templates/windows/reenable-mac.yml
+++ b/tools/devops/automation/templates/windows/reenable-mac.yml
@@ -30,14 +30,18 @@ steps:
   displayName: 'Download id_rsa'
 
 - pwsh: |
-    $idRsaPath = "$(Get-Location)\id_rsa"
+    $idRsaPath = "$(Get-Location)/id_rsa"
     Write-Host "##vso[task.setvariable variable=ID_RSA_PATH]$idRsaPath"
     Add-Content -Path "id_rsa"  -Value "$(RemoteMacIdRsa)"
     # We need to make sure the private key is only accessible by the current user,
     # otherwise ssh will complain and not use it.
-    icacls id_rsa /inheritance:r
-    $grant="$Env:USERNAME" + ":(R)"
-    icacls id_rsa /grant:r $grant
+    if ($IsWindows) {
+      icacls id_rsa /inheritance:r
+      $grant="$Env:USERNAME" + ":(R)"
+      icacls id_rsa /grant:r $grant
+    } else {
+      chmod 600 $idRsaPath
+    }
   displayName: "Write and verify id_rsa"
   continueOnError: true
 
@@ -51,7 +55,7 @@ steps:
 - template: ./generate-token.yml
 
 - pwsh: |
-    Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\$Env:BUILD_REPOSITORY_TITLE\tools\devops\automation\scripts\MaciosCI.psd1
+    Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/$Env:BUILD_REPOSITORY_TITLE/tools/devops/automation/scripts/MaciosCI.psd1
 
     $azdoBearerToken = "$(AzDO.BearerToken)"
     $azdoBearerTokenHint = $azdoBearerToken.Substring(0, 8)

--- a/tools/devops/automation/templates/windows/reenable-mac.yml
+++ b/tools/devops/automation/templates/windows/reenable-mac.yml
@@ -40,9 +40,3 @@ steps:
     $vsts.Agents.SetEnabled($pool, $agent, $True)
   displayName: 'Re-enabled macOS bot from pool'
   condition: always()
-
-- pwsh: |
-    Remove-Item "$(ID_RSA_PATH)"
-  displayName: "Remove secrets"
-  condition: always()
-  continueOnError: true

--- a/tools/devops/automation/templates/windows/reenable-mac.yml
+++ b/tools/devops/automation/templates/windows/reenable-mac.yml
@@ -22,35 +22,6 @@ steps:
 - pwsh: '& "$Env:SYSTEM_DEFAULTWORKINGDIRECTORY/$Env:BUILD_REPOSITORY_TITLE/tools/devops/automation/scripts/show_bot_info.ps1"'
   displayName: 'Show Bot Info'
 
-- task: AzureKeyVault@2
-  inputs:
-    azureSubscription: 'Xamarin - SDK Engineering - macios-team-pair-to-mac-ci'
-    KeyVaultName: 'xamarin-ios-vault'
-    SecretsFilter: 'RemoteMacIdRsa'
-  displayName: 'Download id_rsa'
-
-- pwsh: |
-    $idRsaPath = "$(Get-Location)/id_rsa"
-    Write-Host "##vso[task.setvariable variable=ID_RSA_PATH]$idRsaPath"
-    Add-Content -Path "id_rsa"  -Value "$(RemoteMacIdRsa)"
-    # We need to make sure the private key is only accessible by the current user,
-    # otherwise ssh will complain and not use it.
-    if ($IsWindows) {
-      icacls id_rsa /inheritance:r
-      $grant="$Env:USERNAME" + ":(R)"
-      icacls id_rsa /grant:r $grant
-    } else {
-      chmod 600 $idRsaPath
-    }
-  displayName: "Write and verify id_rsa"
-  continueOnError: true
-
-- pwsh: |
-    ssh -v -i "$(ID_RSA_PATH)" -o IdentitiesOnly=yes -o StrictHostKeyChecking=no builder@$Env:MAC_AGENT_IP -- rm -f "/Users/$($Env:MAC_AGENT_USER)/remote_build_testing/BuildId.txt"
-  displayName: 'Remove BuildId from macOS bot'
-  condition: always()
-  continueOnError: true
-
 # Sets the AzDO.BearerToken variable used as the auth token to disable/reenable agents
 - template: ./generate-token.yml
 

--- a/tools/devops/automation/templates/windows/stage.yml
+++ b/tools/devops/automation/templates/windows/stage.yml
@@ -116,9 +116,7 @@ stages:
     workspace:
       clean: all
     pool:
-      name: ${{ parameters.windowsPool }}
-      demands:
-      - agent.os -equals Windows_NT
+      vmImage: ubuntu-latest
 
     steps:
     - template: reenable-mac.yml


### PR DESCRIPTION
Our windows bots have pwsh problems, causing re-enabling to fail, so just do
this on a Ubuntu vm image instead. Hopefully this will be more reliable.

Also remove some cleanup, which is not strictly necessary and doesn't work from VMs.

Backport of #23222.