### PR TITLE
Revert "[release/9.0.1xx] Update dependencies from dotnet/sdk (#22770)"

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -10,20 +10,13 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from xamarin-xamarin-macios -->
+    <add key="darc-pub-xamarin-xamarin-macios-72132bf" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-xamarin-xamarin-macios-72132bf9/nuget/v3/index.json" />
     <!--  End: Package sources from xamarin-xamarin-macios -->
     <!--  Begin: Package sources from dotnet-emsdk -->
     <!--  End: Package sources from dotnet-emsdk -->
     <!--  Begin: Package sources from dotnet-aspnetcore -->
-    <add key="darc-int-dotnet-aspnetcore-f6b3a5d" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-aspnetcore-f6b3a5da/nuget/v3/index.json" />
-    <add key="darc-int-dotnet-aspnetcore-f6b3a5d-3" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-aspnetcore-f6b3a5da-3/nuget/v3/index.json" />
-    <add key="darc-int-dotnet-aspnetcore-f6b3a5d-2" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-aspnetcore-f6b3a5da-2/nuget/v3/index.json" />
-    <add key="darc-int-dotnet-aspnetcore-f6b3a5d-1" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-aspnetcore-f6b3a5da-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-aspnetcore -->
     <!--  Begin: Package sources from dotnet-runtime -->
-    <add key="darc-int-dotnet-runtime-3c298d9" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-runtime-3c298d9f/nuget/v3/index.json" />
-    <add key="darc-int-dotnet-runtime-3c298d9-3" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-runtime-3c298d9f-3/nuget/v3/index.json" />
-    <add key="darc-int-dotnet-runtime-3c298d9-2" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-runtime-3c298d9f-2/nuget/v3/index.json" />
-    <add key="darc-int-dotnet-runtime-3c298d9-1" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-runtime-3c298d9f-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-runtime -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />
@@ -48,23 +41,13 @@
     <add key="darc-pub-dotnet-runtime-7aa8bb0" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-7aa8bb0e/nuget/v3/index.json" />
     <!-- Add a 8.0.16 feed -->
     <add key="darc-pub-dotnet-runtime-0239fb04" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-0239fb04/nuget/v3/index.json" />
-    <!-- Add a 8.0.18 feed -->
-    <add key="darc-pub-dotnet-runtime-c0390586" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-c0390586/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-runtime -->
-    <add key="darc-int-dotnet-runtime-3c298d9-1" value="true" />
-    <add key="darc-int-dotnet-runtime-3c298d9-2" value="true" />
-    <add key="darc-int-dotnet-runtime-3c298d9-3" value="true" />
-    <add key="darc-int-dotnet-runtime-3c298d9" value="true" />
     <!--  End: Package sources from dotnet-runtime -->
     <!--  Begin: Package sources from dotnet-aspnetcore -->
-    <add key="darc-int-dotnet-aspnetcore-f6b3a5d-1" value="true" />
-    <add key="darc-int-dotnet-aspnetcore-f6b3a5d-2" value="true" />
-    <add key="darc-int-dotnet-aspnetcore-f6b3a5d-3" value="true" />
-    <add key="darc-int-dotnet-aspnetcore-f6b3a5d" value="true" />
     <!--  End: Package sources from dotnet-aspnetcore -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
   </disabledPackageSources>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,34 +1,34 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="9.0.108-servicing.25359.17">
+    <Dependency Name="Microsoft.NET.Sdk" Version="9.0.107-servicing.25272.8">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>53b64c5f26e0a61734ed5944fe19903e649d2dec</Sha>
+      <Sha>38e51fe4e1fa36644ea66191001e82078989f051</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink" Version="9.0.0-alpha.1.23556.4">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf47d9ff6827a3e1d6f2acbf925cd618418f20dd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="9.0.7" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="9.0.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
-      <Sha>3c298d9f00936d651cc47d221762474e25277672</Sha>
+      <Sha>e36e4d1a8f8dfb08d7e3a6041459c9791d732c01</Sha>
     </Dependency>
     <!-- Set TRACKING_DOTNET_RUNTIME_SEPARATELY to something in Make.config if removing the CoherentParentDependency on Microsoft.NET.Sdk -->
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.7" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
-      <Sha>3c298d9f00936d651cc47d221762474e25277672</Sha>
+      <Sha>e36e4d1a8f8dfb08d7e3a6041459c9791d732c01</Sha>
     </Dependency>
     <!-- This is required for our test apps to build; in some cases Microsoft.AspNetCore.App is pulled in, and when building test apps the build needs to be able to resolve that -->
-    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="9.0.7" CoherentParentDependency="Microsoft.NET.Sdk">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="9.0.5" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-aspnetcore</Uri>
-      <Sha>f6b3a5da75eb405046889a5447ec9b14cc29d285</Sha>
+      <Sha>ed74665e773dd1ebea3289c5662d71c590305932</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-9.0.100.Transport" Version="9.0.7-servicing.25304.2" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-9.0.100.Transport" Version="9.0.5-servicing.25212.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>b567cdb6b8b461de79f2a2536a22ca3a67f2f33e</Sha>
+      <Sha>78f6f07d38e8755e573039a8aa04e131d3e59b76</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Cecil" Version="0.11.5-alpha.25275.2" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+    <Dependency Name="Microsoft.DotNet.Cecil" Version="0.11.5-alpha.25213.4" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/cecil</Uri>
-      <Sha>bbb895e8e9f2d566eae04f09977b8c5f895057d2</Sha>
+      <Sha>a8336269316c42f8164fe7bf45972dd8a81e52dc</Sha>
     </Dependency>
     <!-- This is a subscription of the .NET 8/Xcode 16.0 versions of our packages -->
     <Dependency Name="Microsoft.MacCatalyst.Sdk.net8.0_18.0" Version="18.0.8324">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,16 +2,16 @@
   <!--Package versions-->
   <PropertyGroup>
     <!-- Versions updated by maestro -->
-    <MicrosoftNETSdkPackageVersion>9.0.108-servicing.25359.17</MicrosoftNETSdkPackageVersion>
-    <MicrosoftNETILLinkTasksPackageVersion>9.0.7</MicrosoftNETILLinkTasksPackageVersion>
+    <MicrosoftNETSdkPackageVersion>9.0.107-servicing.25272.8</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETILLinkTasksPackageVersion>9.0.5</MicrosoftNETILLinkTasksPackageVersion>
     <MicrosoftNETILLinkPackageVersion>9.0.0-alpha.1.23556.4</MicrosoftNETILLinkPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>9.0.0-beta.25271.1</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftDotNetSharedFrameworkSdkVersion>8.0.0-beta.24413.2</MicrosoftDotNetSharedFrameworkSdkVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>9.0.7</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>9.0.5</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportVersion>8.0.0-rtm.23511.3</MicrosoftNETWorkloadEmscriptenCurrentManifest80100TransportVersion>
     <MicrosoftNETRuntimeMonoTargetsSdkPackageVersion>9.0.0-rc.2.24462.10</MicrosoftNETRuntimeMonoTargetsSdkPackageVersion>
     <MicrosoftTemplateEngineTasksVersion>7.0.100-alpha.1.21601.1</MicrosoftTemplateEngineTasksVersion>
-    <MicrosoftDotNetCecilPackageVersion>0.11.5-alpha.25275.2</MicrosoftDotNetCecilPackageVersion>
+    <MicrosoftDotNetCecilPackageVersion>0.11.5-alpha.25213.4</MicrosoftDotNetCecilPackageVersion>
     <MicrosoftDotNetXHarnessiOSSharedPackageVersion>10.0.0-prerelease.25262.1</MicrosoftDotNetXHarnessiOSSharedPackageVersion>
     <MicrosoftDotNetArcadeSdkPackageVersion>9.0.0-beta.25271.1</MicrosoftDotNetArcadeSdkPackageVersion>
     <!-- Manually updated versions -->

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "9.0.108-servicing.25359.17"
+    "version": "9.0.107-servicing.25272.8"
   },
   "tools": {
-    "dotnet": "9.0.108-servicing.25359.17"
+    "dotnet": "9.0.107-servicing.25272.8"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.25271.1"


### PR DESCRIPTION
This reverts commit 5feed5c9d7bc8dd05cce95f85c928a2902cfdca1.

This commit adds internal nuget feeds, which we want to avoid.