### PR TITLE
[release/9.0.1xx] [src/runtime] Rework how we store data in NSObject. Fixes #23284.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -214,8 +214,7 @@ monoobject_dict_free_value (CFAllocatorRef allocator, const void *value)
  */
 
 struct TrackedObjectInfo {
-	id handle;
-	enum NSObjectFlags flags;
+	struct NSObjectData* data;
 };
 
 void
@@ -298,9 +297,9 @@ xamarin_coreclr_reference_tracking_is_referenced_callback (void* ptr)
 	// (and which is passed as the 'ptr' argument), so let's get the data we need from there.
 	int rv = 0;
 	struct TrackedObjectInfo *info = (struct TrackedObjectInfo *) ptr;
-	enum NSObjectFlags flags = info->flags;
+	enum NSObjectFlags flags = (enum NSObjectFlags) info->data->flags;
 	bool isRegisteredToggleRef = (flags & NSObjectFlagsRegisteredToggleRef) == NSObjectFlagsRegisteredToggleRef;
-	id handle = info->handle;
+	id handle = info->data->handle;
 	MonoToggleRefStatus res = (MonoToggleRefStatus) 0;
 
 	if (isRegisteredToggleRef) {
@@ -339,7 +338,7 @@ void
 xamarin_coreclr_reference_tracking_tracked_object_entered_finalization (void* ptr)
 {
 	struct TrackedObjectInfo *info = (struct TrackedObjectInfo *) ptr;
-	info->flags = (enum NSObjectFlags) (info->flags | NSObjectFlagsInFinalizerQueue);
+	info->data->flags = (enum NSObjectFlags) (info->data->flags | NSObjectFlagsInFinalizerQueue);
 	LOG_CORECLR (stderr, "%s (%p) flags: %i\n", __func__, ptr, (int) info->flags);
 }
 

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -203,7 +203,7 @@ xamarin_get_nsobject_handle (MonoObject *obj)
 	return rv;
 #else
 	struct Managed_NSObject *mobj = (struct Managed_NSObject *) obj;
-	return mobj->handle;
+	return mobj->data->handle;
 #endif
 }
 
@@ -214,7 +214,9 @@ xamarin_get_nsobject_flags (MonoObject *obj)
 	return xamarin_get_flags_for_nsobject (obj->gchandle);
 #else
 	struct Managed_NSObject *mobj = (struct Managed_NSObject *) obj;
-	return mobj->flags;
+	if (mobj->data)
+		return mobj->data->flags;
+	return NSObjectFlagsDisposed;
 #endif
 }
 
@@ -225,8 +227,17 @@ xamarin_set_nsobject_flags (MonoObject *obj, uint8_t flags)
 	xamarin_set_flags_for_nsobject (obj->gchandle, flags);
 #else
 	struct Managed_NSObject *mobj = (struct Managed_NSObject *) obj;
-	mobj->flags = flags;
+	mobj->data->flags = flags;
 #endif
+}
+
+uint32_t
+xamarin_get_nsobject_id_flags (id obj)
+{
+	NSObjectData *data = xamarin_get_nsobject_data (obj);
+	if (data)
+		return data->flags;
+	return 0;
 }
 
 MonoType *
@@ -400,39 +411,40 @@ xamarin_get_nullable_type (MonoClass *cls, GCHandle *exception_gchandle)
 // compiler warning (no 'xamarinGetGChandle' selector found).
 @protocol XamarinExtendedObject
 -(GCHandle) xamarinGetGCHandle;
--(bool) xamarinSetGCHandle: (GCHandle) gc_handle flags: (enum XamarinGCHandleFlags) flags;
--(enum XamarinGCHandleFlags) xamarinGetFlags;
--(void) xamarinSetFlags: (enum XamarinGCHandleFlags) flags;
+-(bool) xamarinSetGCHandle: (GCHandle) gc_handle flags: (enum XamarinGCHandleFlags) flags data: (struct NSObjectData *) data;
+-(enum XamarinGCHandleFlags) xamarinGetGCHandleFlags;
+-(void) xamarinSetGCHandleFlags: (enum XamarinGCHandleFlags) gchandle_flags;
+-(struct NSObjectData*) xamarinGetNSObjectData;
 @end
 
 static inline GCHandle
-get_gchandle_safe (id self, enum XamarinGCHandleFlags *flags)
+get_gchandle_safe (id self, enum XamarinGCHandleFlags *gchandle_flags)
 {
 	id<XamarinExtendedObject> xself = self;
 	GCHandle rv = [xself xamarinGetGCHandle];
-	if (flags)
-		*flags = [xself xamarinGetFlags];
+	if (gchandle_flags)
+		*gchandle_flags = [xself xamarinGetGCHandleFlags];
 	return rv;
 }
 
 static inline bool
-set_gchandle (id self, GCHandle gc_handle, enum XamarinGCHandleFlags flags)
+set_gchandle (id self, GCHandle gc_handle, enum XamarinGCHandleFlags flags, struct NSObjectData *data)
 {
 	bool rv;
 
 	id<XamarinExtendedObject> xself = self;
-	rv = [xself xamarinSetGCHandle: gc_handle flags: flags];
+	rv = [xself xamarinSetGCHandle: gc_handle flags: flags data: data];
 
 	return rv;
 }
 
 static inline bool
-set_gchandle_safe (id self, GCHandle gc_handle, enum XamarinGCHandleFlags flags)
+set_gchandle_safe (id self, GCHandle gc_handle, enum XamarinGCHandleFlags flags, struct NSObjectData *data)
 {
 	bool rv;
 
 	id<XamarinExtendedObject> xself = self;
-	rv = [xself xamarinSetGCHandle: gc_handle flags: flags];
+	rv = [xself xamarinSetGCHandle: gc_handle flags: flags data: data];
 
 	return rv;
 }
@@ -447,13 +459,13 @@ get_gchandle_without_flags (id self)
 }
 
 static inline GCHandle
-get_gchandle_with_flags (id self, enum XamarinGCHandleFlags* flags)
+get_gchandle_with_flags (id self, enum XamarinGCHandleFlags* gchandle_flags)
 {
 	GCHandle rv;
 	id<XamarinExtendedObject> xself = self;
 	rv = (GCHandle) [xself xamarinGetGCHandle];
-	if (flags != NULL)
-		*flags = [xself xamarinGetFlags];
+	if (gchandle_flags != NULL)
+		*gchandle_flags = [xself xamarinGetGCHandleFlags];
 	return rv;
 }
 
@@ -462,16 +474,16 @@ get_flags (id self)
 {
 	enum XamarinGCHandleFlags rv;
 	id<XamarinExtendedObject> xself = self;
-	rv = [xself xamarinGetFlags];
+	rv = [xself xamarinGetGCHandleFlags];
 
 	return rv;
 }
 
 static inline void
-set_flags_safe (id self, enum XamarinGCHandleFlags flags)
+set_gchandle_flags_safe (id self, enum XamarinGCHandleFlags flags)
 {
 	id<XamarinExtendedObject> xself = self;
-	[xself xamarinSetFlags: flags];
+	[xself xamarinSetGCHandleFlags: flags];
 }
 
 static inline enum XamarinGCHandleFlags
@@ -479,7 +491,17 @@ get_flags_safe (id self)
 {
 	enum XamarinGCHandleFlags rv;
 	id<XamarinExtendedObject> xself = self;
-	rv = [xself xamarinGetFlags];
+	rv = [xself xamarinGetGCHandleFlags];
+
+	return rv;
+}
+
+struct NSObjectData *
+xamarin_get_nsobject_data (id self)
+{
+	struct NSObjectData * rv;
+	id<XamarinExtendedObject> xself = self;
+	rv = [xself xamarinGetNSObjectData];
 
 	return rv;
 }
@@ -895,7 +917,8 @@ object_queued_for_finalization (MonoObject *object)
 	/* This is called with the GC lock held, so it can only use signal-safe code */
 	struct Managed_NSObject *obj = (struct Managed_NSObject *) object;
 	//PRINT ("In finalization response for %s.%s %p (handle: %p class_handle: %p flags: %i)\n", 
-	obj->flags |= NSObjectFlagsInFinalizerQueue;
+	if (obj->data)
+		obj->data->flags |= NSObjectFlagsInFinalizerQueue;
 }
 #endif // !defined (CORECLR_RUNTIME)
 
@@ -1650,7 +1673,7 @@ xamarin_switch_gchandle (id self, bool to_weak)
 		// null, because the target would be collected.
 		xamarin_set_nsobject_flags (managed_object, xamarin_get_nsobject_flags (managed_object) | NSObjectFlagsHasManagedRef);
 	}
-	set_gchandle (self, new_gchandle, flags);
+	set_gchandle (self, new_gchandle, flags, NULL);
 
 	MONO_THREAD_DETACH;
 
@@ -1670,7 +1693,7 @@ xamarin_free_gchandle (id self, GCHandle gchandle)
 #endif
 		xamarin_gchandle_free (gchandle);
 
-		set_gchandle (self, INVALID_GCHANDLE, XamarinGCHandleFlags_None);
+		set_gchandle (self, INVALID_GCHANDLE, XamarinGCHandleFlags_None, NULL);
 	} else {
 #if defined(DEBUG_REF_COUNTING)
 		PRINT ("\tNo GCHandle for the object %p\n", self);
@@ -1681,19 +1704,19 @@ xamarin_free_gchandle (id self, GCHandle gchandle)
 void
 xamarin_clear_gchandle (id self)
 {
-	set_gchandle (self, INVALID_GCHANDLE, XamarinGCHandleFlags_None);
+	set_gchandle (self, INVALID_GCHANDLE, XamarinGCHandleFlags_None, NULL);
 }
 
 bool
 xamarin_set_gchandle_with_flags (id self, GCHandle gchandle, enum XamarinGCHandleFlags flags)
 {
-	return set_gchandle (self, gchandle, flags);
+	return set_gchandle (self, gchandle, flags, NULL);
 }
 
 bool
-xamarin_set_gchandle_with_flags_safe (id self, GCHandle gchandle, enum XamarinGCHandleFlags flags)
+xamarin_set_gchandle_with_flags_safe (id self, GCHandle gchandle, enum XamarinGCHandleFlags flags, struct NSObjectData *data)
 {
-	return set_gchandle_safe (self, gchandle, flags);
+	return set_gchandle_safe (self, gchandle, flags, data);
 }
 
 #if defined(DEBUG_REF_COUNTING)
@@ -1742,7 +1765,7 @@ xamarin_release_managed_ref (id self, bool user_type)
 
 	if (user_type) {
 		/* clear MANAGED_REF_BIT */
-		set_flags_safe (self, (enum XamarinGCHandleFlags) (get_flags_safe (self) & ~XamarinGCHandleFlags_HasManagedRef));
+		set_gchandle_flags_safe (self, (enum XamarinGCHandleFlags) (get_flags_safe (self) & ~XamarinGCHandleFlags_HasManagedRef));
 	} else {
 		//
 		// This waypoint (lock+unlock) is needed so that we can safely call retainCount in the
@@ -2844,7 +2867,7 @@ xamarin_gchandle_unwrap (GCHandle handle)
 bool
 xamarin_is_user_type (Class cls)
 {
-	Method setGCHandle = class_getInstanceMethod (cls, @selector(xamarinSetGCHandle:flags:));
+	Method setGCHandle = class_getInstanceMethod (cls, @selector(xamarinSetGCHandle:flags:data:));
 	return setGCHandle != NULL;
 }
 
@@ -2964,7 +2987,7 @@ XamarinObject::~XamarinObject ()
  * calling xamarinGetGCHandle. TODO: verify if this is really faster than
  * checking the type first.
  *
- * Do not add a xamarinSetGCHandle:flags: method, since we use the presence
+ * Do not add a xamarinSetGCHandle:flags:data: method, since we use the presence
  * of it to detect whether a particular type is a user type or not
  * (see Runtime.IsUserType).
  */
@@ -2975,9 +2998,14 @@ XamarinObject::~XamarinObject ()
 	return INVALID_GCHANDLE;
 }
 
--(enum XamarinGCHandleFlags) xamarinGetFlags
+-(enum XamarinGCHandleFlags) xamarinGetGCHandleFlags
 {
 	return XamarinGCHandleFlags_None;
+}
+
+-(struct NSObjectData*) xamarinGetNSObjectData
+{
+	return NULL;
 }
 @end
 

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -231,7 +231,7 @@ xamarin_set_nsobject_flags (MonoObject *obj, uint8_t flags)
 #endif
 }
 
-uint32_t
+uint8_t
 xamarin_get_nsobject_id_flags (id obj)
 {
 	NSObjectData *data = xamarin_get_nsobject_data (obj);

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -816,24 +816,12 @@ xamarin_retain_trampoline (id self, SEL sel)
 BOOL
 xamarin_retainWeakReference_trampoline (id self, SEL sel)
 {
-	GCHandle gchandle = xamarin_get_gchandle (self);
-	uint32_t flags = 0;
-	MonoObject *mobj = NULL;
-	bool isInFinalizerQueue = false;
-
-	if (gchandle != INVALID_GCHANDLE) {
-		MONO_THREAD_ATTACH;
-		mobj = xamarin_gchandle_get_target (gchandle);
-		if (mobj != NULL) {
-			flags = xamarin_get_nsobject_flags (mobj);
-			isInFinalizerQueue = (flags & NSObjectFlagsInFinalizerQueue) == NSObjectFlagsInFinalizerQueue;
-		}
-		MONO_THREAD_DETACH;
-	}
+	uint32_t flags = xamarin_get_nsobject_id_flags (self);
+	bool isInFinalizerQueue = (flags & NSObjectFlagsInFinalizerQueue) == NSObjectFlagsInFinalizerQueue;
 
 #if defined(DEBUG_REF_COUNTING)
-	PRINT ("xamarin_retainWeakReference_trampoline (%s Handle=%p) gchandle: %i flags: %x mobj: %p isInFinalizerQueue: %i\n",
-		class_getName ([self class]), self, gchandle, flags, mobj, isInFinalizerQueue);
+	PRINT ("xamarin_retainWeakReference_trampoline (%s Handle=%p) flags: %x isInFinalizerQueue: %i\n",
+		class_getName ([self class]), self, flags, isInFinalizerQueue);
 #endif
 
 	// Do not allow any weak references to be resolved if the managed wrapper has been scheduled for finalization,
@@ -856,7 +844,7 @@ static pthread_mutex_t gchandle_hash_lock = PTHREAD_MUTEX_INITIALIZER;
 
 struct gchandle_dictionary_entry {
 	GCHandle gc_handle;
-	enum XamarinGCHandleFlags flags;
+	enum XamarinGCHandleFlags gchandle_flags;
 };
 
 static void
@@ -867,22 +855,24 @@ release_gchandle_dictionary_entry (CFAllocatorRef allocator, const void *value)
 
 static const char *associated_key = "x"; // the string value doesn't matter, only the pointer value.
 bool
-xamarin_set_gchandle_trampoline (id self, SEL sel, GCHandle gc_handle, enum XamarinGCHandleFlags flags)
+xamarin_set_gchandle_trampoline (id self, SEL sel, GCHandle gc_handle, enum XamarinGCHandleFlags gchandle_flags, struct NSObjectData *data)
 {
 	/* This is for types registered using the dynamic registrar */
 	XamarinAssociatedObject *obj;
 	obj = objc_getAssociatedObject (self, associated_key);
 
 	// Check if we're setting the initial value, in which case we don't want to overwrite
-	if (obj != NULL && obj->gc_handle != INVALID_GCHANDLE && ((flags & XamarinGCHandleFlags_InitialSet) == XamarinGCHandleFlags_InitialSet))
+	if (obj != NULL && obj->gc_handle != INVALID_GCHANDLE && ((gchandle_flags & XamarinGCHandleFlags_InitialSet) == XamarinGCHandleFlags_InitialSet))
 		return false;
 
-	flags = (enum XamarinGCHandleFlags) (flags & ~XamarinGCHandleFlags_InitialSet); // Remove the InitialSet flag, we don't want to store it.
+	gchandle_flags = (enum XamarinGCHandleFlags) (gchandle_flags & ~XamarinGCHandleFlags_InitialSet); // Remove the InitialSet flag, we don't want to store it.
 
 	if (obj == NULL && gc_handle != INVALID_GCHANDLE) {
 		obj = [[XamarinAssociatedObject alloc] init];
 		obj->gc_handle = gc_handle;
-		obj->flags = flags;
+		assert (data); // fixme!
+		obj->data = data;
+		obj->gchandle_flags = gchandle_flags;
 		obj->native_object = self;
 		objc_setAssociatedObject (self, associated_key, obj, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 		objc_release (obj);
@@ -890,7 +880,8 @@ xamarin_set_gchandle_trampoline (id self, SEL sel, GCHandle gc_handle, enum Xama
 
 	if (obj != NULL) {
 		obj->gc_handle = gc_handle;
-		obj->flags = flags;
+		obj->data = NULL;
+		obj->gchandle_flags = gchandle_flags;
 	}
 	
 	pthread_mutex_lock (&gchandle_hash_lock);
@@ -904,7 +895,7 @@ xamarin_set_gchandle_trampoline (id self, SEL sel, GCHandle gc_handle, enum Xama
 	} else {
 		struct gchandle_dictionary_entry *entry = (struct gchandle_dictionary_entry *) calloc (1, sizeof (struct gchandle_dictionary_entry));
 		entry->gc_handle = gc_handle;
-		entry->flags = flags;
+		entry->gchandle_flags = gchandle_flags;
 		CFDictionarySetValue (gchandle_hash, self, entry);
 	}
 	pthread_mutex_unlock (&gchandle_hash_lock);
@@ -932,20 +923,20 @@ enum XamarinGCHandleFlags
 xamarin_get_flags_trampoline (id self, SEL sel)
 {
 	/* This is for types registered using the dynamic registrar */
-	enum XamarinGCHandleFlags flags = XamarinGCHandleFlags_None;
+	enum XamarinGCHandleFlags gchandle_flags = XamarinGCHandleFlags_None;
 	pthread_mutex_lock (&gchandle_hash_lock);
 	if (gchandle_hash != NULL) {
 		struct gchandle_dictionary_entry *entry;
 		entry = (struct gchandle_dictionary_entry *) CFDictionaryGetValue (gchandle_hash, self);
 		if (entry != NULL)
-			flags = entry->flags;
+			gchandle_flags = entry->gchandle_flags;
 	}
 	pthread_mutex_unlock (&gchandle_hash_lock);
-	return flags;
+	return gchandle_flags;
 }
 
 void
-xamarin_set_flags_trampoline (id self, SEL sel, enum XamarinGCHandleFlags flags)
+xamarin_set_flags_trampoline (id self, SEL sel, enum XamarinGCHandleFlags gchandle_flags)
 {
 	/* This is for types registered using the dynamic registrar */
 	pthread_mutex_lock (&gchandle_hash_lock);
@@ -953,7 +944,7 @@ xamarin_set_flags_trampoline (id self, SEL sel, enum XamarinGCHandleFlags flags)
 		struct gchandle_dictionary_entry *entry;
 		entry = (struct gchandle_dictionary_entry *) CFDictionaryGetValue (gchandle_hash, self);
 		if (entry != NULL)
-			entry->flags = flags;
+			entry->gchandle_flags = gchandle_flags;
 	}
 	pthread_mutex_unlock (&gchandle_hash_lock);
 }

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -813,10 +813,27 @@ xamarin_retain_trampoline (id self, SEL sel)
 	return self;
 }
 
+/*
+ * We override 'NSObject retainWeakReference' so that we can detect when Objective-C tries to resolve
+ * a weak reference, and if the managed wrapper is in the finalization queue, we refuse to resolve the
+ * weak reference (because it would mean we end up with a native object whose managed wrapper is
+ * finalized, and a number of things start going wrong when that native object is surfaced to managed
+ * code again).
+ *
+ * Unfortunately it's limited what we can do here, because the Objective-C runtime has acquired internal
+ * locks, which means we can't re-enter the Objective-C runtime. One of the results is that we can't
+ * call into managed code, not even the Mono/CoreCLR's runtime code, because that might end up calling
+ * into the Objective-C runtime, and those previously acquired locks will abort because they're not
+ * recursive locks.
+ *
+ * For this reason, the managed wrapper's flags that say whether the manager wrapper is in the finalization
+ * queue or not, is stored in native memory - and that's all we do here, we fetch the flag and return
+ * FALSE if we're in the finalization queue.
+ */
 BOOL
 xamarin_retainWeakReference_trampoline (id self, SEL sel)
 {
-	uint32_t flags = xamarin_get_nsobject_id_flags (self);
+	uint8_t flags = xamarin_get_nsobject_id_flags (self);
 	bool isInFinalizerQueue = (flags & NSObjectFlagsInFinalizerQueue) == NSObjectFlagsInFinalizerQueue;
 
 #if defined(DEBUG_REF_COUNTING)
@@ -870,7 +887,6 @@ xamarin_set_gchandle_trampoline (id self, SEL sel, GCHandle gc_handle, enum Xama
 	if (obj == NULL && gc_handle != INVALID_GCHANDLE) {
 		obj = [[XamarinAssociatedObject alloc] init];
 		obj->gc_handle = gc_handle;
-		assert (data); // fixme!
 		obj->data = data;
 		obj->gchandle_flags = gchandle_flags;
 		obj->native_object = self;

--- a/runtime/xamarin/monovm-bridge.h
+++ b/runtime/xamarin/monovm-bridge.h
@@ -29,9 +29,7 @@ struct _MonoObject {
 
 struct Managed_NSObject {
 	MonoObject obj;
-	id handle;
-	void *class_handle;
-	uint8_t flags;
+	struct NSObjectData *data;
 };
 
 typedef struct {

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -187,8 +187,10 @@ MonoObject *	xamarin_get_nsobject_with_type_for_ptr_created (id self, bool owns,
 MonoObject *	xamarin_get_delegate_for_block_parameter (MonoMethod *method, guint32 token_ref, int par, void *nativeBlock, GCHandle *exception_gchandle);
 id              xamarin_get_block_for_delegate (MonoMethod *method, MonoObject *delegate, const char *signature /* NULL allowed, but requires the dynamic registrar at runtime to compute */, guint32 token_ref /* INVALID_TOKEN_REF allowed, but requires the dynamic registrar at runtime */, GCHandle *exception_gchandle);
 id				xamarin_get_nsobject_handle (MonoObject *obj);
-uint8_t         xamarin_get_nsobject_flags (MonoObject *obj);
+uint8_t			xamarin_get_nsobject_flags (MonoObject *obj);
 void			xamarin_set_nsobject_flags (MonoObject *obj, uint8_t flags);
+uint8_t			xamarin_get_nsobject_id_flags (id obj);
+struct NSObjectData* xamarin_get_nsobject_data (id obj);
 void			xamarin_throw_nsexception (MonoException *exc);
 void			xamarin_rethrow_managed_exception (GCHandle original_gchandle, GCHandle *exception_gchandle);
 MonoException *	xamarin_create_exception (const char *msg);
@@ -239,7 +241,7 @@ void			xamarin_free_gchandle (id self, GCHandle gchandle);
 void			xamarin_clear_gchandle (id self);
 GCHandle		xamarin_get_gchandle_with_flags (id self, enum XamarinGCHandleFlags *flags);
 bool			xamarin_set_gchandle_with_flags (id self, GCHandle gchandle, enum XamarinGCHandleFlags flags);
-bool			xamarin_set_gchandle_with_flags_safe (id self, GCHandle gchandle, enum XamarinGCHandleFlags flags);
+bool			xamarin_set_gchandle_with_flags_safe (id self, GCHandle gchandle, enum XamarinGCHandleFlags flags, struct NSObjectData *data);
 void            xamarin_release_managed_ref (id self, bool user_type);
 void			xamarin_notify_dealloc (id self, GCHandle gchandle);
 void			xamarin_release_static_dictionaries ();
@@ -363,12 +365,20 @@ typedef void (*xamarin_register_assemblies_callback) ();
 extern xamarin_register_module_callback xamarin_register_modules;
 extern xamarin_register_assemblies_callback xamarin_register_assemblies;
 
+// This has a managed equivalent in NSObject.cs
+struct NSObjectData {
+	id handle;
+	struct objc_super* super;
+	uint8_t /* NSObjectFlags */ flags;
+};
+
 #ifdef __cplusplus
 class XamarinObject {
 public:
 	id native_object;
 	GCHandle gc_handle;
-	enum XamarinGCHandleFlags flags;
+	enum XamarinGCHandleFlags gchandle_flags;
+	struct NSObjectData* data;
 
 	~XamarinObject ();
 };
@@ -379,14 +389,16 @@ public:
 @public
 	id native_object;
 	GCHandle gc_handle;
-	enum XamarinGCHandleFlags flags;
+	enum XamarinGCHandleFlags gchandle_flags;
+	struct NSObjectData* data;
 }
 -(void) dealloc;
 @end
 
 @interface NSObject (NonXamarinObject)
 -(GCHandle) xamarinGetGCHandle;
--(enum XamarinGCHandleFlags) xamarinGetFlags;
+-(enum XamarinGCHandleFlags) xamarinGetGCHandleFlags;
+-(struct NSObjectData*) xamarinGetNSObjectData;
 @end
 #endif
 

--- a/runtime/xamarin/trampolines.h
+++ b/runtime/xamarin/trampolines.h
@@ -40,7 +40,7 @@ long long	xamarin_static_longret_trampoline (id self, SEL sel, ...);
 id			xamarin_copyWithZone_trampoline1 (id self, SEL sel, NSZone *zone);
 id			xamarin_copyWithZone_trampoline2 (id self, SEL sel, NSZone *zone);
 GCHandle	xamarin_get_gchandle_trampoline (id self, SEL sel);
-bool		xamarin_set_gchandle_trampoline (id self, SEL sel, GCHandle gc_handle, enum XamarinGCHandleFlags flags);
+bool		xamarin_set_gchandle_trampoline (id self, SEL sel, GCHandle gc_handle, enum XamarinGCHandleFlags flags, struct NSObjectData *data);
 enum XamarinGCHandleFlags xamarin_get_flags_trampoline (id self, SEL sel);
 void		xamarin_set_flags_trampoline (id self, SEL sel, enum XamarinGCHandleFlags flags);
 

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -145,8 +145,8 @@ namespace Foundation {
 			set => GetData ()->handle = value;
 		}
 
-		// The NSObjectData contains some data we want to keep in native memoroy, so that it can be accessed
-		// safely fron native code without having to make sure the GC doesn't move the memory around. Among
+		// The NSObjectData contains some data we want to keep in native memory, so that it can be accessed
+		// safely from native code without having to make sure the GC doesn't move the memory around. Among
 		// other things, this means it's accessible from threads that has never seen/run managed code without
 		// having to attach those threads to to the managed runtime.
 #nullable enable

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -90,7 +90,7 @@ namespace Foundation {
 		}
 
 		public unsafe NSObjectData* Data {
-			get => (NSObjectData *) handle;
+			get => (NSObjectData*) handle;
 		}
 
 		public override bool IsInvalid {
@@ -100,7 +100,7 @@ namespace Foundation {
 		protected override bool ReleaseHandle ()
 		{
 			unsafe {
-				NativeMemory.Free ((void *) handle);
+				NativeMemory.Free ((void*) handle);
 			}
 			handle = IntPtr.Zero;
 			return true;

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -70,6 +70,45 @@ namespace Foundation {
 	}
 
 #if !COREBUILD
+	// Allocated in native memory, so that it can be accessed from native code without having to deal with the GC.
+	// Also put objc_super here, because it simplifies code.
+	// This is mirrored in runtime.h and the definition needs to be in sync.
+	struct NSObjectData {
+		// the layout here is important, the two first fields have to match the objc_super struct.
+		public NativeHandle handle;
+		public NativeHandle classHandle;
+		public NSObject.Flags flags;
+	}
+
+	class NSObjectDataHandle : CriticalHandle {
+		public NSObjectDataHandle ()
+			: base (IntPtr.Zero)
+		{
+			unsafe {
+				this.handle = (IntPtr) NativeMemory.AllocZeroed ((nuint) sizeof (NSObjectData));
+			}
+		}
+
+		public unsafe NSObjectData* Data {
+			get => (NSObjectData *) handle;
+		}
+
+		public override bool IsInvalid {
+			get => handle != IntPtr.Zero;
+		}
+
+		protected override bool ReleaseHandle ()
+		{
+			unsafe {
+				NativeMemory.Free ((void *) handle);
+			}
+			handle = IntPtr.Zero;
+			return true;
+		}
+	}
+#endif
+
+#if !COREBUILD
 	/// <include file="../../docs/api/Foundation/NSObject.xml" path="/Documentation/Docs[@DocId='T:Foundation.NSObject']/*" />
 	[ObjectiveCTrackedType]
 	[SupportedOSPlatform ("ios")]
@@ -98,29 +137,50 @@ namespace Foundation {
 		///         <remarks>To be added.</remarks>
 		public static readonly Assembly PlatformAssembly = typeof (NSObject).Assembly;
 
-		NativeHandle handle;
-		IntPtr super; /* objc_super* */
+		// This is exclusively for Mono
+		unsafe NSObjectData* __data_for_mono; // Read directly from several places in the runtime
 
-		// See  "Toggle-ref support for CoreCLR" in coreclr-bridge.m for more information.
-		Flags actual_flags;
-		internal unsafe Runtime.TrackedObjectInfo* tracked_object_info;
+		unsafe NativeHandle handle {
+			get => GetData ()->handle;
+			set => GetData ()->handle = value;
+		}
+
+		// The NSObjectData contains some data we want to keep in native memoroy, so that it can be accessed
+		// safely fron native code without having to make sure the GC doesn't move the memory around. Among
+		// other things, this means it's accessible from threads that has never seen/run managed code without
+		// having to attach those threads to to the managed runtime.
+#nullable enable
+		NSObjectDataHandle? data_handle;
+
+		internal unsafe NSObjectData* GetData ()
+		{
+			return AllocateData ().Data;
+		}
+
+		unsafe NSObjectDataHandle AllocateData ()
+		{
+			if (data_handle is not null)
+				return data_handle;
+
+			var data = new NSObjectDataHandle ();
+			var previousValue = Interlocked.CompareExchange (ref data_handle, data, null);
+			if (previousValue is not null) {
+				// somebody beat us to the allocation and assignment.
+				data.Dispose ();
+				return previousValue;
+			}
+
+			if (!Runtime.IsCoreCLR) // This condition (and the assignment to __handle_for_mono if applicable) is trimmed away by the linker.
+				__data_for_mono = data.Data;
+
+			return data;
+		}
 
 		unsafe Flags flags {
-			get {
-				// Get back the InFinalizerQueue flag, it's the only flag we'll set in the tracked object info structure from native code.
-				// The InFinalizerQueue will never be cleared once set, so there's no need to unset it here if it's not set in the tracked_object_info structure.
-				if (tracked_object_info is not null && ((tracked_object_info->Flags) & Flags.InFinalizerQueue) == Flags.InFinalizerQueue)
-					actual_flags |= Flags.InFinalizerQueue;
-
-				return actual_flags;
-			}
-			set {
-				actual_flags = value;
-				// Update the flags value that we can access them from the toggle ref callback as well.
-				if (tracked_object_info is not null)
-					tracked_object_info->Flags = value;
-			}
+			get { return GetData ()->flags; }
+			set { GetData ()->flags = value; }
 		}
+#nullable disable
 
 		// This enum has a native counterpart in runtime.h
 		[Flags]
@@ -144,7 +204,7 @@ namespace Foundation {
 		}
 
 		[StructLayout (LayoutKind.Sequential)]
-		struct objc_super {
+		internal struct objc_super {
 			public IntPtr Handle;
 			public IntPtr ClassHandle;
 		}
@@ -259,32 +319,12 @@ namespace Foundation {
 			}
 		}
 
-		NativeHandle GetSuper ()
+		unsafe NativeHandle GetSuper ()
 		{
-			if (super == NativeHandle.Zero) {
-				IntPtr ptr;
-
-				unsafe {
-					ptr = Marshal.AllocHGlobal (sizeof (objc_super));
-					*(objc_super*) ptr = default (objc_super); // zero fill
-				}
-
-				var previousValue = Interlocked.CompareExchange (ref super, ptr, IntPtr.Zero);
-				if (previousValue != IntPtr.Zero) {
-					// somebody beat us to the assignment.
-					Marshal.FreeHGlobal (ptr);
-					ptr = IntPtr.Zero;
-				}
-			}
-
-			unsafe {
-				objc_super* sup = (objc_super*) super;
-				if (sup->ClassHandle == NativeHandle.Zero)
-					sup->ClassHandle = ClassHandle;
-				sup->Handle = handle;
-			}
-
-			return super;
+			var data = GetData ();
+			if (data->classHandle == NativeHandle.Zero)
+				data->classHandle = ClassHandle;
+			return (IntPtr) (&data->handle);
 		}
 
 		internal static NativeHandle Initialize ()
@@ -378,7 +418,7 @@ namespace Foundation {
 		}
 
 		[DllImport ("__Internal")]
-		static extern byte xamarin_set_gchandle_with_flags_safe (IntPtr handle, IntPtr gchandle, XamarinGCHandleFlags flags);
+		static extern byte xamarin_set_gchandle_with_flags_safe (IntPtr handle, IntPtr gchandle, XamarinGCHandleFlags gchandle_flags, IntPtr data);
 
 		void CreateManagedRef (bool retain)
 		{
@@ -387,10 +427,14 @@ namespace Foundation {
 				throw new InvalidOperationException ($"Unable to create a managed reference for the pointer {handle} whose managed type is {GetType ().FullName} because it wasn't possible to get the class of the pointer: {error_message}");
 
 			if (isUserType) {
-				var flags = XamarinGCHandleFlags.HasManagedRef | XamarinGCHandleFlags.InitialSet | XamarinGCHandleFlags.WeakGCHandle;
+				var gchandle_flags = XamarinGCHandleFlags.HasManagedRef | XamarinGCHandleFlags.InitialSet | XamarinGCHandleFlags.WeakGCHandle;
 				var gchandle = GCHandle.Alloc (this, GCHandleType.WeakTrackResurrection);
 				var h = GCHandle.ToIntPtr (gchandle);
-				if (xamarin_set_gchandle_with_flags_safe (handle, h, flags) == 0) {
+				byte rv;
+				unsafe {
+					rv = xamarin_set_gchandle_with_flags_safe (handle, h, gchandle_flags, (IntPtr) GetData ());
+				}
+				if (rv == 0) {
 					// A GCHandle already existed: this shouldn't happen, but let's handle it anyway.
 					Runtime.NSLog ($"Tried to create a managed reference from an object that already has a managed reference (type: {GetType ()})");
 					gchandle.Free ();
@@ -412,7 +456,6 @@ namespace Foundation {
 				Runtime.NativeObjectHasDied (handle, this);
 			}
 			xamarin_release_managed_ref (handle, user_type.AsByte ());
-			FreeData ();
 		}
 
 		static bool IsProtocol (Type type, IntPtr protocol)
@@ -634,11 +677,6 @@ namespace Foundation {
 					Runtime.UnregisterNSObject (handle);
 
 				handle = value;
-
-				unsafe {
-					if (tracked_object_info is not null)
-						tracked_object_info->Handle = value;
-				}
 
 				if (handle != IntPtr.Zero)
 					Runtime.RegisterNSObject (this, handle);
@@ -966,16 +1004,6 @@ namespace Foundation {
 				} else {
 					NSObject_Disposer.Add (this);
 				}
-			} else {
-				FreeData ();
-			}
-		}
-
-		unsafe void FreeData ()
-		{
-			if (super != NativeHandle.Zero) {
-				Marshal.FreeHGlobal (super);
-				super = NativeHandle.Zero;
 			}
 		}
 

--- a/src/ObjCRuntime/DynamicRegistrar.cs
+++ b/src/ObjCRuntime/DynamicRegistrar.cs
@@ -1125,11 +1125,11 @@ namespace Registrar {
 			case Trampoline.SetGCHandle:
 				tramp = Method.SetGCHandleTrampoline;
 				break;
-			case Trampoline.GetFlags:
-				tramp = Method.GetFlagsTrampoline;
+			case Trampoline.GetGCHandleFlags:
+				tramp = Method.GetGCHandleFlagsTrampoline;
 				break;
-			case Trampoline.SetFlags:
-				tramp = Method.SetFlagsTrampoline;
+			case Trampoline.SetGCHandleFlags:
+				tramp = Method.SetGCHandleFlagsTrampoline;
 				break;
 			case Trampoline.RetainWeakReference:
 				tramp = Method.RetainWeakReferenceTrampoline;

--- a/src/ObjCRuntime/Method.cs
+++ b/src/ObjCRuntime/Method.cs
@@ -101,12 +101,12 @@ namespace ObjCRuntime {
 			get { return Runtime.options->Trampolines->set_gchandle_tramp; }
 		}
 
-		internal unsafe static IntPtr GetFlagsTrampoline {
-			get { return Runtime.options->Trampolines->get_flags_tramp; }
+		internal unsafe static IntPtr GetGCHandleFlagsTrampoline {
+			get { return Runtime.options->Trampolines->get_gchandle_flags_tramp; }
 		}
 
-		internal unsafe static IntPtr SetFlagsTrampoline {
-			get { return Runtime.options->Trampolines->set_flags_tramp; }
+		internal unsafe static IntPtr SetGCHandleFlagsTrampoline {
+			get { return Runtime.options->Trampolines->set_gchandle_flags_tramp; }
 		}
 
 		internal unsafe static IntPtr RetainWeakReferenceTrampoline {

--- a/src/ObjCRuntime/Registrar.cs
+++ b/src/ObjCRuntime/Registrar.cs
@@ -616,8 +616,8 @@ namespace Registrar {
 					case Trampoline.Retain:
 					case Trampoline.GetGCHandle:
 					case Trampoline.SetGCHandle:
-					case Trampoline.GetFlags:
-					case Trampoline.SetFlags:
+					case Trampoline.GetGCHandleFlags:
+					case Trampoline.SetGCHandleFlags:
 					case Trampoline.RetainWeakReference:
 						return true;
 					default:
@@ -2097,22 +2097,22 @@ namespace Registrar {
 					}, ref exceptions);
 
 					objcType.Add (new ObjCMethod (this, objcType, null) {
-						Selector = "xamarinSetGCHandle:flags:",
+						Selector = "xamarinSetGCHandle:flags:data:",
 						Trampoline = Trampoline.SetGCHandle,
-						Signature = "v@:^vi",
+						Signature = "v@:^vi^v",
 						IsStatic = false,
 					}, ref exceptions);
 
 					objcType.Add (new ObjCMethod (this, objcType, null) {
-						Selector = "xamarinGetFlags",
-						Trampoline = Trampoline.GetFlags,
+						Selector = "xamarinGetGCHandleFlags",
+						Trampoline = Trampoline.GetGCHandleFlags,
 						Signature = "i@:",
 						IsStatic = false,
 					}, ref exceptions);
 
 					objcType.Add (new ObjCMethod (this, objcType, null) {
-						Selector = "xamarinSetFlags:",
-						Trampoline = Trampoline.SetFlags,
+						Selector = "xamarinSetGCHandleFlags:",
+						Trampoline = Trampoline.SetGCHandleFlags,
 						Signature = "v@:i",
 						IsStatic = false,
 					}, ref exceptions);
@@ -2855,8 +2855,8 @@ namespace Registrar {
 		CopyWithZone2,
 		GetGCHandle,
 		SetGCHandle,
-		GetFlags,
-		SetFlags,
+		GetGCHandleFlags,
+		SetGCHandleFlags,
 		RetainWeakReference,
 	}
 }

--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -205,8 +205,7 @@ namespace ObjCRuntime {
 
 		// Size: 2 pointers
 		internal struct TrackedObjectInfo {
-			public IntPtr Handle;
-			public NSObject.Flags Flags;
+			public unsafe NSObjectData* Data;
 		}
 
 		[SupportedOSPlatform ("macos")]
@@ -218,11 +217,9 @@ namespace ObjCRuntime {
 				TrackedObjectInfo* tracked_info;
 				fixed (void* ptr = info)
 					tracked_info = (TrackedObjectInfo*) ptr;
-				tracked_info->Handle = handle;
-				tracked_info->Flags = obj.FlagsInternal;
-				obj.tracked_object_info = tracked_info;
+				tracked_info->Data = obj.GetData ();
 
-				log_coreclr ($"GetOrCreateTrackingGCHandle ({obj.GetType ().FullName}, 0x{handle.ToString ("x")}) => Info=0x{((IntPtr) tracked_info).ToString ("x")} Flags={tracked_info->Flags} Created new");
+				log_coreclr ($"GetOrCreateTrackingGCHandle ({obj.GetType ().FullName}, 0x{handle.ToString ("x")}) => Info=0x{((IntPtr) tracked_info).ToString ("x")} Data=0x{(IntPtr) tracked_info->Data:x} Created new");
 			}
 
 			return gchandle;
@@ -232,10 +229,7 @@ namespace ObjCRuntime {
 		internal static void RegisterToggleReferenceCoreCLR (NSObject obj, IntPtr handle, bool isCustomType)
 		{
 			unsafe {
-				TrackedObjectInfo* tracked_info = obj.tracked_object_info;
-				tracked_info->Flags = obj.FlagsInternal;
-
-				log_coreclr ($"RegisterToggleReferenceCoreCLR ({obj.GetType ().FullName}, 0x{handle.ToString ("x")}, {isCustomType}) => Info=0x{((IntPtr) tracked_info).ToString ("x")} Flags={tracked_info->Flags}");
+				log_coreclr ($"RegisterToggleReferenceCoreCLR ({obj.GetType ().FullName}, 0x{handle.ToString ("x")}, {isCustomType}) => Data=0x{(IntPtr) obj.GetData ():x}");
 			}
 
 			// Make sure the GCHandle we have is a weak one for custom types.

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -162,8 +162,8 @@ namespace ObjCRuntime {
 #endif
 			public IntPtr get_gchandle_tramp;
 			public IntPtr set_gchandle_tramp;
-			public IntPtr get_flags_tramp;
-			public IntPtr set_flags_tramp;
+			public IntPtr get_gchandle_flags_tramp;
+			public IntPtr set_gchandle_flags_tramp;
 			public IntPtr retainWeakReference_tramp;
 		}
 #pragma warning restore 649

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -1455,8 +1455,11 @@ partial class TestRuntime {
 
 	public static byte GetFlags (NSObject obj)
 	{
-		const string fieldName = "actual_flags";
-		return (byte) typeof (NSObject).GetField (fieldName, BindingFlags.Instance | BindingFlags.GetField | BindingFlags.NonPublic)!.GetValue (obj)!;
+		const string name = "flags";
+		var prop = typeof (NSObject).GetProperty (name, BindingFlags.Instance | BindingFlags.NonPublic);
+		if (prop is null)
+			throw new InvalidOperationException ($"Unable to find the property '{name}' in NSObject.");
+		return (byte) prop.GetValue (obj)!;
 	}
 
 	// Determine if linkall was enabled by checking if an unused class in this assembly is still here.

--- a/tests/monotouch-test/CoreFoundation/DispatchTests.cs
+++ b/tests/monotouch-test/CoreFoundation/DispatchTests.cs
@@ -26,7 +26,6 @@ namespace MonoTouchFixtures.CoreFoundation {
 
 	[TestFixture]
 	[Preserve (AllMembers = true)]
-	[Ignore ("NRE")]
 	public class DispatchTests {
 #if !MONOMAC // UIKitThreadAccessException and NSStringDrawing.WeakDrawString don't exist on mac
 		[Test]

--- a/tests/monotouch-test/CoreFoundation/DispatchTests.cs
+++ b/tests/monotouch-test/CoreFoundation/DispatchTests.cs
@@ -26,6 +26,7 @@ namespace MonoTouchFixtures.CoreFoundation {
 
 	[TestFixture]
 	[Preserve (AllMembers = true)]
+	[Ignore ("NRE")]
 	public class DispatchTests {
 #if !MONOMAC // UIKitThreadAccessException and NSStringDrawing.WeakDrawString don't exist on mac
 		[Test]

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -2653,12 +2653,12 @@ namespace Registrar {
 				return "-(void) release";
 			else if (method.CurrentTrampoline == Trampoline.GetGCHandle)
 				return "-(GCHandle) xamarinGetGCHandle";
-			else if (method.CurrentTrampoline == Trampoline.GetFlags)
-				return "-(enum XamarinGCHandleFlags) xamarinGetFlags";
-			else if (method.CurrentTrampoline == Trampoline.SetFlags)
-				return "-(void) xamarinSetFlags: (enum XamarinGCHandleFlags) flags";
+			else if (method.CurrentTrampoline == Trampoline.GetGCHandleFlags)
+				return "-(enum XamarinGCHandleFlags) xamarinGetGCHandleFlags";
+			else if (method.CurrentTrampoline == Trampoline.SetGCHandleFlags)
+				return "-(void) xamarinSetGCHandleFlags: (enum XamarinGCHandleFlags) gchandle_flags";
 			else if (method.CurrentTrampoline == Trampoline.SetGCHandle)
-				return "-(bool) xamarinSetGCHandle: (GCHandle) gchandle flags: (enum XamarinGCHandleFlags) flags";
+				return "-(bool) xamarinSetGCHandle: (GCHandle) gchandle flags: (enum XamarinGCHandleFlags) gchandle_flags data: (NSObjectData *) data";
 			else if (method.CurrentTrampoline == Trampoline.CopyWithZone1 || method.CurrentTrampoline == Trampoline.CopyWithZone2)
 				return "-(id) copyWithZone: (NSZone *)zone";
 			else if (method.CurrentTrampoline == Trampoline.RetainWeakReference)
@@ -3411,30 +3411,31 @@ namespace Registrar {
 				sb.WriteLine ();
 				return true;
 			case Trampoline.SetGCHandle:
-				sb.WriteLine ("-(bool) xamarinSetGCHandle: (GCHandle) gc_handle flags: (enum XamarinGCHandleFlags) flags");
+				sb.WriteLine ("-(bool) xamarinSetGCHandle: (GCHandle) gc_handle flags: (enum XamarinGCHandleFlags) gchandle_flags data: (NSObjectData *) data");
 				sb.WriteLine ("{");
-				sb.WriteLine ("if (((flags & XamarinGCHandleFlags_InitialSet) == XamarinGCHandleFlags_InitialSet) && __monoObjectGCHandle.gc_handle != INVALID_GCHANDLE) {");
+				sb.WriteLine ("if (((gchandle_flags & XamarinGCHandleFlags_InitialSet) == XamarinGCHandleFlags_InitialSet) && __monoObjectGCHandle.gc_handle != INVALID_GCHANDLE) {");
 				sb.WriteLine ("return false;");
 				sb.WriteLine ("}");
-				sb.WriteLine ("flags = (enum XamarinGCHandleFlags) (flags & ~XamarinGCHandleFlags_InitialSet);"); // Remove the InitialSet flag, we don't want to store it.
+				sb.WriteLine ("gchandle_flags = (enum XamarinGCHandleFlags) (gchandle_flags & ~XamarinGCHandleFlags_InitialSet);"); // Remove the InitialSet flag, we don't want to store it.
 				sb.WriteLine ("__monoObjectGCHandle.gc_handle = gc_handle;");
-				sb.WriteLine ("__monoObjectGCHandle.flags = flags;");
+				sb.WriteLine ("__monoObjectGCHandle.data = data;");
+				sb.WriteLine ("__monoObjectGCHandle.gchandle_flags = gchandle_flags;");
 				sb.WriteLine ("__monoObjectGCHandle.native_object = self;");
 				sb.WriteLine ("return true;");
 				sb.WriteLine ("}");
 				sb.WriteLine ();
 				return true;
-			case Trampoline.GetFlags:
-				sb.WriteLine ("-(enum XamarinGCHandleFlags) xamarinGetFlags");
+			case Trampoline.GetGCHandleFlags:
+				sb.WriteLine ("-(enum XamarinGCHandleFlags) xamarinGetGCHandleFlags");
 				sb.WriteLine ("{");
-				sb.WriteLine ("return __monoObjectGCHandle.flags;");
+				sb.WriteLine ("return __monoObjectGCHandle.gchandle_flags;");
 				sb.WriteLine ("}");
 				sb.WriteLine ();
 				return true;
-			case Trampoline.SetFlags:
-				sb.WriteLine ("-(void) xamarinSetFlags: (enum XamarinGCHandleFlags) flags");
+			case Trampoline.SetGCHandleFlags:
+				sb.WriteLine ("-(void) xamarinSetGCHandleFlags: (enum XamarinGCHandleFlags) gchandle_flags");
 				sb.WriteLine ("{");
-				sb.WriteLine ("__monoObjectGCHandle.flags = flags;");
+				sb.WriteLine ("__monoObjectGCHandle.gchandle_flags = gchandle_flags;");
 				sb.WriteLine ("}");
 				sb.WriteLine ();
 				return true;
@@ -3453,16 +3454,16 @@ namespace Registrar {
 				sb.AppendLine ("{");
 				sb.AppendLine ("id rv;");
 				sb.AppendLine ("GCHandle gchandle;");
-				sb.AppendLine ("enum XamarinGCHandleFlags flags = XamarinGCHandleFlags_None;");
+				sb.AppendLine ("enum XamarinGCHandleFlags gchandle_flags = XamarinGCHandleFlags_None;");
 				sb.AppendLine ();
-				sb.AppendLine ("gchandle = xamarin_get_gchandle_with_flags (self, &flags);");
+				sb.AppendLine ("gchandle = xamarin_get_gchandle_with_flags (self, &gchandle_flags);");
 				sb.AppendLine ("if (gchandle != INVALID_GCHANDLE)");
 				sb.Indent ().AppendLine ("xamarin_set_gchandle_with_flags (self, INVALID_GCHANDLE, XamarinGCHandleFlags_None);").Unindent ();
 				// Call the base class implementation
 				sb.AppendLine ("rv = [super copyWithZone: zone];");
 				sb.AppendLine ();
 				sb.AppendLine ("if (gchandle != INVALID_GCHANDLE)");
-				sb.Indent ().AppendLine ("xamarin_set_gchandle_with_flags (self, gchandle, flags);").Unindent ();
+				sb.Indent ().AppendLine ("xamarin_set_gchandle_with_flags (self, gchandle, gchandle_flags);").Unindent ();
 				sb.AppendLine ();
 				sb.AppendLine ("return rv;");
 				sb.AppendLine ("}");

--- a/tools/dotnet-linker/AppBundleRewriter.cs
+++ b/tools/dotnet-linker/AppBundleRewriter.cs
@@ -358,25 +358,17 @@ namespace Xamarin.Linker {
 			}
 		}
 
-		public FieldReference Foundation_NSObject_HandleField {
+		public MethodReference Foundation_NSObject_HandleSetterMethod {
 			get {
-				return GetFieldReference (PlatformAssembly, Foundation_NSObject, "handle", "Foundation.NSObject::handle", out var _);
+				return GetMethodReference (PlatformAssembly, Foundation_NSObject, "set_handle", "Foundation.NSObject::set_handle", predicate: null, out var _);
 			}
 		}
 
-#if NET
 		public MethodReference Foundation_NSObject_FlagsSetterMethod {
 			get {
 				return GetMethodReference (PlatformAssembly, Foundation_NSObject, "set_flags", "Foundation.NSObject::set_flags", predicate: null, out var _);
 			}
 		}
-#else
-		public FieldReference Foundation_NSObject_FlagsField {
-			get {
-				return GetFieldReference (PlatformAssembly, Foundation_NSObject, "flags", "Foundation.NSObject::flags", out var _);
-			}
-		}
-#endif
 
 		public TypeReference ObjCRuntime_BindAs {
 			get {

--- a/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
@@ -1352,28 +1352,18 @@ namespace Xamarin.Linker {
 			var body = clonedCtor.CreateBody (out var il);
 
 			// ensure visible
-			abr.Foundation_NSObject_HandleField.Resolve ().IsFamily = true;
-#if NET
+			abr.Foundation_NSObject_HandleSetterMethod.Resolve ().IsFamily = true;
 			abr.Foundation_NSObject_FlagsSetterMethod.Resolve ().IsFamily = true;
-#else
-			abr.Foundation_NSObject_FlagsField.Resolve ().IsFamily = true;
-#endif
 
 			// store the handle and flags first
 			il.Emit (OpCodes.Ldarg_0);
 			il.Emit (OpCodes.Ldarg, handleParameter);
-#if NET
 			il.Emit (OpCodes.Call, abr.NativeObject_op_Implicit_NativeHandle);
-#endif
-			il.Emit (OpCodes.Stfld, abr.CurrentAssembly.MainModule.ImportReference (abr.Foundation_NSObject_HandleField));
+			il.Emit (OpCodes.Call, abr.CurrentAssembly.MainModule.ImportReference (abr.Foundation_NSObject_HandleSetterMethod));
 
 			il.Emit (OpCodes.Ldarg_0);
 			il.Emit (OpCodes.Ldc_I4_2); // Flags.NativeRef == 2
-#if NET
-			il.Emit (OpCodes.Call, abr.Foundation_NSObject_FlagsSetterMethod);
-#else
-			il.Emit (OpCodes.Stfld, abr.Foundation_NSObject_FlagsField);
-#endif
+			il.Emit (OpCodes.Call, abr.CurrentAssembly.MainModule.ImportReference (abr.Foundation_NSObject_FlagsSetterMethod));
 
 			// call the original constructor with all of the original parameters
 			il.Emit (OpCodes.Ldarg_0);


### PR DESCRIPTION
In a recent change, we modified our runtime to disallow Objective-C to resolve weak references for a native object whose managed wrapper is in the finalizer queue (d281b3c01038259f1b332e005bd7332b8352306e).

Unfortunately this introduced a regression, because we added a method that's called by the Objective-C runtime with rather strict requirements:

* Can't call into the Objective-C runtime again (such as retain or release on any object), because it will result in an abort due to attempting to re-lock a non-recursive lock (see stack trace in #23284).
* This means we can't call into the Mono or CoreCLR runtime, because they might end up calling retain or release (again, see stack trace in #23284 for a case for Mono, or #23322 for a case for CoreCLR).
* This means we can't store the flag that tracks whether a managed wrapper is in the finalizer queue or not in managed code.

So the fix does a few things:

1. Allocate native memory to hold the NSObject flags. In order to simplify our code a bit, also allocate a bit more and use the memory for the super handle as well (which also must be stored in native memory).
2. Update everywhere to take into account the new location for this data.
3. Rename a 'flags' variable/parameter to 'gchandle_flags' to avoid confusion with the NSObject flags.
4. Free the native memory using a CriticalHandle, this way we ensure it's always collected, and also that it's available for at least as long as the owning managed wrapper instance.

Fixes https://github.com/dotnet/macios/issues/23284.

Backport of #23300.