### PR TITLE
[vs] Disable build acceleration

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -93,6 +93,13 @@
 		<!-- Tell .NET to skip sanity checks that trigger too eagerly for builds with multiple RuntimeIdentifiers -->
 		<AllowPublishAotWithoutRuntimeIdentifier Condition="'$(AllowPublishAotWithoutRuntimeIdentifier)' == '' And '$(_UseNativeAot)' == 'true'">true</AllowPublishAotWithoutRuntimeIdentifier>
 		<AllowSelfContainedWithoutRuntimeIdentifier Condition="'$(AllowSelfContainedWithoutRuntimeIdentifier)' == ''">true</AllowSelfContainedWithoutRuntimeIdentifier>
+
+		<!--
+        	Disable Visual Studio build acceleration as our build is not compatible with it.
+        	It skips building the app project depending on changes on the project references, but we need still need to build the app project to generate the app bundle.
+        	https://github.com/dotnet/project-system/blob/main/docs/build-acceleration.md 
+      	-->
+		<AccelerateBuildsInVisualStudio Condition="'$(AccelerateBuildsInVisualStudio)' == ''">false</AccelerateBuildsInVisualStudio>
 	</PropertyGroup>
 
 	<!-- Set the default RuntimeIdentifier if not already specified. -->


### PR DESCRIPTION
Visual Studio Build Acceleration is a feature designed to avoid rebuilding a project when changes occur in its project references.

For example, if you have an iOS app project and a MAUI class library that includes XAML files, an incremental change to the XAML will not trigger a rebuild of the iOS project. Instead, the updated assembly is simply copied into the iOS project’s output directory.

However, this behavior is not compatible with iOS builds, since the final app bundle is produced as part of the build process. As a result, skipping the build step can lead to unexpected behavior as incremental changes not reflected in the app.

For more details, see the https://github.com/dotnet/project-system/blob/main/docs/build-acceleration.md.