### PR TITLE
[bgen] Improve the BI1078 error message to include the type name.

### DIFF
--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -1001,7 +1001,7 @@ public partial class Generator : IMemberGatherer {
 		try {
 			sb.Append (ParameterGetMarshalType (new MarshalInfo (this, mi) { IsAligned = aligned }));
 		} catch (BindingException ex) {
-			throw new BindingException (1078, ex.Error, ex, ex.Message, mi.Name);
+			throw new BindingException (1078, ex.Error, ex, ex.Message, $"{mi.DeclaringType}.{mi.Name}");
 		}
 
 		sb.Append ("_");


### PR DESCRIPTION
Old message:

    error BI1078: bgen: Do not know how to make a signature for System.Object in method `get_ModifierFlags'

New message:

    error BI1078: bgen: Do not know how to make a signature for System.Object in method `WebKit.WKNavigationAction.get_ModifierFlags'