### PR TITLE
[RGen] Update the BindingAttribute to allow to pass the type for a category.

### DIFF
--- a/src/ObjCBindings/BindingTypeAttribute.cs
+++ b/src/ObjCBindings/BindingTypeAttribute.cs
@@ -20,6 +20,11 @@ namespace ObjCBindings {
 		/// </summary >
 		public T? Flags { get; set; } = default (T);
 
+		/// <summary>
+		/// The type of the class that a category is extending.
+		/// </summary>
+		public Type? CategoryType { get; set; } = null;
+
 
 		/// <summary>
 		/// Get/set the error domain for an error enumerator. This has to be used with the SmartEnum flag.
@@ -73,6 +78,25 @@ namespace ObjCBindings {
 		public BindingTypeAttribute (string name, T flags)
 		{
 			Name = name;
+			Flags = flags;
+		}
+
+		/// <summary>
+		/// Creates a binding type attribute with the specified category type.
+		/// </summary>
+		public BindingTypeAttribute (Type categoryType)
+		{
+			Name = categoryType.Name;
+			CategoryType = categoryType;
+		}
+
+		/// <summary>
+		/// Creates a binding type attribute with the specified category type and flags.
+		/// </summary>
+		public BindingTypeAttribute (Type categoryType, T flags)
+		{
+			Name = categoryType.Name;
+			CategoryType = categoryType;
 			Flags = flags;
 		}
 	}

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/BindingTypeData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/BindingTypeData.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
+using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
 
 namespace Microsoft.Macios.Generator.Attributes;
 
@@ -13,12 +14,16 @@ readonly struct BindingTypeData : IEquatable<BindingTypeData> {
 	/// Original name of the ObjC class or protocol.
 	/// </summary>
 	public string? Name { get; }
-
+	
+	/// <summary>
+	/// Initializes a new instance of the <see cref="BindingTypeData"/> struct.
+	/// </summary>
+	/// <param name="name">The original name of the ObjC class or protocol.</param>
 	public BindingTypeData (string? name)
 	{
 		Name = name;
 	}
-
+	
 	/// <summary>
 	/// Try to parse the attribute data to retrieve the information of an ExportAttribute&lt;T&gt;.
 	/// </summary>
@@ -78,11 +83,23 @@ readonly struct BindingTypeData : IEquatable<BindingTypeData> {
 		return HashCode.Combine (Name);
 	}
 
+	/// <summary>
+	/// Compares two <see cref="BindingTypeData"/> instances for equality.
+	/// </summary>
+	/// <param name="x">The first instance to compare.</param>
+	/// <param name="y">The second instance to compare.</param>
+	/// <returns><c>true</c> if the instances are equal; otherwise, <c>false</c>.</returns>
 	public static bool operator == (BindingTypeData x, BindingTypeData y)
 	{
 		return x.Equals (y);
 	}
 
+	/// <summary>
+	/// Compares two <see cref="BindingTypeData"/> instances for inequality.
+	/// </summary>
+	/// <param name="x">The first instance to compare.</param>
+	/// <param name="y">The second instance to compare.</param>
+	/// <returns><c>true</c> if the instances are not equal; otherwise, <c>false</c>.</returns>
 	public static bool operator != (BindingTypeData x, BindingTypeData y)
 	{
 		return !(x == y);
@@ -131,21 +148,61 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 	/// The visibility of the string constructor for a core image filter.
 	/// </summary>
 	public MethodAttributes StringCtorVisibility { get; init; } = MethodAttributes.PrivateScope;
+	
+	/// <summary>
+	/// The type that the category extends.
+	/// </summary>
+	public TypeInfo? CategoryType { get; init; } = null;
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="BindingTypeData{T}"/> struct.
+	/// </summary>
+	/// <param name="name">The original name of the ObjC class or protocol.</param>
 	public BindingTypeData (string? name)
 	{
 		Name = name;
 	}
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="BindingTypeData{T}"/> struct.
+	/// </summary>
+	/// <param name="flags">The configuration flags.</param>
 	public BindingTypeData (T? flags)
 	{
 		Name = null;
 		Flags = flags;
 	}
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="BindingTypeData{T}"/> struct.
+	/// </summary>
+	/// <param name="name">The original name of the ObjC class or protocol.</param>
+	/// <param name="flags">The configuration flags.</param>
 	public BindingTypeData (string? name, T? flags)
 	{
 		Name = name;
+		Flags = flags;
+	}
+	
+	/// <summary>
+	/// Initializes a new instance of the <see cref="BindingTypeData"/> struct for a category.
+	/// </summary>
+	/// <param name="categoryType">The type that the category extends.</param>
+	public BindingTypeData (TypeInfo? categoryType)
+	{
+		Name = categoryType?.Name;
+		CategoryType = categoryType;
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="BindingTypeData"/> struct for a category.
+	/// </summary>
+	/// <param name="categoryType">The type that the category extends.</param>
+	/// <param name="flags">The configuration flags.</param>
+	public BindingTypeData (TypeInfo? categoryType, T? flags)
+	{
+		Name = categoryType?.Name;
+		CategoryType = categoryType;
 		Flags = flags;
 	}
 
@@ -162,11 +219,11 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 		var count = attributeData.ConstructorArguments.Length;
 		string? name = null;
 		T? flags = default;
-		string? errorDomain = null;
-		string? libraryName = null;
-		var defaultCtorVisibility = MethodAttributes.Public;
-		var intPtrCtorVisibility = MethodAttributes.PrivateScope;
-		var stringCtorVisibility = MethodAttributes.PrivateScope;
+		// category related data
+		TypeInfo? categoryType = null;
+		
+		// check if we have a category type, we can do that by checking the type of the flag
+		var isCategory = typeof(T) == typeof(ObjCBindings.Category); 
 
 		switch (count) {
 		case 0:
@@ -175,15 +232,24 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 			flags = default;
 			break;
 		case 1:
-			if (attributeData.ConstructorArguments [0].Value is string) {
-				name = (string?) attributeData.ConstructorArguments [0].Value!;
-			} else {
-				flags = (T) attributeData.ConstructorArguments [0].Value!;
+			var value = attributeData.ConstructorArguments [0].Value;
+			if (isCategory && value is INamedTypeSymbol typeSymbol) {
+				categoryType = new (typeSymbol);
+				name = categoryType.Value.Name;
+			} else if (!isCategory && value is string str) {
+				name = str;
+			} else if (value is not null) {
+				flags = (T) value;
 			}
 			break;
 		case 2:
-			// we have the name and the config flags present
-			name = (string?) attributeData.ConstructorArguments [0].Value!;
+			if (isCategory) {
+				categoryType = new ((INamedTypeSymbol) attributeData.ConstructorArguments [0].Value!);
+				name = categoryType.Value.Name;
+			} else {
+				// we have the name and the config flags present
+				name = (string?) attributeData.ConstructorArguments [0].Value!;
+			}
 			flags = (T) attributeData.ConstructorArguments [1].Value!;
 			break;
 		default:
@@ -191,11 +257,97 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 		}
 
 		if (attributeData.NamedArguments.Length == 0) {
-			data = flags is not null ?
-				new (name, flags) : new (name);
+			if (isCategory) {
+				data = flags is not null ?
+					new (categoryType, flags) : new (categoryType);
+			} else {
+				data = flags is not null ?
+					new (name, flags) : new (name);
+			}
 			return true;
 		}
 
+		// the named types are different depending on the type of the flag, if we are dealing with a category or not.
+		if (isCategory && TryExtractCategoryNamedParameters (attributeData, out name, ref flags, out categoryType)) {
+			data = CreateCategoryBindingData (flags, categoryType);
+			return true;
+		} else if (TryExtractClassNamedParameters (attributeData, out name, ref flags, out string? errorDomain, out string? libraryName, out MethodAttributes defaultCtorVisibility, out MethodAttributes intPtrCtorVisibility, out MethodAttributes stringCtorVisibility)) {
+			data = CreateClassBindingData (flags, name, errorDomain, libraryName, defaultCtorVisibility, intPtrCtorVisibility, stringCtorVisibility);
+			return true;
+		}
+		
+		return false;
+	}
+
+	/// <summary>
+	/// Creates a new instance of <see cref="BindingTypeData{T}"/> for a class.
+	/// </summary>
+	/// <param name="flags">The configuration flags.</param>
+	/// <param name="name">The original name of the ObjC class or protocol.</param>
+	/// <param name="errorDomain">The domain of an error enumerator.</param>
+	/// <param name="libraryName">The library name of an error/smart enum.</param>
+	/// <param name="defaultCtorVisibility">The visibility of the default constructor.</param>
+	/// <param name="intPtrCtorVisibility">The visibility of the IntPtr constructor.</param>
+	/// <param name="stringCtorVisibility">The visibility of the string constructor.</param>
+	/// <returns>A new instance of <see cref="BindingTypeData{T}"/>.</returns>
+	static BindingTypeData<T> CreateClassBindingData (T? flags, string? name, string? errorDomain, 
+		string? libraryName, MethodAttributes defaultCtorVisibility, MethodAttributes intPtrCtorVisibility, 
+		MethodAttributes stringCtorVisibility)
+	{
+		return flags is not null
+			? new (name, flags) {
+				ErrorDomain = errorDomain,
+				LibraryName = libraryName,
+				DefaultCtorVisibility = defaultCtorVisibility,
+				IntPtrCtorVisibility = intPtrCtorVisibility,
+				StringCtorVisibility = stringCtorVisibility,
+			}
+			: new (name) {
+				ErrorDomain = errorDomain,
+				LibraryName = libraryName,
+				DefaultCtorVisibility = defaultCtorVisibility,
+				IntPtrCtorVisibility = intPtrCtorVisibility,
+				StringCtorVisibility = stringCtorVisibility,
+			};
+	}
+	
+	/// <summary>
+	/// Creates a new instance of <see cref="BindingTypeData{T}"/> for a category.
+	/// </summary>
+	/// <param name="flags">The configuration flags.</param>
+	/// <param name="categoryType">The type that the category extends.</param>
+	/// <returns>A new instance of <see cref="BindingTypeData{T}"/>.</returns>
+	static BindingTypeData<T> CreateCategoryBindingData (T? flags, TypeInfo? categoryType)
+	{
+		return flags is not null
+			? new (categoryType, flags)
+			: new (categoryType);
+	}
+
+	/// <summary>
+	/// Tries to extract the named parameters for a class from the attribute data.
+	/// </summary>
+	/// <param name="attributeData">The attribute data to be parsed.</param>
+	/// <param name="name">The original name of the ObjC class or protocol.</param>
+	/// <param name="flags">The configuration flags.</param>
+	/// <param name="errorDomain">The domain of an error enumerator.</param>
+	/// <param name="libraryName">The library name of an error/smart enum.</param>
+	/// <param name="defaultCtorVisibility">The visibility of the default constructor.</param>
+	/// <param name="intPtrCtorVisibility">The visibility of the IntPtr constructor.</param>
+	/// <param name="stringCtorVisibility">The visibility of the string constructor.</param>
+	/// <returns>True if the data was parsed.</returns>
+	static bool TryExtractClassNamedParameters (AttributeData attributeData, 
+		out string? name, ref T? flags, out string? errorDomain, out string? libraryName,
+		out MethodAttributes defaultCtorVisibility, out MethodAttributes intPtrCtorVisibility,
+		out MethodAttributes stringCtorVisibility)
+	{
+		name = null;
+		errorDomain = null;
+		libraryName = null;
+		defaultCtorVisibility = MethodAttributes.PrivateScope;
+		intPtrCtorVisibility = MethodAttributes.PrivateScope;
+		stringCtorVisibility = MethodAttributes.PrivateScope;
+		
 		foreach (var (paramName, value) in attributeData.NamedArguments) {
 			switch (paramName) {
 			case "Name":
@@ -220,26 +372,41 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 				stringCtorVisibility = (MethodAttributes) Convert.ToSingle ((int) value.Value!);
 				break;
 			default:
-				data = null;
 				return false;
 			}
 		}
 
-		data = flags is not null
-			? new (name, flags) {
-				ErrorDomain = errorDomain,
-				LibraryName = libraryName,
-				DefaultCtorVisibility = defaultCtorVisibility,
-				IntPtrCtorVisibility = intPtrCtorVisibility,
-				StringCtorVisibility = stringCtorVisibility,
+		return true;
+	}
+
+	/// <summary>
+	/// Tries to extract the named parameters for a category from the attribute data.
+	/// </summary>
+	/// <param name="attributeData">The attribute data to be parsed.</param>
+	/// <param name="name">The original name of the ObjC class or protocol.</param>
+	/// <param name="flags">The configuration flags.</param>
+	/// <param name="categoryType">The type that the category extends.</param>
+	/// <returns>True if the data was parsed.</returns>
+	static bool TryExtractCategoryNamedParameters (AttributeData attributeData, out string? name, ref T? flags, out TypeInfo? categoryType)
+	{
+		name = null;
+		categoryType = null;
+		foreach (var (paramName, value) in attributeData.NamedArguments) {
+			switch (paramName) {
+			case "Name":
+				name = (string?) value.Value!;
+				break;
+			case "Flags":
+				flags = (T) value.Value!;
+				break;
+			case "CategoryType":
+				categoryType = new ((INamedTypeSymbol) value.Value!);
+				break;
+			default:
+				return false;
 			}
-			: new (name) {
-				ErrorDomain = errorDomain,
-				LibraryName = libraryName,
-				DefaultCtorVisibility = defaultCtorVisibility,
-				IntPtrCtorVisibility = intPtrCtorVisibility,
-				StringCtorVisibility = stringCtorVisibility,
-			};
+		}
+
 		return true;
 	}
 
@@ -247,6 +414,8 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 	public bool Equals (BindingTypeData<T> other)
 	{
 		if (Name != other.Name)
+			return false;
+		if (CategoryType != other.CategoryType)
 			return false;
 		if (Flags is not null && other.Flags is not null) {
 			return Flags.Equals (other.Flags);
@@ -266,11 +435,23 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 		return HashCode.Combine (Name, Flags);
 	}
 
+	/// <summary>
+	/// Compares two <see cref="BindingTypeData{T}"/> instances for equality.
+	/// </summary>
+	/// <param name="x">The first instance to compare.</param>
+	/// <param name="y">The second instance to compare.</param>
+	/// <returns><c>true</c> if the instances are equal; otherwise, <c>false</c>.</returns>
 	public static bool operator == (BindingTypeData<T> x, BindingTypeData<T> y)
 	{
 		return x.Equals (y);
 	}
 
+	/// <summary>
+	/// Compares two <see cref="BindingTypeData{T}"/> instances for inequality.
+	/// </summary>
+	/// <param name="x">The first instance to compare.</param>
+	/// <param name="y">The second instance to compare.</param>
+	/// <returns><c>true</c> if the instances are not equal; otherwise, <c>false</c>.</returns>
 	public static bool operator != (BindingTypeData<T> x, BindingTypeData<T> y)
 	{
 		return !(x == y);
@@ -279,6 +460,6 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 	/// <inheritdoc />
 	public override string ToString ()
 	{
-		return $"{{ Name: '{Name}', Flags: '{Flags}' }}";
+		return $"{{ Name: '{Name}', CategoryType: '{CategoryType?.ToString () ?? "null" }', Flags: '{Flags}' }}";
 	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/BindingTypeData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/BindingTypeData.cs
@@ -14,7 +14,7 @@ readonly struct BindingTypeData : IEquatable<BindingTypeData> {
 	/// Original name of the ObjC class or protocol.
 	/// </summary>
 	public string? Name { get; }
-	
+
 	/// <summary>
 	/// Initializes a new instance of the <see cref="BindingTypeData"/> struct.
 	/// </summary>
@@ -23,7 +23,7 @@ readonly struct BindingTypeData : IEquatable<BindingTypeData> {
 	{
 		Name = name;
 	}
-	
+
 	/// <summary>
 	/// Try to parse the attribute data to retrieve the information of an ExportAttribute&lt;T&gt;.
 	/// </summary>
@@ -148,7 +148,7 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 	/// The visibility of the string constructor for a core image filter.
 	/// </summary>
 	public MethodAttributes StringCtorVisibility { get; init; } = MethodAttributes.PrivateScope;
-	
+
 	/// <summary>
 	/// The type that the category extends.
 	/// </summary>
@@ -183,7 +183,7 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 		Name = name;
 		Flags = flags;
 	}
-	
+
 	/// <summary>
 	/// Initializes a new instance of the <see cref="BindingTypeData"/> struct for a category.
 	/// </summary>
@@ -221,9 +221,9 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 		T? flags = default;
 		// category related data
 		TypeInfo? categoryType = null;
-		
+
 		// check if we have a category type, we can do that by checking the type of the flag
-		var isCategory = typeof(T) == typeof(ObjCBindings.Category); 
+		var isCategory = typeof (T) == typeof (ObjCBindings.Category);
 
 		switch (count) {
 		case 0:
@@ -275,7 +275,7 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 			data = CreateClassBindingData (flags, name, errorDomain, libraryName, defaultCtorVisibility, intPtrCtorVisibility, stringCtorVisibility);
 			return true;
 		}
-		
+
 		return false;
 	}
 
@@ -290,8 +290,8 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 	/// <param name="intPtrCtorVisibility">The visibility of the IntPtr constructor.</param>
 	/// <param name="stringCtorVisibility">The visibility of the string constructor.</param>
 	/// <returns>A new instance of <see cref="BindingTypeData{T}"/>.</returns>
-	static BindingTypeData<T> CreateClassBindingData (T? flags, string? name, string? errorDomain, 
-		string? libraryName, MethodAttributes defaultCtorVisibility, MethodAttributes intPtrCtorVisibility, 
+	static BindingTypeData<T> CreateClassBindingData (T? flags, string? name, string? errorDomain,
+		string? libraryName, MethodAttributes defaultCtorVisibility, MethodAttributes intPtrCtorVisibility,
 		MethodAttributes stringCtorVisibility)
 	{
 		return flags is not null
@@ -310,7 +310,7 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 				StringCtorVisibility = stringCtorVisibility,
 			};
 	}
-	
+
 	/// <summary>
 	/// Creates a new instance of <see cref="BindingTypeData{T}"/> for a category.
 	/// </summary>
@@ -336,7 +336,7 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 	/// <param name="intPtrCtorVisibility">The visibility of the IntPtr constructor.</param>
 	/// <param name="stringCtorVisibility">The visibility of the string constructor.</param>
 	/// <returns>True if the data was parsed.</returns>
-	static bool TryExtractClassNamedParameters (AttributeData attributeData, 
+	static bool TryExtractClassNamedParameters (AttributeData attributeData,
 		out string? name, ref T? flags, out string? errorDomain, out string? libraryName,
 		out MethodAttributes defaultCtorVisibility, out MethodAttributes intPtrCtorVisibility,
 		out MethodAttributes stringCtorVisibility)
@@ -347,7 +347,7 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 		defaultCtorVisibility = MethodAttributes.PrivateScope;
 		intPtrCtorVisibility = MethodAttributes.PrivateScope;
 		stringCtorVisibility = MethodAttributes.PrivateScope;
-		
+
 		foreach (var (paramName, value) in attributeData.NamedArguments) {
 			switch (paramName) {
 			case "Name":
@@ -460,6 +460,6 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 	/// <inheritdoc />
 	public override string ToString ()
 	{
-		return $"{{ Name: '{Name}', CategoryType: '{CategoryType?.ToString () ?? "null" }', Flags: '{Flags}' }}";
+		return $"{{ Name: '{Name}', CategoryType: '{CategoryType?.ToString () ?? "null"}', Flags: '{Flags}' }}";
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingInfoTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingInfoTests.cs
@@ -178,27 +178,27 @@ public class BindingInfoTests {
 		{
 			yield return [
 				new BindingInfo (new BindingTypeData<ObjCBindings.SmartEnum> ("Name")),
-				"{ BindingType: SmartEnum, BindingData: { Name: 'Name', Flags: 'Default' } }",
+				"{ BindingType: SmartEnum, BindingData: { Name: 'Name', CategoryType: 'null', Flags: 'Default' } }",
 			];
 
 			yield return [
 				new BindingInfo (new BindingTypeData<ObjCBindings.Class> ("Name")),
-				"{ BindingType: Class, BindingData: { Name: 'Name', Flags: 'Default' } }"
+				"{ BindingType: Class, BindingData: { Name: 'Name', CategoryType: 'null', Flags: 'Default' } }"
 			];
 
 			yield return [
 				new BindingInfo (new BindingTypeData<ObjCBindings.Class> ("Name", Class.DisableDefaultCtor)),
-				"{ BindingType: Class, BindingData: { Name: 'Name', Flags: 'DisableDefaultCtor' } }"
+				"{ BindingType: Class, BindingData: { Name: 'Name', CategoryType: 'null', Flags: 'DisableDefaultCtor' } }"
 			];
 
 			yield return [
 				new BindingInfo (new BindingTypeData<ObjCBindings.Protocol> ("Name")),
-				"{ BindingType: Protocol, BindingData: { Name: 'Name', Flags: 'Default' } }"
+				"{ BindingType: Protocol, BindingData: { Name: 'Name', CategoryType: 'null', Flags: 'Default' } }"
 			];
 
 			yield return [
 				new BindingInfo (new BindingTypeData<ObjCBindings.Category> ("Name")),
-				"{ BindingType: Category, BindingData: { Name: 'Name', Flags: 'Default' } }"
+				"{ BindingType: Category, BindingData: { Name: 'Name', CategoryType: 'null', Flags: 'Default' } }"
 			];
 		}
 


### PR DESCRIPTION
This allows to pass the type rather than the name of the type which is a safer approach since the compiler will help us. The creation of a Category will now look like:

```csharp
[Binding<Category>(typeof (NSObject))]
public static class MyCategory {
  // static extension methods
}
```