### PR TITLE
[RGen] Fix how we detect 'this' parameters.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.Generator.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Context;
@@ -43,7 +44,7 @@ readonly partial struct Parameter {
 			ForcedType = symbol.GetForceTypeData (),
 			IsOptional = symbol.IsOptional,
 			IsParams = symbol.IsParams,
-			IsThis = symbol.IsThis,
+			IsThis = declaration.Modifiers.Any (SyntaxKind.ThisKeyword),
 			DefaultValue = (symbol.HasExplicitDefaultValue) ? symbol.ExplicitDefaultValue?.ToString () : null,
 			ReferenceKind = symbol.RefKind.ToReferenceKind (),
 			Attributes = declaration.GetAttributeCodeChanges (context.SemanticModel),

--- a/src/rgen/Microsoft.Macios.Generator/Formatters/ParameterFormatter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Formatters/ParameterFormatter.cs
@@ -39,12 +39,17 @@ static class ParameterFormatter {
 
 	public static ParameterSyntax ToDeclaration (this in ParameterDataModel parameter)
 	{
-		// modifiers come from two situations, we have the params keyword or not. We cannot have params + a ref modifier
-		// so we build them based on that. If you call WithModifiers twice, you will me stepping on the previous collection
-		// it won't be a merge
-		var modifiers = parameter.IsParams
-			? TokenList (Token (SyntaxKind.ParamsKeyword))
-			: parameter.ReferenceKind.ToTokens ();
+		SyntaxTokenList modifiers;
+		if (parameter.IsThis) {
+			modifiers = TokenList (Token (SyntaxKind.ThisKeyword));
+		} else {
+			// modifiers come from two situations, we have the params keyword or not. We cannot have params + a ref modifier
+			// so we build them based on that. If you call WithModifiers twice, you will me stepping on the previous collection
+			// it won't be a merge
+			modifiers = parameter.IsParams
+				? TokenList (Token (SyntaxKind.ParamsKeyword))
+				: parameter.ReferenceKind.ToTokens ();
+		}
 
 		// we are going to be ignoring the default value, the reason for it is that the partial method implementation
 		// can ignore it. The following c# code is valid:

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Formatters/MethodFormatterTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Formatters/MethodFormatterTests.cs
@@ -555,6 +555,17 @@ public partial class MyClass {
 }
 ";
 			yield return [nullableIntPtrReturnMethod, $"public partial {Global ("System.IntPtr")}? TestMethod (string myParam, int myParamInt)"];
+			
+			const string extensionMethod = @"
+using System;
+using ObjCBindings;
+namespace NS;
+[BindingType<Class>]
+public partial static class MyClass {
+	public static partial IntPtr? TestMethod(this string self, string myParam, int myParamInt);
+}
+";
+			yield return [extensionMethod, $"public static partial {Global ("System.IntPtr")}? TestMethod (this string self, string myParam, int myParamInt)"];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();


### PR DESCRIPTION
Fix the method that parses a parameter to correctly mark it as a 'this' parameter and update the parameter formater to correctly render the parameter modifiers.