### PR TITLE
[RGen] Add missing availability in the class declaration.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
@@ -535,6 +535,8 @@ public static NSObject {name} ({NSObject} objectToObserve, {EventHandler}<{event
 		// we use the name of the class
 		var registrationName = bindingData.Name ?? bindingContext.Changes.Name;
 
+		// append the class availability, this will add the necessary attributes to the class
+		bindingContext.Builder.AppendMemberAvailability (bindingContext.Changes.SymbolAvailability);
 		if (!bindingContext.Changes.IsStatic) {
 			bindingContext.Builder.WriteLine ($"[Register (\"{registrationName}\", true)]");
 		}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/CIImage.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/CIImage.cs
@@ -9,7 +9,6 @@ namespace TestNamespace;
 [SupportedOSPlatform ("macos")]
 [SupportedOSPlatform ("ios11.0")]
 [SupportedOSPlatform ("tvos11.0")]
-
 [BindingType<Class> ()]
 public partial class CIImage {
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedCIImage.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedCIImage.cs
@@ -16,11 +16,14 @@ using System.Threading.Tasks;
 
 namespace TestNamespace;
 
+[SupportedOSPlatform ("macos")]
+[SupportedOSPlatform ("ios11.0")]
+[SupportedOSPlatform ("tvos11.0")]
 [Register ("CIImage", true)]
 public partial class CIImage
 {
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	static readonly $GLOBAL$ObjCRuntime.NativeHandle class_ptr = $GLOBAL$ObjCRuntime.Class.GetHandle ("CIImage");
+	static readonly global::ObjCRuntime.NativeHandle class_ptr = global::ObjCRuntime.Class.GetHandle ("CIImage");
 
 	/// <summary>The Objective-C class handle for this class.</summary>
 	/// <value>The pointer to the Objective-C class.</value>
@@ -29,18 +32,18 @@ public partial class CIImage
 	///     This value contains the pointer to the Objective-C class.
 	///     It is similar to calling the managed <see cref=\"ObjCRuntime.Class.GetHandle(string)\" /> or the native <see href=\"https://developer.apple.com/documentation/objectivec/1418952-objc_getclass\">objc_getClass</see> method with the type name.
 	/// </remarks>
-	public override $GLOBAL$ObjCRuntime.NativeHandle ClassHandle => class_ptr;
+	public override global::ObjCRuntime.NativeHandle ClassHandle => class_ptr;
 
 	/// <summary>Creates a new <see cref="CIImage" /> with default values.</summary>
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[DesignatedInitializer]
 	[Export ("init")]
-	public CIImage () : base ($GLOBAL$Foundation.NSObjectFlag.Empty)
+	public CIImage () : base (global::Foundation.NSObjectFlag.Empty)
 	{
 		if (IsDirectBinding)
-			InitializeHandle ($GLOBAL$ObjCRuntime.Messaging.IntPtr_objc_msgSend (this.Handle, $GLOBAL$ObjCRuntime.Selector.GetHandle ("init")), "init");
+			InitializeHandle (global::ObjCRuntime.Messaging.IntPtr_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("init")), "init");
 		else
-			InitializeHandle ($GLOBAL$ObjCRuntime.Messaging.IntPtr_objc_msgSendSuper (this.SuperHandle, $GLOBAL$ObjCRuntime.Selector.GetHandle ("init")), "init");
+			InitializeHandle (global::ObjCRuntime.Messaging.IntPtr_objc_msgSendSuper (this.SuperHandle, global::ObjCRuntime.Selector.GetHandle ("init")), "init");
 	}
 
 	/// <summary>Constructor to call on derived classes to skip initialization and merely allocate the object.</summary>
@@ -90,7 +93,7 @@ public partial class CIImage
 	/// </remarks>
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	protected CIImage ($GLOBAL$Foundation.NSObjectFlag t) : base (t) {}
+	protected CIImage (global::Foundation.NSObjectFlag t) : base (t) {}
 
 	/// <summary>A constructor used when creating managed representations of unmanaged objects. Called by the runtime.</summary>
 	/// <param name="handle">Pointer (handle) to the unmanaged object.</param>
@@ -102,9 +105,9 @@ public partial class CIImage
 	/// </remarks>
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
-	protected internal CIImage ($GLOBAL$ObjCRuntime.NativeHandle handle) : base (handle) {}
+	protected internal CIImage (global::ObjCRuntime.NativeHandle handle) : base (handle) {}
 
-	static $GLOBAL$Foundation.NSString? _DidProcessEditingNotification;
+	static global::Foundation.NSString? _DidProcessEditingNotification;
 
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios11.0")]
@@ -112,7 +115,7 @@ public partial class CIImage
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	[Advice ("Use 'CIImage.Notifications.DidProcessEditingNotification' helper method instead.")]
-	public static partial $GLOBAL$Foundation.NSString DidProcessEditingNotification
+	public static partial global::Foundation.NSString DidProcessEditingNotification
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios11.0")]
@@ -121,7 +124,7 @@ public partial class CIImage
 		get
 		{
 			if (_DidProcessEditingNotification is null)
-				_DidProcessEditingNotification = $GLOBAL$ObjCRuntime.Dlfcn.GetStringConstant ($GLOBAL$ObjCRuntime.Libraries.TestNamespace.Handle, "kCIFormatLA8")!;
+				_DidProcessEditingNotification = global::ObjCRuntime.Dlfcn.GetStringConstant (global::ObjCRuntime.Libraries.TestNamespace.Handle, "kCIFormatLA8")!;
 			return _DidProcessEditingNotification;
 		}
 	}
@@ -140,7 +143,7 @@ public partial class CIImage
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			return $GLOBAL$ObjCRuntime.Dlfcn.GetInt32 ($GLOBAL$ObjCRuntime.Libraries.TestNamespace.Handle, "kCIFormatABGR8");
+			return global::ObjCRuntime.Dlfcn.GetInt32 (global::ObjCRuntime.Libraries.TestNamespace.Handle, "kCIFormatABGR8");
 		}
 	}
 
@@ -158,7 +161,7 @@ public partial class CIImage
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			return $GLOBAL$ObjCRuntime.Dlfcn.GetInt32 ($GLOBAL$ObjCRuntime.Libraries.TestNamespace.Handle, "kCIFormatLA8");
+			return global::ObjCRuntime.Dlfcn.GetInt32 (global::ObjCRuntime.Libraries.TestNamespace.Handle, "kCIFormatLA8");
 		}
 
 		[SupportedOSPlatform ("macos14.0")]
@@ -167,7 +170,7 @@ public partial class CIImage
 		[SupportedOSPlatform ("maccatalyst17.0")]
 		set
 		{
-			$GLOBAL$ObjCRuntime.Dlfcn.SetInt32 ($GLOBAL$ObjCRuntime.Libraries.TestNamespace.Handle, "kCIFormatLA8", value);
+			global::ObjCRuntime.Dlfcn.SetInt32 (global::ObjCRuntime.Libraries.TestNamespace.Handle, "kCIFormatLA8", value);
 		}
 	}
 
@@ -185,21 +188,21 @@ public partial class CIImage
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			return $GLOBAL$ObjCRuntime.Dlfcn.GetInt32 ($GLOBAL$ObjCRuntime.Libraries.TestNamespace.Handle, "FormatRGBA16Int");
+			return global::ObjCRuntime.Dlfcn.GetInt32 (global::ObjCRuntime.Libraries.TestNamespace.Handle, "FormatRGBA16Int");
 		}
 	}
 
 	public static partial class Notifications
 	{
 
-		public static $GLOBAL$Foundation.NSObject ObserveDidProcessEditing ($GLOBAL$System.EventHandler<$GLOBAL$Foundation.NSNotificationEventArgs> handler)
+		public static global::Foundation.NSObject ObserveDidProcessEditing (global::System.EventHandler<global::Foundation.NSNotificationEventArgs> handler)
 		{
-			return $GLOBAL$Foundation.NotificationCenter.DefaultCenter.AddObserver (DidProcessEditingNotification, notification => handler (null, new $GLOBAL$Foundation.NSNotificationEventArgs (notification)));
+			return global::Foundation.NotificationCenter.DefaultCenter.AddObserver (DidProcessEditingNotification, notification => handler (null, new global::Foundation.NSNotificationEventArgs (notification)));
 		}
 
-		public static NSObject ObserveDidProcessEditing ($GLOBAL$Foundation.NSObject objectToObserve, $GLOBAL$System.EventHandler<$GLOBAL$Foundation.NSNotificationEventArgs> handler)
+		public static NSObject ObserveDidProcessEditing (global::Foundation.NSObject objectToObserve, global::System.EventHandler<global::Foundation.NSNotificationEventArgs> handler)
 		{
-			return $GLOBAL$Foundation.NotificationCenter.DefaultCenter.AddObserver (DidProcessEditingNotification, notification => handler (null, new $GLOBAL$Foundation.NSNotificationEventArgs (notification)), objectToObserve);
+			return global::Foundation.NotificationCenter.DefaultCenter.AddObserver (DidProcessEditingNotification, notification => handler (null, new global::Foundation.NSNotificationEventArgs (notification)), objectToObserve);
 		}
 
 	}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedMethodsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedMethodsTests.cs
@@ -18,6 +18,10 @@ using System.Threading.Tasks;
 
 namespace TestNamespace;
 
+[SupportedOSPlatform ("macos")]
+[SupportedOSPlatform ("ios")]
+[SupportedOSPlatform ("tvos")]
+[SupportedOSPlatform ("maccatalyst13.1")]
 [Register ("MethodTests", true)]
 public partial class MethodTests
 {

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedThreadSafeAppKitPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedThreadSafeAppKitPropertyTests.cs
@@ -16,6 +16,10 @@ using System.Threading.Tasks;
 
 namespace AppKit;
 
+[SupportedOSPlatform ("macos")]
+[SupportedOSPlatform ("ios")]
+[SupportedOSPlatform ("tvos")]
+[SupportedOSPlatform ("maccatalyst13.1")]
 [Register ("ThreadSafeAppKitPropertyTests", true)]
 public partial class ThreadSafeAppKitPropertyTests
 {

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedThreadSafeUIKitPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedThreadSafeUIKitPropertyTests.cs
@@ -16,6 +16,10 @@ using System.Threading.Tasks;
 
 namespace UIKit;
 
+[SupportedOSPlatform ("macos")]
+[SupportedOSPlatform ("ios")]
+[SupportedOSPlatform ("tvos")]
+[SupportedOSPlatform ("maccatalyst13.1")]
 [Register ("ThreadSafeUIKitPropertyTests", true)]
 public partial class ThreadSafeUIKitPropertyTests
 {

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
@@ -13,6 +13,10 @@ using nfloat = System.Runtime.InteropServices.NFloat;
 
 namespace TestNamespace;
 
+[SupportedOSPlatform ("macos")]
+[SupportedOSPlatform ("ios")]
+[SupportedOSPlatform ("tvos")]
+[SupportedOSPlatform ("maccatalyst13.1")]
 [BindingType<Class>]
 public partial class MethodTests {
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/PropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/PropertyTests.cs
@@ -13,6 +13,10 @@ using nfloat = System.Runtime.InteropServices.NFloat;
 
 namespace TestNamespace;
 
+[SupportedOSPlatform ("macos")]
+[SupportedOSPlatform ("ios")]
+[SupportedOSPlatform ("tvos")]
+[SupportedOSPlatform ("maccatalyst13.1")]
 [BindingType<ObjCBindings.Class>]
 public partial class PropertyTests {
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ThreadSafeAppKitPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ThreadSafeAppKitPropertyTests.cs
@@ -9,6 +9,10 @@ using ObjCBindings;
 
 namespace AppKit;
 
+[SupportedOSPlatform ("macos")]
+[SupportedOSPlatform ("ios")]
+[SupportedOSPlatform ("tvos")]
+[SupportedOSPlatform ("maccatalyst13.1")]
 [BindingType<Class> (Class.IsThreadSafe)]
 public partial class ThreadSafeAppKitPropertyTests {
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ThreadSafeUIKitPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ThreadSafeUIKitPropertyTests.cs
@@ -9,6 +9,10 @@ using ObjCBindings;
 
 namespace UIKit;
 
+[SupportedOSPlatform ("macos")]
+[SupportedOSPlatform ("ios")]
+[SupportedOSPlatform ("tvos")]
+[SupportedOSPlatform ("maccatalyst13.1")]
 [BindingType<Class> (Class.IsThreadSafe)]
 public partial class ThreadSafeUIKitPropertyTests {
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
@@ -18,6 +18,10 @@ using System.Threading.Tasks;
 
 namespace TestNamespace;
 
+[SupportedOSPlatform ("macos")]
+[SupportedOSPlatform ("ios")]
+[SupportedOSPlatform ("tvos")]
+[SupportedOSPlatform ("maccatalyst13.1")]
 [Register ("PropertyTests", true)]
 public partial class PropertyTests
 {

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
@@ -18,6 +18,10 @@ using System.Threading.Tasks;
 
 namespace TestNamespace;
 
+[SupportedOSPlatform ("macos")]
+[SupportedOSPlatform ("ios")]
+[SupportedOSPlatform ("tvos")]
+[SupportedOSPlatform ("maccatalyst13.1")]
 [Register ("PropertyTests", true)]
 public partial class PropertyTests
 {

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedMethodsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedMethodsTests.cs
@@ -18,6 +18,10 @@ using System.Threading.Tasks;
 
 namespace TestNamespace;
 
+[SupportedOSPlatform ("macos")]
+[SupportedOSPlatform ("ios")]
+[SupportedOSPlatform ("tvos")]
+[SupportedOSPlatform ("maccatalyst13.1")]
 [Register ("MethodTests", true)]
 public partial class MethodTests
 {

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
@@ -18,6 +18,10 @@ using System.Threading.Tasks;
 
 namespace TestNamespace;
 
+[SupportedOSPlatform ("macos")]
+[SupportedOSPlatform ("ios")]
+[SupportedOSPlatform ("tvos")]
+[SupportedOSPlatform ("maccatalyst13.1")]
 [Register ("PropertyTests", true)]
 public partial class PropertyTests
 {


### PR DESCRIPTION
We must add the availability to the top of the class generated for consistency. The reality is that is not needed but we are adding it to reduce the diff with the old code generated by bgen (important for the migration).