### PR TITLE
[RGen] Performance improvement by using the semantic model over parsing the AST.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Binding.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Binding.Generator.cs
@@ -204,7 +204,7 @@ readonly partial struct Binding {
 			namespaces: out namespaces,
 			symbolAvailability: out availability,
 			bindingInfo: out bindingInfo);
-		FullyQualifiedSymbol = enumDeclaration.GetFullyQualifiedIdentifier ();
+		FullyQualifiedSymbol = enumDeclaration.GetFullyQualifiedIdentifier (context.SemanticModel);
 		Attributes = enumDeclaration.GetAttributeCodeChanges (context.SemanticModel);
 		UsingDirectives = enumDeclaration.SyntaxTree.CollectUsingStatements ();
 		Modifiers = [.. enumDeclaration.Modifiers];
@@ -254,7 +254,7 @@ readonly partial struct Binding {
 			namespaces: out namespaces,
 			symbolAvailability: out availability,
 			bindingInfo: out bindingInfo);
-		FullyQualifiedSymbol = classDeclaration.GetFullyQualifiedIdentifier ();
+		FullyQualifiedSymbol = classDeclaration.GetFullyQualifiedIdentifier (context.SemanticModel);
 		Attributes = classDeclaration.GetAttributeCodeChanges (context.SemanticModel);
 		UsingDirectives = classDeclaration.SyntaxTree.CollectUsingStatements ();
 		Modifiers = [.. classDeclaration.Modifiers];
@@ -286,7 +286,7 @@ readonly partial struct Binding {
 			namespaces: out namespaces,
 			symbolAvailability: out availability,
 			bindingInfo: out bindingInfo);
-		FullyQualifiedSymbol = interfaceDeclaration.GetFullyQualifiedIdentifier ();
+		FullyQualifiedSymbol = interfaceDeclaration.GetFullyQualifiedIdentifier (context.SemanticModel);
 		Attributes = interfaceDeclaration.GetAttributeCodeChanges (context.SemanticModel);
 		UsingDirectives = interfaceDeclaration.SyntaxTree.CollectUsingStatements ();
 		Modifiers = [.. interfaceDeclaration.Modifiers];

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/BaseTypeDeclarationSyntaxExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/BaseTypeDeclarationSyntaxExtensions.cs
@@ -17,8 +17,8 @@ static class BaseTypeDeclarationSyntaxExtensions {
 	public static string GetFullyQualifiedIdentifier (this BaseTypeDeclarationSyntax self, SemanticModel semanticModel)
 	{
 		var symbol = semanticModel.GetDeclaredSymbol (self);
-		return symbol is null ? 
-			string.Empty : 
+		return symbol is null ?
+			string.Empty :
 			symbol.ToDisplayString (SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle (SymbolDisplayGlobalNamespaceStyle.Omitted));
 	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/BaseTypeDeclarationSyntaxExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/BaseTypeDeclarationSyntaxExtensions.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using System.Linq;
-using System.Text;
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.Macios.Generator.Extensions;
@@ -12,39 +12,13 @@ static class BaseTypeDeclarationSyntaxExtensions {
 	/// navigating the syntax tree and getting the namespace and class names.
 	/// </summary>
 	/// <param name="self">The declaration whose fully qualified name we want to retrieve.</param>
+	/// <param name="semanticModel">The current compilation semantic model.</param>
 	/// <returns>A fully qualified identifier with all namespaces and classes found in the syntax tree.</returns>
-	public static string GetFullyQualifiedIdentifier (this BaseTypeDeclarationSyntax self)
+	public static string GetFullyQualifiedIdentifier (this BaseTypeDeclarationSyntax self, SemanticModel semanticModel)
 	{
-		var root = self.SyntaxTree.GetRoot ();
-		// check if the namespace is a file scoped one "namespace Foo;"
-		var fileScoped = root.DescendantNodes ()
-			.OfType<FileScopedNamespaceDeclarationSyntax> ()
-			.FirstOrDefault ();
-
-		var namespaces = self.Ancestors ()
-			.OfType<NamespaceDeclarationSyntax> ()
-			.Reverse ()
-			.Select (ns => ns.Name.ToString ().Trim ())
-			.ToArray ();
-
-		// get all the classes
-		var parents = self.Ancestors ()
-			.OfType<BaseTypeDeclarationSyntax> ()
-			.Reverse ()
-			.Select (c => c.Identifier.ToFullString ().Trim ())
-			.ToArray ();
-
-		var sb = new StringBuilder ();
-		if (fileScoped is not null)
-			sb.Append ($"{fileScoped.Name}");
-		// not need to add a '.' before the namespaces, you cannot have both field scope and namespace
-		sb.AppendJoin (".", namespaces);
-		if (parents.Length > 0) {
-			sb.Append ('.');
-			sb.AppendJoin (".", parents);
-		}
-
-		sb.Append ($".{self.Identifier.ToFullString ()}");
-		return sb.ToString ().Trim ();
+		var symbol = semanticModel.GetDeclaredSymbol (self);
+		return symbol is null ? 
+			string.Empty : 
+			symbol.ToDisplayString (SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle (SymbolDisplayGlobalNamespaceStyle.Omitted));
 	}
 }

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Binding.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Binding.Transformer.cs
@@ -74,7 +74,7 @@ readonly partial struct Binding {
 			namespaces: out namespaces,
 			symbolAvailability: out availability);
 		BindingBindingInfo = new BindingInfo (null, BindingType.SmartEnum);
-		FullyQualifiedSymbol = enumDeclaration.GetFullyQualifiedIdentifier ();
+		FullyQualifiedSymbol = enumDeclaration.GetFullyQualifiedIdentifier (context.SemanticModel);
 		UsingDirectives = enumDeclaration.SyntaxTree.CollectUsingStatements ();
 		AttributesDictionary = symbol.GetAttributeData ();
 		// smart enums are expected to be public, we might need to change this in the future
@@ -236,7 +236,7 @@ readonly partial struct Binding {
 	internal Binding (InterfaceDeclarationSyntax interfaceDeclarationSyntax, INamedTypeSymbol symbol, in RootContext context)
 	{
 		// basic properties of the binding
-		FullyQualifiedSymbol = interfaceDeclarationSyntax.GetFullyQualifiedIdentifier ();
+		FullyQualifiedSymbol = interfaceDeclarationSyntax.GetFullyQualifiedIdentifier (context.SemanticModel);
 		UsingDirectives = interfaceDeclarationSyntax.SyntaxTree.CollectUsingStatements ();
 		AttributesDictionary = symbol.GetAttributeData ();
 		var baseTypeAttribute = symbol.GetBaseTypeData ();

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/BaseTypeDeclarationSyntaxExtensionsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/BaseTypeDeclarationSyntaxExtensionsTests.cs
@@ -3,6 +3,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.Extensions;
 using Xamarin.Tests;
@@ -62,33 +63,34 @@ namespace Foo {
 	}
 }
 ";
-	T GetDeclaration<T> (ApplePlatform platform, string inputText) where T : BaseTypeDeclarationSyntax
+	T GetDeclaration<T> (ApplePlatform platform, string inputText, out SemanticModel semanticModel) where T : BaseTypeDeclarationSyntax
 	{
-		var (_, sourceTrees) = CreateCompilation (platform, sources: inputText);
+		var (compilation, sourceTrees) = CreateCompilation (platform, sources: inputText);
 		Assert.Single (sourceTrees);
 		var declaration = sourceTrees [0].GetRoot ()
 			.DescendantNodes ()
 			.OfType<T> ()
 			.FirstOrDefault ();
 		Assert.NotNull (declaration);
+		semanticModel = compilation.GetSemanticModel (sourceTrees[0]);
 		return declaration;
 	}
 
 	public IEnumerator<object []> GetEnumerator ()
 	{
 		foreach (var platform in Configuration.GetIncludedPlatforms ()) {
-			yield return [GetDeclaration<ClassDeclarationSyntax> (platform, filescopedNamespaceClass),
-				"Test.Foo"];
-			yield return [GetDeclaration<EnumDeclarationSyntax> (platform, filescopedNamespaceNestedEnum),
-				"Test.Foo.Bar"];
-			yield return [GetDeclaration<ClassDeclarationSyntax> (platform, namespaceClass),
-				"Test.Foo"];
-			yield return [GetDeclaration<ClassDeclarationSyntax> (platform, severalNamespaces),
-				"Test.Foo"];
-			yield return [GetDeclaration<ClassDeclarationSyntax> (platform, nestedNamespaces),
-				"Foo.Bar.Test"];
-			yield return [GetDeclaration<EnumDeclarationSyntax> (platform, nestedEnum),
-				"Foo.Bar.Test.Final"];
+			yield return [GetDeclaration<ClassDeclarationSyntax> (platform, filescopedNamespaceClass, out SemanticModel semanticModel),
+				semanticModel, "Test.Foo"];
+			yield return [GetDeclaration<EnumDeclarationSyntax> (platform, filescopedNamespaceNestedEnum, out semanticModel),
+				semanticModel, "Test.Foo.Bar"];
+			yield return [GetDeclaration<ClassDeclarationSyntax> (platform, namespaceClass, out semanticModel),
+				semanticModel, "Test.Foo"];
+			yield return [GetDeclaration<ClassDeclarationSyntax> (platform, severalNamespaces, out semanticModel),
+				semanticModel, "Test.Foo"];
+			yield return [GetDeclaration<ClassDeclarationSyntax> (platform, nestedNamespaces, out semanticModel),
+				semanticModel, "Foo.Bar.Test"];
+			yield return [GetDeclaration<EnumDeclarationSyntax> (platform, nestedEnum, out semanticModel),
+				semanticModel, "Foo.Bar.Test.Final"];
 		}
 	}
 
@@ -96,9 +98,9 @@ namespace Foo {
 
 	[Theory]
 	[ClassData (typeof (BaseTypeDeclarationSyntaxExtensionsTests))]
-	public void GetFullyQualifiedIdentifier<T> (T declaration, string expected)
+	public void GetFullyQualifiedIdentifier<T> (T declaration, SemanticModel semanticModel, string expected)
 		where T : BaseTypeDeclarationSyntax
 	{
-		Assert.Equal (expected, declaration.GetFullyQualifiedIdentifier ());
+		Assert.Equal (expected, declaration.GetFullyQualifiedIdentifier (semanticModel));
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/BaseTypeDeclarationSyntaxExtensionsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/BaseTypeDeclarationSyntaxExtensionsTests.cs
@@ -72,7 +72,7 @@ namespace Foo {
 			.OfType<T> ()
 			.FirstOrDefault ();
 		Assert.NotNull (declaration);
-		semanticModel = compilation.GetSemanticModel (sourceTrees[0]);
+		semanticModel = compilation.GetSemanticModel (sourceTrees [0]);
 		return declaration;
 	}
 
@@ -80,17 +80,23 @@ namespace Foo {
 	{
 		foreach (var platform in Configuration.GetIncludedPlatforms ()) {
 			yield return [GetDeclaration<ClassDeclarationSyntax> (platform, filescopedNamespaceClass, out SemanticModel semanticModel),
-				semanticModel, "Test.Foo"];
+				semanticModel,
+				"Test.Foo"];
 			yield return [GetDeclaration<EnumDeclarationSyntax> (platform, filescopedNamespaceNestedEnum, out semanticModel),
-				semanticModel, "Test.Foo.Bar"];
+				semanticModel,
+				"Test.Foo.Bar"];
 			yield return [GetDeclaration<ClassDeclarationSyntax> (platform, namespaceClass, out semanticModel),
-				semanticModel, "Test.Foo"];
+				semanticModel,
+				"Test.Foo"];
 			yield return [GetDeclaration<ClassDeclarationSyntax> (platform, severalNamespaces, out semanticModel),
-				semanticModel, "Test.Foo"];
+				semanticModel,
+				"Test.Foo"];
 			yield return [GetDeclaration<ClassDeclarationSyntax> (platform, nestedNamespaces, out semanticModel),
-				semanticModel, "Foo.Bar.Test"];
+				semanticModel,
+				"Foo.Bar.Test"];
 			yield return [GetDeclaration<EnumDeclarationSyntax> (platform, nestedEnum, out semanticModel),
-				semanticModel, "Foo.Bar.Test.Final"];
+				semanticModel,
+				"Foo.Bar.Test.Final"];
 		}
 	}
 


### PR DESCRIPTION
We have access to the semantic model which means that we can rely on the symbol to get the fully qualified name. This approach is more efficient that walking the AST, uses less code and still allows use to customize the way the fully qualified name is created.