### PR TITLE
[RGen] Add code to retrieve strong dict properties for a binding.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/AttributesNames.cs
+++ b/src/rgen/Microsoft.Macios.Generator/AttributesNames.cs
@@ -20,6 +20,7 @@ static class AttributesNames {
 	public const string EnumFieldAttribute = "ObjCBindings.FieldAttribute<ObjCBindings.EnumValue>";
 	public const string FieldPropertyAttribute = "ObjCBindings.FieldAttribute<ObjCBindings.Property>";
 	public const string ExportPropertyAttribute = "ObjCBindings.ExportAttribute<ObjCBindings.Property>";
+	public const string ExportStrongDictionaryPropertyAttribute = "ObjCBindings.ExportAttribute<ObjCBindings.StrongDictionaryProperty>";
 	public const string ExportMethodAttribute = "ObjCBindings.ExportAttribute<ObjCBindings.Method>";
 	public const string ExportConstructorAttribute = "ObjCBindings.ExportAttribute<ObjCBindings.Constructor>";
 	public const string SupportedOSPlatformAttribute = "System.Runtime.Versioning.SupportedOSPlatformAttribute";

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Binding.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Binding.Generator.cs
@@ -130,7 +130,7 @@ readonly partial struct Binding {
 	/// <param name="propertyDeclarationSyntax">The property declaration under test.</param>
 	/// <param name="semanticModel">The semantic model of the compilation.</param>
 	/// <returns>True if the property should be ignored. False otherwise.</returns>
-	internal static bool Skip (PropertyDeclarationSyntax propertyDeclarationSyntax, SemanticModel semanticModel)
+	internal static bool PropertySkip (PropertyDeclarationSyntax propertyDeclarationSyntax, SemanticModel semanticModel)
 	{
 		// valid properties are: 
 		// 1. Partial
@@ -142,6 +142,25 @@ readonly partial struct Binding {
 				AttributesNames.FieldPropertyAttribute, AttributesNames.ExportPropertyAttribute);
 		}
 
+		return true;
+	}
+
+	/// <summary>
+	/// Decide if a property in a strong dictionary should be ignored as a change.
+	/// </summary>
+	/// <param name="propertyDeclarationSyntax">The property declaration under test.</param>
+	/// <param name="semanticModel">The semantic model of the compilation.</param>
+	/// <returns>True if the property should be ignored. False otherwise.</returns>
+	internal static bool StrongDictionarySkip (PropertyDeclarationSyntax propertyDeclarationSyntax,
+		SemanticModel semanticModel)
+	{
+		// valid properties for strong dictionaries are:
+		// 1. Partial
+		// 2. Exported properties as dictionary properties
+		if (propertyDeclarationSyntax.Modifiers.Any (SyntaxKind.PartialKeyword)) {
+			return !propertyDeclarationSyntax.HasAttribute (semanticModel,
+				AttributesNames.ExportStrongDictionaryPropertyAttribute);
+		}
 		return true;
 	}
 
@@ -263,11 +282,19 @@ readonly partial struct Binding {
 		// the value types are copied
 		GetMembers<ConstructorDeclarationSyntax, Constructor> (classDeclaration, context, Skip,
 			Constructor.TryCreate, out constructors);
-		GetMembers<PropertyDeclarationSyntax, Property> (classDeclaration, context, Skip, Property.TryCreate,
-			out properties);
 		GetMembers<EventDeclarationSyntax, Event> (classDeclaration, context, Skip, Event.TryCreate, out events);
 		GetMembers<MethodDeclarationSyntax, Method> (classDeclaration, context, Skip, Method.TryCreate,
 			out methods);
+
+		// if an only if the class declaration is a strong dictionary we will retrieve strong dictionary properties, else
+		// we will retrieve the properties as normal properties.
+		if (bindingInfo.BindingType == BindingType.StrongDictionary) {
+			GetMembers<PropertyDeclarationSyntax, Property> (classDeclaration, context, StrongDictionarySkip, Property.TryCreate,
+				out strongDictproperties);
+		} else {
+			GetMembers<PropertyDeclarationSyntax, Property> (classDeclaration, context, PropertySkip, Property.TryCreate,
+				out properties);
+		}
 	}
 
 	/// <summary>
@@ -292,7 +319,7 @@ readonly partial struct Binding {
 		Modifiers = [.. interfaceDeclaration.Modifiers];
 		// we do not init the constructors, we use the default empty array
 
-		GetMembers<PropertyDeclarationSyntax, Property> (interfaceDeclaration, context.SemanticModel, Skip, Property.TryCreate,
+		GetMembers<PropertyDeclarationSyntax, Property> (interfaceDeclaration, context.SemanticModel, PropertySkip, Property.TryCreate,
 			out properties);
 		GetMembers<EventDeclarationSyntax, Event> (interfaceDeclaration, context.SemanticModel, Skip, Event.TryCreate,
 			out events);

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Binding.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Binding.cs
@@ -153,12 +153,38 @@ readonly partial struct Binding {
 			}
 		}
 	}
-
+	
 	/// <summary>
 	/// Returns all the selectors for the properties.
 	/// </summary>
 	public ImmutableArray<string> PropertySelectors => [.. propertyIndex.Keys];
+	
+	readonly Dictionary<string, int> strongDictPropertyIndex = new ();
+	readonly ImmutableArray<Property> strongDictproperties = [];
 
+	/// <summary>
+	/// Changes to the properties of the symbol that is a StrongDictionary.
+	/// </summary>
+	public ImmutableArray<Property> StrongDictionaryProperties {
+		get => strongDictproperties;
+		init {
+			strongDictproperties = value;
+			// populate the property index for fast lookup using the symbol name
+			for (var index = 0; index < strongDictproperties.Length; index++) {
+				var property = strongDictproperties [index];
+				// there are two type of properties, those that are fields and those that are properties
+				if (property.Selector is null)
+					continue;
+				strongDictPropertyIndex[property.Selector!] = index;
+			}
+		}
+	}
+	
+	/// <summary>
+	/// Returns all the strings that are used as keys in the StrongDictionary properties.
+	/// </summary>
+	public ImmutableArray<string> StrongDictionaryKeys => [.. strongDictPropertyIndex.Keys];
+	
 	readonly Dictionary<string, int> constructorIndex = new ();
 	readonly ImmutableArray<Constructor> constructors = [];
 

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/StrongDictionaryEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/StrongDictionaryEmitter.cs
@@ -4,9 +4,11 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.Macios.Generator.Context;
 using Microsoft.Macios.Generator.DataModel;
+using Microsoft.Macios.Generator.IO;
 
 namespace Microsoft.Macios.Generator.Emitters;
 
@@ -20,11 +22,53 @@ class StrongDictionaryEmitter : IClassEmitter {
 	/// <inheritdoc />
 	public IEnumerable<string> UsingStatements { get; } = [];
 
+	void EmitDefaultConstructors (in BindingContext bindingContext, TabbedWriter<StringWriter> classBlock)
+	{
+		classBlock.WriteLine ();
+		classBlock.WriteLine("// TODO: implement default constructors.");
+		classBlock.WriteLine ();
+	}
+
+	void EmitProperties (in BindingContext context, TabbedWriter<StringWriter> classBlock)
+	{
+		classBlock.WriteLine ();
+		classBlock.WriteLine ("// TODO: implement properties.");
+		classBlock.WriteLine ();
+		
+		foreach (var property in context.Changes.StrongDictionaryProperties) {
+			classBlock.WriteLine ();
+			classBlock.WriteLine ($"// Emit code for property: {property.Name}");
+			classBlock.WriteLine ();
+		}
+	}
+
 	/// <inheritdoc />
 	public bool TryEmit (in BindingContext bindingContext, [NotNullWhen (false)] out ImmutableArray<Diagnostic>? diagnostics)
 	{
 		diagnostics = null;
-		bindingContext.Builder.WriteLine ("// TODO: implement emitter.");
+		if (bindingContext.Changes.BindingType != BindingType.StrongDictionary) {
+			diagnostics = [Diagnostic.Create (
+				Diagnostics
+					.RBI0000, // An unexpected error occurred while processing '{0}'. Please fill a bug report at https://github.com/dotnet/macios/issues/new.
+				null,
+				bindingContext.Changes.FullyQualifiedSymbol)];
+			return false;
+		}
+		
+		// namespace declaration
+		bindingContext.Builder.WriteLine ();
+		bindingContext.Builder.WriteLine ($"namespace {string.Join (".", bindingContext.Changes.Namespace)};");
+		bindingContext.Builder.WriteLine ();
+		
+		var modifiers = $"{string.Join (' ', bindingContext.Changes.Modifiers)} ";
+		using (var classBlock = bindingContext.Builder.CreateBlock (
+			       $"{(string.IsNullOrWhiteSpace (modifiers) ? string.Empty : modifiers)}class {bindingContext.Changes.Name} : DictionaryContainer",
+			       true)) {
+			// we care about two specific things, the constructors and the strong dictionary properties
+			EmitDefaultConstructors (bindingContext, classBlock);
+			EmitProperties (bindingContext, classBlock);
+		}
+
 		return true;
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingTests.cs
@@ -190,7 +190,7 @@ public class TestClass {
 			.FirstOrDefault ();
 		Assert.NotNull (node);
 		var semanticModel = compilation.GetSemanticModel (sourceTrees [0]);
-		Assert.Equal (expected, Binding.Skip (node, semanticModel));
+		Assert.Equal (expected, Binding.PropertySkip (node, semanticModel));
 	}
 
 	class TestDataSkipMethodDeclaration : IEnumerable<object []> {

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/StrongDictionaries/Data/CARendererOptions.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/StrongDictionaries/Data/CARendererOptions.cs
@@ -28,4 +28,7 @@ public partial class CARendererOptions : DictionaryContainer {
 
 	[Export<StrongDictionaryProperty> (nameof (Keys.MetalCommandQueue), StrongDictionaryKeyClass = typeof (Keys))]
 	public partial IMTLCommandQueue MetalCommandQueue { get; set; }
+	
+	// this is a random property to test the generator's handling of properties that are not marked as StrongDictionaryProperty.
+	public string int Radom => Int32.MaxValue;
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/StrongDictionaries/Data/ExpectedCARendererOptions.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/StrongDictionaries/Data/ExpectedCARendererOptions.cs
@@ -8,4 +8,21 @@ using Metal;
 using ObjCBindings;
 using System;
 using System.Runtime.Versioning;
-// TODO: implement emitter.
+
+namespace TestNamespace;
+
+public partial class CARendererOptions : DictionaryContainer
+{
+
+	// TODO: implement default constructors.
+
+
+	// TODO: implement properties.
+
+
+	// Emit code for property: ColorSpace
+
+
+	// Emit code for property: MetalCommandQueue
+
+}


### PR DESCRIPTION
Add the needed code to extran only strong dictionary properties when the binding is a strong dictionary. The emitter now generates comments for the constructors and for the properties that should be generated in later PRs.