### PR TITLE
[release/9.0.1xx] [msbuild] Make sure that non-iOS platforms build successfully on non-macOS platforms. Fixes #23101.

### DIFF
--- a/builds/create-csproj-for-all-packagereferences.sh
+++ b/builds/create-csproj-for-all-packagereferences.sh
@@ -50,6 +50,7 @@ sed -i '' 's/""/"/g' "$TMPPATH"
 sed -i '' '/Xamarin.Tests.FrameworksInRuntimesNativeDirectory/d' "$TMPPATH"
 sed -i '' '/Xamarin.Tests.DynamicLibrariesInRuntimesNativeDirectory/d' "$TMPPATH"
 sed -i '' '/Xamarin.Tests.XCFrameworkWithStaticLibraryInRuntimesNativeDirectory/d' "$TMPPATH"
+sed -i '' '/Xamarin.Tests.XCFrameworkWithSymlinks/d' "$TMPPATH"
 
 # Get only the name and version of each package, and write that back in a PackageDownload item
 sed -i '' 's@.*<PackageReference.*Include="\([a-zA-Z0-9._-]*\)".*Version="\([a-zA-Z0-9._-]*\)".*>.*@\t\t<PackageDownload Include="\1" Version="[\2]" />@g' "$TMPPATH"

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -2171,9 +2171,10 @@
 
 		<!-- This task is executed on Windows as well, for hotrestart builds -->
 		<!-- resolve any .xcframeworks and binding resource packages -->
+		<!-- Skip doing this when not building or macOS if we're not a remotable platform (i.e. iOS), because we want such builds to succeed (even if they produce non-working output), and ResolveNativeReferences will fail if running into symlinks (which happens for macOS and Mac Catalyst builds) -->
 		<ResolveNativeReferences
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true' Or '$(IsHotRestartBuild)' == 'true'"
+			Condition="('$(IsMacEnabled)' == 'true' Or '$(IsHotRestartBuild)' == 'true') And '$(_IsNonMacOSBuildForNonRemotablePlatform)' != 'true'"
 			Architectures="$(TargetArchitectures)"
 			FrameworksDirectory="$(_AppFrameworksRelativePath)"
 			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -2171,10 +2171,9 @@
 
 		<!-- This task is executed on Windows as well, for hotrestart builds -->
 		<!-- resolve any .xcframeworks and binding resource packages -->
-		<!-- Skip doing this when not building or macOS if we're not a remotable platform (i.e. iOS), because we want such builds to succeed (even if they produce non-working output), and ResolveNativeReferences will fail if running into symlinks (which happens for macOS and Mac Catalyst builds) -->
 		<ResolveNativeReferences
 			SessionId="$(BuildSessionId)"
-			Condition="('$(IsMacEnabled)' == 'true' Or '$(IsHotRestartBuild)' == 'true') And '$(_IsNonMacOSBuildForNonRemotablePlatform)' != 'true'"
+			Condition="'$(IsMacEnabled)' == 'true' Or '$(IsHotRestartBuild)' == 'true'"
 			Architectures="$(TargetArchitectures)"
 			FrameworksDirectory="$(_AppFrameworksRelativePath)"
 			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -123,6 +123,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<IsHotRestartBuild Condition="'$(IsHotRestartBuild)' == 'True' And '$(_PlatformName)' != 'iOS'">False</IsHotRestartBuild>
 			<IsRemoteBuild Condition="'$(IsHotRestartBuild)' == 'True'">False</IsRemoteBuild>
 			<IsRemoteBuild Condition="'$(BundleOriginalResources)' == 'true' And '$(OutputType)' != 'Exe' And '$(BuildBindingProjectLocally)' != 'false'">False</IsRemoteBuild>
+			<_IsNonMacOSBuildForNonRemotablePlatform Condition="'$(_IsNonMacOSBuildForNonRemotablePlatform)' == '' And $([System.OperatingSystem]::IsMacOS()) And '$(_PlatformName)' != 'iOS'">true</_IsNonMacOSBuildForNonRemotablePlatform>
 		</PropertyGroup>
 	</Target>
 

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -123,7 +123,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<IsHotRestartBuild Condition="'$(IsHotRestartBuild)' == 'True' And '$(_PlatformName)' != 'iOS'">False</IsHotRestartBuild>
 			<IsRemoteBuild Condition="'$(IsHotRestartBuild)' == 'True'">False</IsRemoteBuild>
 			<IsRemoteBuild Condition="'$(BundleOriginalResources)' == 'true' And '$(OutputType)' != 'Exe' And '$(BuildBindingProjectLocally)' != 'false'">False</IsRemoteBuild>
-			<_IsNonMacOSBuildForNonRemotablePlatform Condition="'$(_IsNonMacOSBuildForNonRemotablePlatform)' == '' And $([System.OperatingSystem]::IsMacOS()) And '$(_PlatformName)' != 'iOS'">true</_IsNonMacOSBuildForNonRemotablePlatform>
 		</PropertyGroup>
 	</Target>
 

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -123,7 +123,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<IsHotRestartBuild Condition="'$(IsHotRestartBuild)' == 'True' And '$(_PlatformName)' != 'iOS'">False</IsHotRestartBuild>
 			<IsRemoteBuild Condition="'$(IsHotRestartBuild)' == 'True'">False</IsRemoteBuild>
 			<IsRemoteBuild Condition="'$(BundleOriginalResources)' == 'true' And '$(OutputType)' != 'Exe' And '$(BuildBindingProjectLocally)' != 'false'">False</IsRemoteBuild>
-			<_IsNonMacOSBuildForNonRemotablePlatform Condition="'$(_IsNonMacOSBuildForNonRemotablePlatform)' == '' And $([System.OperatingSystem]::IsMacOS()) And '$(_PlatformName)' != 'iOS'">true</_IsNonMacOSBuildForNonRemotablePlatform>
+			<_IsNonMacOSBuildForNonRemotablePlatform Condition="'$(_IsNonMacOSBuildForNonRemotablePlatform)' == '' And !$([System.OperatingSystem]::IsMacOS()) And '$(_PlatformName)' != 'iOS'">true</_IsNonMacOSBuildForNonRemotablePlatform>
 		</PropertyGroup>
 	</Target>
 
@@ -145,7 +145,11 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		@(NativeReference) are not safe to use as an Input to a task, as frameworks are a directory and will appears unbuilt every time.
 		So we split it into two camps as a prebuild step
 	-->
-	<Target Name="_ExpandNativeReferences" Condition="'$(DesignTimeBuild)' != 'true'" DependsOnTargets="_DetectSdkLocations;_ComputeTargetArchitectures;_GenerateBundleName;_SanitizeNativeReferences">
+	<Target
+		Name="_ExpandNativeReferences"
+		Condition="'$(DesignTimeBuild)' != 'true' And '$(_IsNonMacOSBuildForNonRemotablePlatform)' != 'true'"
+		DependsOnTargets="_DetectSdkLocations;_ComputeTargetArchitectures;_GenerateBundleName;_SanitizeNativeReferences"
+		>
 		<ItemGroup>
 			<_XCFrameworkNativeReference Include="@(NativeReference -> '%(Identity)/.')" Condition="'%(Extension)' == '.xcframework' Or $([MSBuild]::ValueOrDefault('%(FileName)%(Extension)', '').EndsWith('.xcframework.zip'))" />
 			<_FrameworkNativeReference Include="@(NativeReference -> '%(Identity)/%(Filename)')" Condition="'%(Extension)' == '.framework'" />

--- a/tests/dotnet/AppWithXCFrameworkWithSymlinks/AppDelegate.cs
+++ b/tests/dotnet/AppWithXCFrameworkWithSymlinks/AppDelegate.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Runtime.InteropServices;
+
+using Foundation;
+
+namespace AppWithXCFrameworkWithStaticLibraryInPackageReference {
+	public class Program {
+		static int Main (string [] args)
+		{
+			GC.KeepAlive (typeof (NSObject)); // prevent linking away the platform assembly
+
+			Console.WriteLine (Environment.GetEnvironmentVariable ("MAGIC_WORD"));
+
+			return 0;
+		}
+	}
+}

--- a/tests/dotnet/AppWithXCFrameworkWithSymlinks/MacCatalyst/AppWithXCFrameworkWithSymlinks.csproj
+++ b/tests/dotnet/AppWithXCFrameworkWithSymlinks/MacCatalyst/AppWithXCFrameworkWithSymlinks.csproj
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>
+

--- a/tests/dotnet/AppWithXCFrameworkWithSymlinks/MacCatalyst/Makefile
+++ b/tests/dotnet/AppWithXCFrameworkWithSymlinks/MacCatalyst/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/AppWithXCFrameworkWithSymlinks/Makefile
+++ b/tests/dotnet/AppWithXCFrameworkWithSymlinks/Makefile
@@ -1,0 +1,2 @@
+TOP=../../..
+include $(TOP)/tests/common/shared-dotnet-test.mk

--- a/tests/dotnet/AppWithXCFrameworkWithSymlinks/iOS/AppWithXCFrameworkWithSymlinks.csproj
+++ b/tests/dotnet/AppWithXCFrameworkWithSymlinks/iOS/AppWithXCFrameworkWithSymlinks.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/AppWithXCFrameworkWithSymlinks/iOS/Makefile
+++ b/tests/dotnet/AppWithXCFrameworkWithSymlinks/iOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/AppWithXCFrameworkWithSymlinks/macOS/AppWithXCFrameworkWithSymlinks.csproj
+++ b/tests/dotnet/AppWithXCFrameworkWithSymlinks/macOS/AppWithXCFrameworkWithSymlinks.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/AppWithXCFrameworkWithSymlinks/macOS/Makefile
+++ b/tests/dotnet/AppWithXCFrameworkWithSymlinks/macOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/AppWithXCFrameworkWithSymlinks/shared.csproj
+++ b/tests/dotnet/AppWithXCFrameworkWithSymlinks/shared.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<ApplicationTitle>AppWithXCFrameworkWithSymlinks</ApplicationTitle>
+		<ApplicationId>com.xamarin.appwithxcframeworkwithsymlinks</ApplicationId>
+		<ApplicationVersion>1.0</ApplicationVersion>
+	</PropertyGroup>
+
+	<Import Project="../../common/shared-dotnet.csproj" />
+
+	<ItemGroup>
+		<PackageReference Include="Xamarin.Tests.XCFrameworkWithSymlinks" Version="1.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Compile Include="../*.cs" />
+	</ItemGroup>
+</Project>

--- a/tests/dotnet/AppWithXCFrameworkWithSymlinks/shared.mk
+++ b/tests/dotnet/AppWithXCFrameworkWithSymlinks/shared.mk
@@ -1,0 +1,3 @@
+TOP=../../../..
+TESTNAME=AppWithXCFrameworkWithSymlinks
+include $(TOP)/tests/common/shared-dotnet.mk

--- a/tests/dotnet/AppWithXCFrameworkWithSymlinks/tvOS/AppWithXCFrameworkWithSymlinks.csproj
+++ b/tests/dotnet/AppWithXCFrameworkWithSymlinks/tvOS/AppWithXCFrameworkWithSymlinks.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/AppWithXCFrameworkWithSymlinks/tvOS/Makefile
+++ b/tests/dotnet/AppWithXCFrameworkWithSymlinks/tvOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/UnitTests/WindowsTest.cs
+++ b/tests/dotnet/UnitTests/WindowsTest.cs
@@ -34,6 +34,28 @@ namespace Xamarin.Tests {
 		}
 
 		[Category ("Windows")]
+		[TestCase (ApplePlatform.MacOSX, "osx-arm64")]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64")]
+		[TestCase (ApplePlatform.TVOS, "tvossimulator-x64")]
+		public void BuildAppWithXCFrameworkWithSymlinks (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.IgnoreIfNotOnWindows ();
+
+			var project = "AppWithXCFrameworkWithSymlinks";
+			var configuration = "Debug";
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath, configuration: configuration);
+			var project_dir = Path.GetDirectoryName (Path.GetDirectoryName (project_path))!;
+			Clean (project_path);
+
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+
+			// For any platform other than iOS, all we care about is that project builds, we don't care about the built app.
+			// So assert that the project builds.
+			DotNet.AssertBuild (project_path, properties);
+		}
+
+		[Category ("Windows")]
 		[TestCase (ApplePlatform.iOS, "ios-arm64")]
 		public void BundleStructureWithHotRestart (ApplePlatform platform, string runtimeIdentifiers)
 		{

--- a/tests/dotnet/UnitTests/WindowsTest.cs
+++ b/tests/dotnet/UnitTests/WindowsTest.cs
@@ -12,6 +12,28 @@ namespace Xamarin.Tests {
 	public class WindowsTest : TestBaseClass {
 
 		[Category ("Windows")]
+		[TestCase (ApplePlatform.MacOSX, "osx-arm64")]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64")]
+		[TestCase (ApplePlatform.TVOS, "tvossimulator-x64")]
+		public void BundleStructureNonRemotablePlatforms (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.IgnoreIfNotOnWindows ();
+
+			var project = "BundleStructure";
+			var configuration = "Debug";
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath, configuration: configuration);
+			var project_dir = Path.GetDirectoryName (Path.GetDirectoryName (project_path))!;
+			Clean (project_path);
+
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+
+			// For any platform other than iOS, all we care about is that project builds, we don't care about the built app.
+			// So assert that the project builds.
+			DotNet.AssertBuild (project_path, properties);
+		}
+
+		[Category ("Windows")]
 		[TestCase (ApplePlatform.iOS, "ios-arm64")]
 		public void BundleStructureWithHotRestart (ApplePlatform platform, string runtimeIdentifiers)
 		{

--- a/tests/test-libraries/nugets/Makefile
+++ b/tests/test-libraries/nugets/Makefile
@@ -3,5 +3,6 @@ SUBDIRS = \
 	FrameworksInRuntimesNativeDirectory \
 	DynamicLibrariesInRuntimesNativeDirectory \
 	XCFrameworkWithStaticLibraryInRuntimesNativeDirectory \
+	XCFrameworkWithSymlinks \
 
 include $(TOP)/Make.config

--- a/tests/test-libraries/nugets/XCFrameworkWithSymlinks/Makefile
+++ b/tests/test-libraries/nugets/XCFrameworkWithSymlinks/Makefile
@@ -1,0 +1,11 @@
+# Test case for dynamic libraries
+
+include ../shared.mk
+
+XCFrameworkWithSymlinks.resources.zip: Makefile manifest ../../.libs/XTest.xcframework.zip
+	$(Q) rm -f $@.tmp
+	$(Q) cd ../../.libs && zip -9r --symlinks $(abspath $@.tmp) XTest.xcframework
+	$(Q) zip -9 --symlinks "$(abspath $@.tmp)" manifest
+	$(Q) mv "$@.tmp" "$@"
+
+$(NUPKG_PATH): XCFrameworkWithSymlinks.resources.zip

--- a/tests/test-libraries/nugets/XCFrameworkWithSymlinks/XCFrameworkWithSymlinks.csproj
+++ b/tests/test-libraries/nugets/XCFrameworkWithSymlinks/XCFrameworkWithSymlinks.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageId>Xamarin.Tests.XCFrameworkWithSymlinks</PackageId>
+    <PackageVersion>1.0.0</PackageVersion>
+    <RepositoryUrl>https://github.com/dotnet/macios</RepositoryUrl>
+    <RepositoryBranch>main</RepositoryBranch>
+    <Authors>Microsoft</Authors>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <PackageProjectUrl>https://github.com/dotnet/macios</PackageProjectUrl>
+    <RootTestDirectory>../../..</RootTestDirectory>
+    <TestFrameworksDirectory>$(RootTestDirectory)/test-libraries/frameworks</TestFrameworksDirectory>
+  </PropertyGroup>
+
+  <Target Name="ComputeContent">
+    <ItemGroup>
+      <Content Include="XCFrameworkWithSymlinks.resources.zip">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Pack>true</Pack>
+        <PackagePath>lib/netstandard2.0/XCFrameworkWithSymlinks.resources.zip</PackagePath>
+      </Content>
+    </ItemGroup>
+  </Target>
+
+  <PropertyGroup>
+    <BeforePack>
+      ComputeContent;
+      $(BeforePack);
+    </BeforePack>
+  </PropertyGroup>
+</Project>

--- a/tests/test-libraries/nugets/XCFrameworkWithSymlinks/manifest
+++ b/tests/test-libraries/nugets/XCFrameworkWithSymlinks/manifest
@@ -1,0 +1,12 @@
+<BindingAssembly>
+	<NativeReference Name="XTest.xcframework">
+		<ForceLoad></ForceLoad>
+		<Frameworks></Frameworks>
+		<IsCxx></IsCxx>
+		<Kind>Framework</Kind>
+		<LinkerFlags></LinkerFlags>
+		<NeedsGccExceptionHandling></NeedsGccExceptionHandling>
+		<SmartLink></SmartLink>
+		<WeakFrameworks></WeakFrameworks>
+	</NativeReference>
+</BindingAssembly>

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -236,10 +236,13 @@ steps:
   timeoutInMinutes: 10
 
 - pwsh: |
-    & $(Build.SourcesDirectory)\$(BUILD_REPOSITORY_TITLE)\tests\dotnet\Windows\bin\dotnet\dotnet.exe `
-        nuget push `
-        "$(Build.SourcesDirectory)\$(BUILD_REPOSITORY_TITLE)\tests\test-libraries\nugets\FrameworksInRuntimesNativeDirectory\bin\Release\Xamarin.Tests.FrameworksInRuntimesNativeDirectory.1.0.0.nupkg" `
-        --source "$(Build.SourcesDirectory)\$(BUILD_REPOSITORY_TITLE)\tests\.nuget\packages"
+    foreach ($nupkg in Get-ChildItem -Path "$(Build.SourcesDirectory)\$(BUILD_REPOSITORY_TITLE)\tests\test-libraries\nugets" -Recurse -Include *.nupkg -Exclude *.symbols.nupkg) {
+      Write-Host "Installing: $nupkg"
+      & $(Build.SourcesDirectory)\$(BUILD_REPOSITORY_TITLE)\tests\dotnet\Windows\bin\dotnet\dotnet.exe `
+          nuget push `
+          "$nupkg" `
+          --source "$(Build.SourcesDirectory)\$(BUILD_REPOSITORY_TITLE)\tests\.nuget\packages"
+    }
   displayName: 'Build dependencies for .NET tests'
   continueOnError: true
 


### PR DESCRIPTION
Make sure that non-iOS platforms build successfully on non-macOS platforms,
even if the actual output is not usable. This makes developing on Windows
easier.

Fixes https://github.com/dotnet/macios/issues/23101.

Backport of #23158.