### PR TITLE
[RGen] Simplify ImmutableArray Equality comparers via generics.

### DIFF
--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Microsoft.Macios.Bindings.Analyzer.csproj
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Microsoft.Macios.Bindings.Analyzer.csproj
@@ -91,6 +91,9 @@
         <Compile Include="../Microsoft.Macios.Generator/DataModel/DelegateParameter.Generator.cs" >
             <Link>DataModel/DelegateParameter.Generator.cs</Link>
         </Compile>
+        <Compile Include="../Microsoft.Macios.Generator/DataModel/ImmutableArrayEqualityComparer.cs" >
+            <Link>DataModel/ImmutableArrayEqualityComparer.cs</Link>
+        </Compile>
         <Compile Include="../Microsoft.Macios.Generator/DataModel/Parameter.cs" >
             <Link>DataModel/Parameter.cs</Link>
         </Compile>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/AttributesEqualityComparer.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/AttributesEqualityComparer.cs
@@ -32,28 +32,14 @@ class AttributeComparer : IComparer<AttributeCodeChange> {
 		return 0;
 	}
 }
-class AttributesEqualityComparer : EqualityComparer<ImmutableArray<AttributeCodeChange>> {
 
-	public override bool Equals (ImmutableArray<AttributeCodeChange> x, ImmutableArray<AttributeCodeChange> y)
-	{
-		if (x.Length != y.Length)
-			return false;
-		var comparer = new AttributeComparer ();
-		var xOrdered = x.Sort (comparer).ToArray ();
-		var yOrdered = y.Sort (comparer).ToArray ();
-		for (var i = 0; i < x.Length; i++) {
-			if (xOrdered [i] != yOrdered [i])
-				return false;
-		}
-		return true;
-	}
-
-	public override int GetHashCode (ImmutableArray<AttributeCodeChange> obj)
-	{
-		var hash = new HashCode ();
-		foreach (var change in obj) {
-			hash.Add (change.GetHashCode ());
-		}
-		return hash.ToHashCode ();
-	}
+/// <summary>
+/// Compares two `ImmutableArray&lt;AttributeCodeChange&gt;` instances.
+/// </summary>
+class AttributesEqualityComparer : ImmutableArrayEqualityComparer<AttributeCodeChange, AttributeCodeChange> {
+	readonly AttributeComparer comparer = new ();
+	
+	/// <inheritdoc/>
+	protected override AttributeCodeChange[] Sort (ImmutableArray<AttributeCodeChange> array) 
+		=> array.Sort (comparer).ToArray ();
 }

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/AttributesEqualityComparer.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/AttributesEqualityComparer.cs
@@ -38,8 +38,8 @@ class AttributeComparer : IComparer<AttributeCodeChange> {
 /// </summary>
 class AttributesEqualityComparer : ImmutableArrayEqualityComparer<AttributeCodeChange, AttributeCodeChange> {
 	readonly AttributeComparer comparer = new ();
-	
+
 	/// <inheritdoc/>
-	protected override AttributeCodeChange[] Sort (ImmutableArray<AttributeCodeChange> array) 
+	protected override AttributeCodeChange [] Sort (ImmutableArray<AttributeCodeChange> array)
 		=> array.Sort (comparer).ToArray ();
 }

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMembersEqualityComparer.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMembersEqualityComparer.cs
@@ -1,35 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using System;
-using System.Collections.Generic;
+
 using System.Collections.Immutable;
 using System.Linq;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
-class EnumMembersEqualityComparer : EqualityComparer<ImmutableArray<EnumMember>> {
-
+/// <summary>
+/// Compares two `ImmutableArray&lt;EnumMember&gt;` instances.
+/// </summary>
+class EnumMembersEqualityComparer : ImmutableArrayEqualityComparer<EnumMember, EnumMember> {
+	
 	/// <inheritdoc/>
-	public override bool Equals (ImmutableArray<EnumMember> x, ImmutableArray<EnumMember> y)
-	{
-		if (x.Length != y.Length)
-			return false;
-		var xOrdered = x.OrderBy (x => x.Name).ToArray ();
-		var yOrdered = y.OrderBy (x => x.Name).ToArray ();
-		for (int i = 0; i < x.Length; i++) {
-			if (xOrdered [i] != yOrdered [i])
-				return false;
-		}
-		return true;
-	}
-
-	/// <inheritdoc/>
-	public override int GetHashCode (ImmutableArray<EnumMember> obj)
-	{
-		var hash = new HashCode ();
-		foreach (var change in obj) {
-			hash.Add (change.GetHashCode ());
-		}
-		return hash.ToHashCode ();
-	}
+	protected override EnumMember[] Sort (ImmutableArray<EnumMember> array) 
+		=> array.OrderBy (x => x.Name).ToArray ();
 }

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMembersEqualityComparer.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMembersEqualityComparer.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Macios.Generator.DataModel;
 /// Compares two `ImmutableArray&lt;EnumMember&gt;` instances.
 /// </summary>
 class EnumMembersEqualityComparer : ImmutableArrayEqualityComparer<EnumMember, EnumMember> {
-	
+
 	/// <inheritdoc/>
-	protected override EnumMember[] Sort (ImmutableArray<EnumMember> array) 
+	protected override EnumMember [] Sort (ImmutableArray<EnumMember> array)
 		=> array.OrderBy (x => x.Name).ToArray ();
 }

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/ImmutableArrayEqualityComparer.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/ImmutableArrayEqualityComparer.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Macios.Generator.DataModel;
 /// </summary>
 /// <typeparam name="T">The type of the elements in the array.</typeparam>
 /// <typeparam name="TR">The type of the elements in the sorted array.</typeparam>
-abstract class ImmutableArrayEqualityComparer<T, TR> : EqualityComparer<ImmutableArray<T>> 
-	where T : IEquatable<T> 
+abstract class ImmutableArrayEqualityComparer<T, TR> : EqualityComparer<ImmutableArray<T>>
+	where T : IEquatable<T>
 	where TR : IEquatable<TR> {
 
 	/// <summary>
@@ -21,8 +21,8 @@ abstract class ImmutableArrayEqualityComparer<T, TR> : EqualityComparer<Immutabl
 	/// </summary>
 	/// <param name="array">The array to sort.</param>
 	/// <returns>A sorted array.</returns>
-	protected abstract TR[] Sort (ImmutableArray<T> array);
-	
+	protected abstract TR [] Sort (ImmutableArray<T> array);
+
 	/// <inheritdoc/>
 	public override bool Equals (ImmutableArray<T> x, ImmutableArray<T> y)
 	{

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/ImmutableArrayEqualityComparer.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/ImmutableArrayEqualityComparer.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using Microsoft.CodeAnalysis;
 
 namespace Microsoft.Macios.Generator.DataModel;
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/ImmutableArrayEqualityComparer.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/ImmutableArrayEqualityComparer.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.Macios.Generator.DataModel;
+
+/// <summary>
+/// Abstract base class for comparing `ImmutableArray` instances.
+/// </summary>
+/// <typeparam name="T">The type of the elements in the array.</typeparam>
+/// <typeparam name="TR">The type of the elements in the sorted array.</typeparam>
+abstract class ImmutableArrayEqualityComparer<T, TR> : EqualityComparer<ImmutableArray<T>> 
+	where T : IEquatable<T> 
+	where TR : IEquatable<TR> {
+
+	/// <summary>
+	/// Sorts the provided array.
+	/// </summary>
+	/// <param name="array">The array to sort.</param>
+	/// <returns>A sorted array.</returns>
+	protected abstract TR[] Sort (ImmutableArray<T> array);
+	
+	/// <inheritdoc/>
+	public override bool Equals (ImmutableArray<T> x, ImmutableArray<T> y)
+	{
+		if (x.Length != y.Length)
+			return false;
+		var xOrdered = Sort (x);
+		var yOrdered = Sort (y);
+		for (int i = 0; i < x.Length; i++) {
+			if (!xOrdered [i].Equals (yOrdered [i]))
+				return false;
+		}
+		return true;
+	}
+
+	/// <inheritdoc/>
+	public override int GetHashCode (ImmutableArray<T> obj)
+	{
+		var hash = new HashCode ();
+		foreach (var change in obj) {
+			hash.Add (change.GetHashCode ());
+		}
+		return hash.ToHashCode ();
+	}
+}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/ModifiersEqualityComparer.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/ModifiersEqualityComparer.cs
@@ -1,36 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using System;
-using System.Collections.Generic;
+
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
-public class ModifiersEqualityComparer : EqualityComparer<ImmutableArray<SyntaxToken>> {
+/// <summary>
+/// Compares two `ImmutableArray&lt;SyntaxToken&gt;` instances representing modifiers.
+/// </summary>
+class ModifiersEqualityComparer : ImmutableArrayEqualityComparer<SyntaxToken, string> {
+	
 	/// <inheritdoc/>
-	public override bool Equals (ImmutableArray<SyntaxToken> x, ImmutableArray<SyntaxToken> y)
-	{
-		if (x.Length != y.Length)
-			return false;
-		// order does not matter, the language does have rules for that, but we can ignore them
-		var xOrdered = x.Select (t => t.Text).Order ().ToArray ();
-		var yOrdered = y.Select (t => t.Text).Order ().ToArray ();
-		for (var i = 0; i < x.Length; i++) {
-			if (xOrdered [i] != yOrdered [i])
-				return false;
-		}
-		return true;
-	}
-
-	/// <inheritdoc/>
-	public override int GetHashCode (ImmutableArray<SyntaxToken> obj)
-	{
-		var hash = new HashCode ();
-		foreach (var token in obj) {
-			hash.Add (token);
-		}
-		return hash.ToHashCode ();
-	}
+	protected override string[] Sort (ImmutableArray<SyntaxToken> array) 
+		=> array.Select (t => t.Text).Order ().ToArray ();
 }

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/ModifiersEqualityComparer.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/ModifiersEqualityComparer.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Macios.Generator.DataModel;
 /// Compares two `ImmutableArray&lt;SyntaxToken&gt;` instances representing modifiers.
 /// </summary>
 class ModifiersEqualityComparer : ImmutableArrayEqualityComparer<SyntaxToken, string> {
-	
+
 	/// <inheritdoc/>
-	protected override string[] Sort (ImmutableArray<SyntaxToken> array) 
+	protected override string [] Sort (ImmutableArray<SyntaxToken> array)
 		=> array.Select (t => t.Text).Order ().ToArray ();
 }

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/OuterClassEqualityComparer.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/OuterClassEqualityComparer.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Macios.Generator.DataModel;
 /// Compares two `ImmutableArray&lt;OuterClass&gt;` instances.
 /// </summary>
 class OuterClassEqualityComparer : ImmutableArrayEqualityComparer<OuterClass, OuterClass> {
-	
+
 	/// <inheritdoc/>
-	protected override OuterClass[] Sort (ImmutableArray<OuterClass> array) 
+	protected override OuterClass [] Sort (ImmutableArray<OuterClass> array)
 		=> array.OrderBy (x => x.Name).ToArray ();
 }

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/OuterClassEqualityComparer.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/OuterClassEqualityComparer.cs
@@ -1,36 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
-class OuterClassEqualityComparer : EqualityComparer<ImmutableArray<OuterClass>> {
-
+/// <summary>
+/// Compares two `ImmutableArray&lt;OuterClass&gt;` instances.
+/// </summary>
+class OuterClassEqualityComparer : ImmutableArrayEqualityComparer<OuterClass, OuterClass> {
+	
 	/// <inheritdoc/>
-	public override bool Equals (ImmutableArray<OuterClass> x, ImmutableArray<OuterClass> y)
-	{
-		if (x.Length != y.Length)
-			return false;
-		var xOrdered = x.OrderBy (x => x.Name).ToArray ();
-		var yOrdered = y.OrderBy (x => x.Name).ToArray ();
-		for (int i = 0; i < x.Length; i++) {
-			if (xOrdered [i] != yOrdered [i])
-				return false;
-		}
-		return true;
-	}
-
-	/// <inheritdoc/>
-	public override int GetHashCode (ImmutableArray<OuterClass> obj)
-	{
-		var hash = new HashCode ();
-		foreach (var change in obj) {
-			hash.Add (change.GetHashCode ());
-		}
-		return hash.ToHashCode ();
-	}
+	protected override OuterClass[] Sort (ImmutableArray<OuterClass> array) 
+		=> array.OrderBy (x => x.Name).ToArray ();
 }


### PR DESCRIPTION
Reduce the code by using a generic abstract class. Resulting behaviour is the same but with less lines.