### PR TITLE
[RGen] Add support for the ProtocolMemberAttribute.

### DIFF
--- a/src/ObjCBindings/ExportTag.cs
+++ b/src/ObjCBindings/ExportTag.cs
@@ -111,6 +111,11 @@ namespace ObjCBindings {
 		/// </summary>
 		Async = 1 << 13,
 
+		/// <summary>
+		/// Use this flag on a method to mark it as optional in a protocol defintion.
+		/// </summary>
+		Optional = 1 << 14,
+
 	}
 
 	/// <summary>
@@ -213,6 +218,11 @@ namespace ObjCBindings {
 		/// Use this flag on a property to mark it as a weak delegate.
 		/// </summary>
 		WeakDelegate = 1 << 15,
+
+		/// <summary>
+		/// Use this flag on a method to mark it as optional in a protocol defintion.
+		/// </summary>
+		Optional = 1 << 16,
 	}
 
 	/// <summary>

--- a/src/ObjCBindings/ExportTag.cs
+++ b/src/ObjCBindings/ExportTag.cs
@@ -112,7 +112,7 @@ namespace ObjCBindings {
 		Async = 1 << 13,
 
 		/// <summary>
-		/// Use this flag on a method to mark it as optional in a protocol defintion.
+		/// Use this flag on a method to mark it as optional in a protocol definition.
 		/// </summary>
 		Optional = 1 << 14,
 

--- a/src/ObjCBindings/ExportTag.cs
+++ b/src/ObjCBindings/ExportTag.cs
@@ -220,7 +220,7 @@ namespace ObjCBindings {
 		WeakDelegate = 1 << 15,
 
 		/// <summary>
-		/// Use this flag on a method to mark it as optional in a protocol defintion.
+		/// Use this flag on a method to mark it as optional in a protocol definition.
 		/// </summary>
 		Optional = 1 << 16,
 	}

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/ProtocolMemberData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/ProtocolMemberData.cs
@@ -158,7 +158,7 @@ readonly struct ProtocolMemberData : IEquatable<ProtocolMemberData> {
 			return false;
 		if (!Nullable.Equals (ReturnType, other.ReturnType))
 			return false;
-		if (Equals (ReturnTypeDelegateProxy, other.ReturnTypeDelegateProxy))
+		if (!Nullable.Equals (ReturnTypeDelegateProxy, other.ReturnTypeDelegateProxy))
 			return false;
 		if (!ParameterType.SequenceEqual (other.ParameterType))
 			return false;

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/ProtocolMemberData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/ProtocolMemberData.cs
@@ -1,0 +1,269 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Microsoft.Macios.Generator.DataModel;
+using ObjCRuntime;
+using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
+
+namespace Microsoft.Macios.Generator.Attributes;
+
+/// <summary>
+/// Represents the metadata for a member (method or property) within a protocol.
+/// </summary>
+readonly struct ProtocolMemberData : IEquatable<ProtocolMemberData> {
+
+	// general properties
+	
+	/// <summary>
+	/// Gets a value indicating whether the protocol member is required.
+	/// </summary>
+	public bool IsRequired { get; init; }
+	/// <summary>
+	/// Gets a value indicating whether the protocol member is a property.
+	/// </summary>
+	public bool IsProperty { get; init; }
+	/// <summary>
+	/// Gets a value indicating whether the protocol member is static.
+	/// </summary>
+	public bool IsStatic { get; init; }
+	/// <summary>
+	/// Gets the name of the protocol member.
+	/// </summary>
+	public string Name { get; init; }
+	/// <summary>
+	/// Gets the selector of the protocol member.
+	/// </summary>
+	public string? Selector { get; init; }
+	
+	// method properties
+	
+	/// <summary>
+	/// Gets the return type of the method. Null for properties.
+	/// </summary>
+	public TypeInfo? ReturnType { get; init; }
+	/// <summary>
+	/// Gets the delegate proxy for the return type of the method. Null for properties.
+	/// </summary>
+	public TypeInfo? ReturnTypeDelegateProxy { get; init; }
+	/// <summary>
+	/// Gets the parameter types of the method. Empty for properties.
+	/// </summary>
+	public ImmutableArray<TypeInfo> ParameterType { get; init; } = [];
+	/// <summary>
+	/// Gets a value indicating whether each parameter is passed by reference. Empty for properties.
+	/// </summary>
+	public ImmutableArray<bool> ParameterByRef { get; init; } = [];
+	/// <summary>
+	/// Gets the block proxy for each parameter. Empty for properties.
+	/// </summary>
+	public ImmutableArray<TypeInfo?> ParameterBlockProxy { get; init; } = [];
+	/// <summary>
+	/// Gets a value indicating whether the method is variadic. False for properties.
+	/// </summary>
+	public bool IsVariadic { get; init; }
+
+	// property properties
+	/// <summary>
+	/// Gets the type of the property. Null for methods.
+	/// </summary>
+	public TypeInfo? PropertyType { get; init; }
+	/// <summary>
+	/// Gets the selector for the property's getter. Null for methods.
+	/// </summary>
+	public string? GetterSelector { get; init; }
+	/// <summary>
+	/// Gets the selector for the property's setter. Null for methods or read-only properties.
+	/// </summary>
+	public string? SetterSelector { get; init; }
+	/// <summary>
+	/// Gets the argument semantic for the property. None for methods.
+	/// </summary>
+	public ArgumentSemantic ArgumentSemantic { get; init; }
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ProtocolMemberData"/> struct.
+	/// </summary>
+	/// <param name="isRequired">A value indicating whether the protocol member is required.</param>
+	/// <param name="isProperty">A value indicating whether the protocol member is a property.</param>
+	/// <param name="isStatic">A value indicating whether the protocol member is static.</param>
+	/// <param name="name">The name of the protocol member.</param>
+	/// <param name="selector">The selector of the protocol member.</param>
+	public ProtocolMemberData (bool isRequired, bool isProperty, bool isStatic, string name, string? selector)
+	{
+		IsRequired = isRequired;
+		IsProperty = isProperty;
+		IsStatic = isStatic;
+		Name = name;
+		Selector = selector;
+	}
+	
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ProtocolMemberData"/> struct for a property.
+	/// </summary>
+	/// <param name="property">The property metadata.</param>
+	/// <param name="getter">The getter method metadata.</param>
+	/// <param name="setter">The setter method metadata.</param>
+	public ProtocolMemberData (in Property property, in Method? getter, in Method? setter)
+		: this (isRequired: !property.IsOptional, isProperty: true, isStatic: property.IsStatic, name: property.Name, selector: property.Selector)
+	{
+		// set the property specific data
+		PropertyType = property.ReturnType.WithNullable (isNullable: false);
+		GetterSelector = getter?.Selector;
+		SetterSelector = setter?.Selector;
+		ArgumentSemantic = property.ExportPropertyData?.ArgumentSemantic ?? ArgumentSemantic.None;
+		ReturnTypeDelegateProxy = property.ReturnType.IsDelegate
+			? TypeInfo.CreateDelegateProxy (property.ReturnType) 
+			: null;
+		ParameterBlockProxy = property.ReturnType.IsDelegate
+			? [TypeInfo.CreateDelegateProxy (property.ReturnType)]
+			: [];
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ProtocolMemberData"/> struct for a method.
+	/// </summary>
+	/// <param name="method">The method metadata.</param>
+	public ProtocolMemberData (in Method method)
+		: this (isRequired: !method.IsOptional, isProperty: false, isStatic: method.IsStatic, name: method.Name, selector: method.Selector)
+	{
+		// set the method specific data
+		ReturnType = method.ReturnType.WithNullable (isNullable: false);
+		ReturnTypeDelegateProxy = method.ReturnType.IsDelegate
+			? TypeInfo.CreateDelegateProxy (method.ReturnType) 
+			: null;
+		ParameterType = [..method.Parameters.Select (p => p.Type.WithNullable (isNullable: false))];
+		ParameterByRef = [..method.Parameters.Select (p => p.IsByRef)];
+		ParameterBlockProxy = [..method.Parameters.Select (p => {
+			return (TypeInfo?) (p.Type.IsDelegate ? TypeInfo.CreateDelegateProxy (p.Type) : null);
+		})];
+		IsVariadic = method.IsVariadic;
+	}
+
+	/// <inheritdoc />
+	public bool Equals (ProtocolMemberData other)
+	{
+		if (IsRequired != other.IsRequired)
+			return false;
+		if (IsProperty != other.IsProperty)
+			return false;
+		if (IsStatic != other.IsStatic)
+			return false;
+		if (Name != other.Name)
+			return false;
+		if (Selector != other.Selector)
+			return false;
+		if (!Nullable.Equals (ReturnType, other.ReturnType))
+			return false;
+		if (Equals (ReturnTypeDelegateProxy, other.ReturnTypeDelegateProxy))
+			return false;
+		if (!ParameterType.SequenceEqual (other.ParameterType))
+			return false;
+		if (!ParameterByRef.SequenceEqual (other.ParameterByRef))
+			return false;
+		if (!ParameterBlockProxy.SequenceEqual (other.ParameterBlockProxy))
+			return false;
+		if (IsVariadic != other.IsVariadic)
+			return false;
+		if (!Nullable.Equals (PropertyType, other.PropertyType))
+			return false;
+		if (GetterSelector != other.GetterSelector)
+			return false;
+		if (SetterSelector != other.SetterSelector)
+			return false;
+		if (ArgumentSemantic != other.ArgumentSemantic)
+			return false;
+		return true;
+	}
+
+
+	/// <inheritdoc />
+	public override bool Equals (object? obj)
+	{
+		return obj is ProtocolMemberData other && Equals(other);
+	}
+
+	/// <inheritdoc />
+	public override int GetHashCode ()
+	{
+		var hashCode = new HashCode();
+		hashCode.Add(IsRequired);
+		hashCode.Add(IsProperty);
+		hashCode.Add(IsStatic);
+		hashCode.Add(Name);
+		hashCode.Add(Selector);
+		hashCode.Add(ReturnType);
+		hashCode.Add(ReturnTypeDelegateProxy);
+		hashCode.Add(ParameterType);
+		hashCode.Add(ParameterByRef);
+		hashCode.Add(ParameterBlockProxy);
+		hashCode.Add(IsVariadic);
+		hashCode.Add(PropertyType);
+		hashCode.Add(GetterSelector);
+		hashCode.Add(SetterSelector);
+		hashCode.Add((int)ArgumentSemantic);
+		return hashCode.ToHashCode();
+	}
+
+	/// <summary>
+	/// Compares two <see cref="ProtocolMemberData"/> instances for equality.
+	/// </summary>
+	/// <param name="left">The first instance to compare.</param>
+	/// <param name="right">The second instance to compare.</param>
+	/// <returns><c>true</c> if the instances are equal; otherwise, <c>false</c>.</returns>
+	public static bool operator ==(ProtocolMemberData left, ProtocolMemberData right)
+	{
+		return left.Equals(right);
+	}
+
+	/// <summary>
+	/// Compares two <see cref="ProtocolMemberData"/> instances for inequality.
+	/// </summary>
+	/// <param name="left">The first instance to compare.</param>
+	/// <param name="right">The second instance to compare.</param>
+	/// <returns><c>true</c> if the instances are not equal; otherwise, <c>false</c>.</returns>
+	public static bool operator !=(ProtocolMemberData left, ProtocolMemberData right)
+	{
+		return !left.Equals(right);
+	}
+
+	/// <inheritdoc />
+	public override string ToString ()
+	{
+		var sb = new StringBuilder ("{ IsRequired: '");
+		sb.Append (IsRequired);
+		sb.Append ("', IsProperty: '");
+		sb.Append (IsProperty);
+		sb.Append ("', IsStatic: '");
+		sb.Append (IsStatic);
+		sb.Append ("', Name: '");
+		sb.Append (Name ?? "null");
+		sb.Append ("', Selector: '");
+		sb.Append (Selector ?? "null");
+		sb.Append ("', ReturnType: '");
+		sb.Append (ReturnType?.FullyQualifiedName ?? "null");
+		sb.Append ("', ReturnTypeDelegateProxy: '");
+		sb.Append (ReturnTypeDelegateProxy?.FullyQualifiedName ?? "null");
+		sb.Append ("', ParameterType: '");
+		sb.Append (ParameterType.IsDefaultOrEmpty ? "null" : string.Join (", ", ParameterType.Select (p => p.FullyQualifiedName)));
+		sb.Append ("', ParameterByRef: '");
+		sb.Append (ParameterByRef.IsDefaultOrEmpty ? "null" : string.Join (", ", ParameterByRef));
+		sb.Append ("', ParameterBlockProxy: '");
+		sb.Append (ParameterBlockProxy.IsDefaultOrEmpty ? "null" : string.Join (", ", ParameterBlockProxy.Select (p => p?.FullyQualifiedName ?? "null")));
+		sb.Append ("', IsVariadic: '");
+		sb.Append (IsVariadic);
+		sb.Append ("', PropertyType: '");
+		sb.Append (PropertyType?.FullyQualifiedName ?? "null");
+		sb.Append ("', GetterSelector: '");
+		sb.Append (GetterSelector ?? "null");
+		sb.Append ("', SetterSelector: '");
+		sb.Append (SetterSelector ?? "null");
+		sb.Append ("', ArgumentSemantic: '");
+		sb.Append (ArgumentSemantic);
+		sb.Append ("' }");
+		return sb.ToString ();
+	}
+}

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/ProtocolMemberData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/ProtocolMemberData.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Macios.Generator.Attributes;
 readonly struct ProtocolMemberData : IEquatable<ProtocolMemberData> {
 
 	// general properties
-	
+
 	/// <summary>
 	/// Gets a value indicating whether the protocol member is required.
 	/// </summary>
@@ -38,9 +38,9 @@ readonly struct ProtocolMemberData : IEquatable<ProtocolMemberData> {
 	/// Gets the selector of the protocol member.
 	/// </summary>
 	public string? Selector { get; init; }
-	
+
 	// method properties
-	
+
 	/// <summary>
 	/// Gets the return type of the method. Null for properties.
 	/// </summary>
@@ -100,7 +100,7 @@ readonly struct ProtocolMemberData : IEquatable<ProtocolMemberData> {
 		Name = name;
 		Selector = selector;
 	}
-	
+
 	/// <summary>
 	/// Initializes a new instance of the <see cref="ProtocolMemberData"/> struct for a property.
 	/// </summary>
@@ -116,7 +116,7 @@ readonly struct ProtocolMemberData : IEquatable<ProtocolMemberData> {
 		SetterSelector = setter?.Selector;
 		ArgumentSemantic = property.ExportPropertyData?.ArgumentSemantic ?? ArgumentSemantic.None;
 		ReturnTypeDelegateProxy = property.ReturnType.IsDelegate
-			? TypeInfo.CreateDelegateProxy (property.ReturnType) 
+			? TypeInfo.CreateDelegateProxy (property.ReturnType)
 			: null;
 		ParameterBlockProxy = property.ReturnType.IsDelegate
 			? [TypeInfo.CreateDelegateProxy (property.ReturnType)]
@@ -133,11 +133,11 @@ readonly struct ProtocolMemberData : IEquatable<ProtocolMemberData> {
 		// set the method specific data
 		ReturnType = method.ReturnType.WithNullable (isNullable: false);
 		ReturnTypeDelegateProxy = method.ReturnType.IsDelegate
-			? TypeInfo.CreateDelegateProxy (method.ReturnType) 
+			? TypeInfo.CreateDelegateProxy (method.ReturnType)
 			: null;
-		ParameterType = [..method.Parameters.Select (p => p.Type.WithNullable (isNullable: false))];
-		ParameterByRef = [..method.Parameters.Select (p => p.IsByRef)];
-		ParameterBlockProxy = [..method.Parameters.Select (p => {
+		ParameterType = [.. method.Parameters.Select (p => p.Type.WithNullable (isNullable: false))];
+		ParameterByRef = [.. method.Parameters.Select (p => p.IsByRef)];
+		ParameterBlockProxy = [.. method.Parameters.Select (p => {
 			return (TypeInfo?) (p.Type.IsDelegate ? TypeInfo.CreateDelegateProxy (p.Type) : null);
 		})];
 		IsVariadic = method.IsVariadic;
@@ -183,29 +183,29 @@ readonly struct ProtocolMemberData : IEquatable<ProtocolMemberData> {
 	/// <inheritdoc />
 	public override bool Equals (object? obj)
 	{
-		return obj is ProtocolMemberData other && Equals(other);
+		return obj is ProtocolMemberData other && Equals (other);
 	}
 
 	/// <inheritdoc />
 	public override int GetHashCode ()
 	{
-		var hashCode = new HashCode();
-		hashCode.Add(IsRequired);
-		hashCode.Add(IsProperty);
-		hashCode.Add(IsStatic);
-		hashCode.Add(Name);
-		hashCode.Add(Selector);
-		hashCode.Add(ReturnType);
-		hashCode.Add(ReturnTypeDelegateProxy);
-		hashCode.Add(ParameterType);
-		hashCode.Add(ParameterByRef);
-		hashCode.Add(ParameterBlockProxy);
-		hashCode.Add(IsVariadic);
-		hashCode.Add(PropertyType);
-		hashCode.Add(GetterSelector);
-		hashCode.Add(SetterSelector);
-		hashCode.Add((int)ArgumentSemantic);
-		return hashCode.ToHashCode();
+		var hashCode = new HashCode ();
+		hashCode.Add (IsRequired);
+		hashCode.Add (IsProperty);
+		hashCode.Add (IsStatic);
+		hashCode.Add (Name);
+		hashCode.Add (Selector);
+		hashCode.Add (ReturnType);
+		hashCode.Add (ReturnTypeDelegateProxy);
+		hashCode.Add (ParameterType);
+		hashCode.Add (ParameterByRef);
+		hashCode.Add (ParameterBlockProxy);
+		hashCode.Add (IsVariadic);
+		hashCode.Add (PropertyType);
+		hashCode.Add (GetterSelector);
+		hashCode.Add (SetterSelector);
+		hashCode.Add ((int) ArgumentSemantic);
+		return hashCode.ToHashCode ();
 	}
 
 	/// <summary>
@@ -214,9 +214,9 @@ readonly struct ProtocolMemberData : IEquatable<ProtocolMemberData> {
 	/// <param name="left">The first instance to compare.</param>
 	/// <param name="right">The second instance to compare.</param>
 	/// <returns><c>true</c> if the instances are equal; otherwise, <c>false</c>.</returns>
-	public static bool operator ==(ProtocolMemberData left, ProtocolMemberData right)
+	public static bool operator == (ProtocolMemberData left, ProtocolMemberData right)
 	{
-		return left.Equals(right);
+		return left.Equals (right);
 	}
 
 	/// <summary>
@@ -225,9 +225,9 @@ readonly struct ProtocolMemberData : IEquatable<ProtocolMemberData> {
 	/// <param name="left">The first instance to compare.</param>
 	/// <param name="right">The second instance to compare.</param>
 	/// <returns><c>true</c> if the instances are not equal; otherwise, <c>false</c>.</returns>
-	public static bool operator !=(ProtocolMemberData left, ProtocolMemberData right)
+	public static bool operator != (ProtocolMemberData left, ProtocolMemberData right)
 	{
-		return !left.Equals(right);
+		return !left.Equals (right);
 	}
 
 	/// <inheritdoc />

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
@@ -84,12 +84,12 @@ readonly partial struct Method {
 	/// True if the method was marked to be generated as an async method.
 	/// </summary>
 	public bool IsAsync => ExportMethodData.Flags.HasFlag (ObjCBindings.Method.Async);
-	
+
 	/// <summary>
 	/// True if the method is variadic.
 	/// </summary>
 	public bool IsVariadic => ExportMethodData.Flags.HasFlag (ObjCBindings.Method.IsVariadic);
-	
+
 	/// <summary>
 	/// States if a method is optional in a protocol definition.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
@@ -84,6 +84,16 @@ readonly partial struct Method {
 	/// True if the method was marked to be generated as an async method.
 	/// </summary>
 	public bool IsAsync => ExportMethodData.Flags.HasFlag (ObjCBindings.Method.Async);
+	
+	/// <summary>
+	/// True if the method is variadic.
+	/// </summary>
+	public bool IsVariadic => ExportMethodData.Flags.HasFlag (ObjCBindings.Method.IsVariadic);
+	
+	/// <summary>
+	/// States if a method is optional in a protocol definition.
+	/// </summary>
+	public bool IsOptional => ExportMethodData.Flags.HasFlag (ObjCBindings.Method.Optional);
 
 	public Method (string type, string name, TypeInfo returnType,
 		SymbolAvailability symbolAvailability,

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.cs
@@ -6,8 +6,9 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.CodeAnalysis;
-using Microsoft.Macios.Generator.Attributes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Macios.Generator.Availability;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
@@ -48,11 +49,25 @@ readonly partial struct Method : IEquatable<Method> {
 	/// Get the attributes added to the constructor.
 	/// </summary>
 	public ImmutableArray<AttributeCodeChange> Attributes { get; } = [];
+	
+	readonly bool isStatic;
 
+	/// <summary>
+	/// Returns if the method is static.
+	/// </summary>
+	public bool IsStatic => isStatic;
+
+	readonly ImmutableArray<SyntaxToken> modifiers = [];
 	/// <summary>
 	/// Modifiers list.
 	/// </summary>
-	public ImmutableArray<SyntaxToken> Modifiers { get; init; } = [];
+	public ImmutableArray<SyntaxToken> Modifiers {
+		get => modifiers;
+		init {
+			modifiers = value;
+			isStatic = modifiers.Any (x => x.IsKind (SyntaxKind.StaticKeyword));
+		}
+	}
 
 	/// <summary>
 	/// Parameters list.
@@ -75,6 +90,10 @@ readonly partial struct Method : IEquatable<Method> {
 		if (BindAs != other.BindAs)
 			return false;
 		if (ForcedType != other.ForcedType)
+			return false;
+		if (IsVariadic != other.IsVariadic)
+			return false;
+		if (IsOptional != other.IsOptional)
 			return false;
 
 		var attrsComparer = new AttributesEqualityComparer ();
@@ -137,6 +156,10 @@ readonly partial struct Method : IEquatable<Method> {
 		sb.Append ($"ExportMethodData: {ExportMethodData}, ");
 		sb.Append ($"BindAs: {BindAs?.ToString () ?? "null"}, ");
 		sb.Append ($"ForcedType: {ForcedType?.ToString () ?? "null"}, ");
+		sb.Append ($"IsStatic: {IsStatic}, ");
+		sb.Append ($"IsExtension: {IsExtension}, ");
+		sb.Append ($"IsVariadic: {IsVariadic}, ");
+		sb.Append ($"IsOptional: {IsOptional}, ");
 		sb.Append ("Attributes: [");
 		sb.AppendJoin (", ", Attributes);
 		sb.Append ("], Modifiers: [");

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.cs
@@ -49,7 +49,7 @@ readonly partial struct Method : IEquatable<Method> {
 	/// Get the attributes added to the constructor.
 	/// </summary>
 	public ImmutableArray<AttributeCodeChange> Attributes { get; } = [];
-	
+
 	readonly bool isStatic;
 
 	/// <summary>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
@@ -137,7 +137,7 @@ readonly partial struct Property {
 	/// True if the property was marked as a weak delegate.
 	/// </summary>
 	public bool IsWeakDelegate => IsProperty && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.WeakDelegate);
-	
+
 	/// <summary>
 	/// States if a property is optional in a protocol definition.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
@@ -137,6 +137,11 @@ readonly partial struct Property {
 	/// True if the property was marked as a weak delegate.
 	/// </summary>
 	public bool IsWeakDelegate => IsProperty && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.WeakDelegate);
+	
+	/// <summary>
+	/// States if a property is optional in a protocol definition.
+	/// </summary>
+	public bool IsOptional => IsProperty && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.Optional);
 
 	readonly bool? needsBackingField = null;
 	/// <summary>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -92,7 +93,7 @@ readonly partial struct Property : IEquatable<Property> {
 		get => modifiers;
 		init {
 			modifiers = value;
-			isStatic = modifiers.Contains (Token (SyntaxKind.StaticKeyword));
+			isStatic = modifiers.Any (x => x.IsKind (SyntaxKind.StaticKeyword));
 		}
 	}
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
@@ -18,4 +18,38 @@ readonly partial struct TypeInfo {
 		NeedsStret = symbol.NeedsStret (compilation);
 	}
 
+	/// <summary>
+	/// Creates a <see cref="TypeInfo"/> for a delegate proxy (trampoline).
+	/// </summary>
+	/// <param name="delegateType">The <see cref="TypeInfo"/> of the delegate.</param>
+	/// <returns>A new <see cref="TypeInfo"/> representing the delegate proxy, or the original <paramref name="delegateType"/> if it's not a delegate.</returns>
+	public static TypeInfo CreateDelegateProxy (TypeInfo delegateType)
+	{
+		if (!delegateType.IsDelegate)
+			return delegateType;
+		
+		// build a new type info that is a delegate proxy
+		var trampolineName = Nomenclator.GetTrampolineName (delegateType);
+		var proxyName = Nomenclator.GetTrampolineClassName (
+			trampolineName, Nomenclator.TrampolineClassType.StaticBridgeClass);
+		
+		var trampolineInfo = new TypeInfo (
+			name: $"ObjCRuntime.Trampolines.{proxyName}",
+			specialType: SpecialType.None,
+			isNullable: false,
+			isBlittable: false,
+			isSmartEnum: false,
+			isArray: false,
+			isReferenceType: true,
+			isStruct: false
+		) {
+			Delegate = null,
+			EnumUnderlyingType = null,
+			IsGenericType = false,
+			IsTask = false,
+			TypeArguments = []
+		};
+		return trampolineInfo;
+	}
+
 }

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
@@ -27,12 +27,12 @@ readonly partial struct TypeInfo {
 	{
 		if (!delegateType.IsDelegate)
 			return delegateType;
-		
+
 		// build a new type info that is a delegate proxy
 		var trampolineName = Nomenclator.GetTrampolineName (delegateType);
 		var proxyName = Nomenclator.GetTrampolineClassName (
 			trampolineName, Nomenclator.TrampolineClassType.StaticBridgeClass);
-		
+
 		var trampolineInfo = new TypeInfo (
 			name: $"ObjCRuntime.Trampolines.{proxyName}",
 			specialType: SpecialType.None,

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -22,7 +22,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// <summary>
 	/// Represents the `void` type.
 	/// </summary>
-	public static TypeInfo Void = new ("void", SpecialType.System_Void) { Parents = ["System.ValueType", "object"], };
+	public static TypeInfo Void = new ("System.void", SpecialType.System_Void) { Parents = ["System.ValueType", "object"], };
 
 	/// <summary>
 	/// Represents a `System.NativeHandle` type.

--- a/src/rgen/Microsoft.Macios.Generator/IO/TabbedStringBuilderExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/IO/TabbedStringBuilderExtensions.cs
@@ -149,7 +149,7 @@ static class TabbedStringBuilderExtensions {
 		self.WriteLine ($"[DynamicDependency ({member})]");
 		return self;
 	}
-	
+
 	/// <summary>
 	/// Appends a `[ProtocolMember]` attribute to the current writer.
 	/// This attribute contains metadata about a protocol member (method or property).
@@ -178,13 +178,13 @@ static class TabbedStringBuilderExtensions {
 			var paramTypes = string.Join (", ",
 				protocolMemberData.ParameterType.Select (x => $"typeof ({x.GetIdentifierSyntax ()})"));
 			sb.Append ($"ParameterType = new Type [] {{ {paramTypes} }}, ");
-			
+
 			// build the parameters ref array
 			var parametersRef = string.Join (", ",
 				protocolMemberData.ParameterByRef.Select (x => x ? "true" : "false"));
 			sb.Append ($"ParameterByRef = new bool [] {{ {parametersRef} }}");
 		}
-		
+
 		// the following are optional since we might not have a proxy for a callback but are used in both cases (methods and properties)
 		if (protocolMemberData.ReturnTypeDelegateProxy is not null) {
 			sb.Append ($", ReturnTypeDelegateProxy = typeof ({protocolMemberData.ReturnTypeDelegateProxy.Value.GetIdentifierSyntax ()})");
@@ -196,7 +196,7 @@ static class TabbedStringBuilderExtensions {
 				protocolMemberData.ParameterBlockProxy.Select (x => x is null ? "null" : $"typeof ({x.Value.GetIdentifierSyntax ()})"));
 			sb.Append ($", ParameterBlockProxy = new Type? [] {{ {blockProxies} }}");
 		}
-		
+
 		sb.Append (")]");
 		self.WriteLine (sb.ToString ());
 		return self;

--- a/src/rgen/Microsoft.Macios.Generator/IO/TabbedStringBuilderExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/IO/TabbedStringBuilderExtensions.cs
@@ -3,7 +3,11 @@
 
 using System.ComponentModel;
 using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.DataModel;
+using Microsoft.Macios.Generator.Formatters;
 using static Microsoft.Macios.Generator.Emitters.BindingSyntaxFactory;
 
 namespace Microsoft.Macios.Generator.IO;
@@ -144,5 +148,62 @@ static class TabbedStringBuilderExtensions {
 
 		self.WriteLine ($"[DynamicDependency ({member})]");
 		return self;
+	}
+	
+	/// <summary>
+	/// Appends a `[ProtocolMember]` attribute to the current writer.
+	/// This attribute contains metadata about a protocol member (method or property).
+	/// </summary>
+	/// <param name="self">A tabbed string writer.</param>
+	/// <param name="protocolMemberData">The protocol member metadata to emit.</param>
+	/// <returns>The current writer.</returns>
+	public static TabbedWriter<StringWriter> AppendProtocolMemberData (this TabbedWriter<StringWriter> self,
+		in ProtocolMemberData protocolMemberData)
+	{
+		// shared properties 
+		var sb = new StringBuilder ("[ProtocolMember (");
+		sb.Append ($"IsRequired = {protocolMemberData.IsRequired.ToString ().ToLower ()}, ");
+		sb.Append ($"IsProperty = {protocolMemberData.IsProperty.ToString ().ToLower ()}, ");
+		sb.Append ($"IsStatic = {protocolMemberData.IsStatic.ToString ().ToLower ()}, ");
+		sb.Append ($"Name = \"{protocolMemberData.Name}\", ");
+		sb.Append ($"Selector = \"{protocolMemberData.Selector}\", ");
+		if (protocolMemberData.IsProperty) {
+			sb.Append ($"PropertyType = typeof ({protocolMemberData.PropertyType!.Value.GetIdentifierSyntax ()}), ");
+			sb.Append ($"GetterSelector = {Quoted (protocolMemberData.GetterSelector)}, ");
+			sb.Append ($"SetterSelector = {Quoted (protocolMemberData.SetterSelector)}, ");
+			sb.Append ($"ArgumentSemantic = ArgumentSemantic.{protocolMemberData.ArgumentSemantic}");
+		} else {
+			sb.Append ($"ReturnType = typeof ({protocolMemberData.ReturnType!.Value.GetIdentifierSyntax ()}), ");
+			// build the parameter types string array
+			var paramTypes = string.Join (", ",
+				protocolMemberData.ParameterType.Select (x => $"typeof ({x.GetIdentifierSyntax ()})"));
+			sb.Append ($"ParameterType = new Type [] {{ {paramTypes} }}, ");
+			
+			// build the parameters ref array
+			var parametersRef = string.Join (", ",
+				protocolMemberData.ParameterByRef.Select (x => x ? "true" : "false"));
+			sb.Append ($"ParameterByRef = new bool [] {{ {parametersRef} }}");
+		}
+		
+		// the following are optional since we might not have a proxy for a callback but are used in both cases (methods and properties)
+		if (protocolMemberData.ReturnTypeDelegateProxy is not null) {
+			sb.Append ($", ReturnTypeDelegateProxy = typeof ({protocolMemberData.ReturnTypeDelegateProxy.Value.GetIdentifierSyntax ()})");
+		}
+
+		if (protocolMemberData.ParameterBlockProxy.Length > 0) {
+			// build the parameter block proxy string array
+			var blockProxies = string.Join (", ",
+				protocolMemberData.ParameterBlockProxy.Select (x => x is null ? "null" : $"typeof ({x.Value.GetIdentifierSyntax ()})"));
+			sb.Append ($", ParameterBlockProxy = new Type? [] {{ {blockProxies} }}");
+		}
+		
+		sb.Append (']');
+		self.WriteLine (sb.ToString ());
+		return self;
+
+		string Quoted (string? str)
+		{
+			return str is null ? "null" : $"\"{str}\"";
+		}
 	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/IO/TabbedStringBuilderExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/IO/TabbedStringBuilderExtensions.cs
@@ -197,7 +197,7 @@ static class TabbedStringBuilderExtensions {
 			sb.Append ($", ParameterBlockProxy = new Type? [] {{ {blockProxies} }}");
 		}
 		
-		sb.Append (']');
+		sb.Append (")]");
 		self.WriteLine (sb.ToString ());
 		return self;
 

--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/ExportData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/ExportData.cs
@@ -18,6 +18,11 @@ readonly record struct ExportData {
 	/// Argument semantics to use with the selector.
 	/// </summary>
 	public ArgumentSemantic ArgumentSemantic { get; } = ArgumentSemantic.None;
+	
+	/// <summary>
+	/// Gets a value indicating whether the method is variadic.
+	/// </summary>
+	public bool IsVariadic { get; init; }
 
 	public ExportData (string? selector)
 	{
@@ -43,6 +48,7 @@ readonly record struct ExportData {
 		var count = attributeData.ConstructorArguments.Length;
 		string? selector;
 		ArgumentSemantic argumentSemantic = ArgumentSemantic.None;
+		bool isVariadic = false;
 
 		// custom marshal directive values
 
@@ -72,13 +78,18 @@ readonly record struct ExportData {
 			case "ArgumentSemantic":
 				argumentSemantic = (ArgumentSemantic) value.Value!;
 				break;
+			case "IsVariadic":
+				isVariadic = (bool) value.Value!;
+				break;
 			default:
 				data = null;
 				return false;
 			}
 		}
 
-		data = new (selector, argumentSemantic);
+		data = new (selector, argumentSemantic) {
+			IsVariadic = isVariadic,
+		};
 		return true;
 	}
 }

--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/ExportData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/ExportData.cs
@@ -18,7 +18,7 @@ readonly record struct ExportData {
 	/// Argument semantics to use with the selector.
 	/// </summary>
 	public ArgumentSemantic ArgumentSemantic { get; } = ArgumentSemantic.None;
-	
+
 	/// <summary>
 	/// Gets a value indicating whether the method is variadic.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Method.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Method.Transformer.cs
@@ -51,6 +51,16 @@ readonly partial struct Method {
 	/// </summary>
 	public bool IsConstructor => Name == constructorName;
 
+	/// <summary>
+	/// True if the method is variadic.
+	/// </summary>
+	public bool IsVariadic => ExportMethodData?.IsVariadic ?? false;
+
+	/// <summary>
+	/// States if a method is optional in a protocol definition.
+	/// </summary>
+	public bool IsOptional => !HasAbstractFlag;
+
 	public Method (string type,
 		string name,
 		TypeInfo returnType,

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Method.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Method.Transformer.cs
@@ -59,7 +59,7 @@ readonly partial struct Method {
 	/// <summary>
 	/// States if a method is optional in a protocol definition.
 	/// </summary>
-	public bool IsOptional => !HasAbstractFlag;
+	public bool IsOptional => false;
 
 	public Method (string type,
 		string name,

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Attributes/ProtocolMemberDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Attributes/ProtocolMemberDataTests.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Macios.Generator.Tests.Attributes;
 
 public class ProtocolMemberDataTests : BaseGeneratorTestClass {
 
-	ProtocolMemberCustomEqualityComparer comparer = new();
-	
+	ProtocolMemberCustomEqualityComparer comparer = new ();
+
 	class TestDataFromPropertyDeclaration : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -51,7 +51,7 @@ public class TestClass {
 					ParameterBlockProxy = [],
 				}
 			];
-			
+
 			const string optionalProperty = @"
 using System;
 using ObjCBindings;
@@ -111,7 +111,7 @@ public class TestClass {
 					ParameterBlockProxy = [],
 				}
 			];
-			
+
 			const string getterSetterProperty = @"
 using System;
 using ObjCBindings;
@@ -141,7 +141,7 @@ public class TestClass {
 					ParameterBlockProxy = [],
 				}
 			];
-			
+
 			const string customSelectorsProperty = @"
 using System;
 using ObjCBindings;
@@ -176,7 +176,7 @@ public class TestClass {
 					ParameterBlockProxy = [],
 				}
 			];
-			
+
 			const string argumentSemantic = @"
 using System;
 using ObjCRuntime;
@@ -207,7 +207,7 @@ public class TestClass {
 					ParameterBlockProxy = [],
 				}
 			];
-			
+
 			const string actionProperty = @"
 using System;
 using ObjCRuntime;
@@ -238,7 +238,7 @@ public class TestClass {
 					ParameterBlockProxy = [TypeInfo.CreateDelegateProxy (ReturnTypeForAction ())],
 				}
 			];
-			
+
 			const string genericActionProperty = @"
 using System;
 using ObjCRuntime;
@@ -274,7 +274,7 @@ public class TestClass {
 		IEnumerator IEnumerable.GetEnumerator ()
 			=> GetEnumerator ();
 	}
-	
+
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataFromPropertyDeclaration>]
 	void FromPropertyDeclaration (ApplePlatform platform, string inputText, ProtocolMemberData expectedAttributeData)
@@ -293,7 +293,7 @@ public class TestClass {
 		var attr = new ProtocolMemberData (changes.Value, getter, setter);
 		Assert.Equal (expectedAttributeData, attr, comparer);
 	}
-	
+
 	class TestDataFromMethodDeclaration : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -317,7 +317,7 @@ namespace NS {
 					isProperty: false,
 					isStatic: false,
 					name: "MyMethod",
-					selector: "completeRequestReturningItems:completionHandler:" 
+					selector: "completeRequestReturningItems:completionHandler:"
 				) {
 					ReturnType = TypeInfo.Void,
 					ParameterType = [ReturnTypeForString ()],
@@ -326,7 +326,7 @@ namespace NS {
 					ParameterBlockProxy = [null],
 				}
 			];
-			
+
 			const string staticVoidMethod = @"
 using System;
 using ObjCBindings;
@@ -347,7 +347,7 @@ namespace NS {
 					isProperty: false,
 					isStatic: true,
 					name: "MyMethod",
-					selector: "completeRequestReturningItems:completionHandler:" 
+					selector: "completeRequestReturningItems:completionHandler:"
 				) {
 					ReturnType = TypeInfo.Void,
 					ParameterType = [ReturnTypeForString ()],
@@ -356,7 +356,7 @@ namespace NS {
 					ParameterBlockProxy = [null],
 				}
 			];
-			
+
 			const string simpleIntMethod = @"
 using System;
 using ObjCBindings;
@@ -377,7 +377,7 @@ namespace NS {
 					isProperty: false,
 					isStatic: false,
 					name: "MyMethod",
-					selector: "completeRequestReturningItems:completionHandler:" 
+					selector: "completeRequestReturningItems:completionHandler:"
 				) {
 					ReturnType = ReturnTypeForInt (),
 					ParameterType = [ReturnTypeForString ()],
@@ -386,7 +386,7 @@ namespace NS {
 					ParameterBlockProxy = [null],
 				}
 			];
-			
+
 			const string intMethodMultiParameter = @"
 using System;
 using ObjCBindings;
@@ -407,7 +407,7 @@ namespace NS {
 					isProperty: false,
 					isStatic: false,
 					name: "MyMethod",
-					selector: "completeRequestReturningItems:completionHandler:" 
+					selector: "completeRequestReturningItems:completionHandler:"
 				) {
 					ReturnType = ReturnTypeForInt (),
 					ParameterType = [ReturnTypeForString (), ReturnTypeForString ()],
@@ -416,7 +416,7 @@ namespace NS {
 					ParameterBlockProxy = [null, null],
 				}
 			];
-			
+
 			const string nullableParameter = @"
 using System;
 using ObjCBindings;
@@ -437,7 +437,7 @@ namespace NS {
 					isProperty: false,
 					isStatic: false,
 					name: "MyMethod",
-					selector: "completeRequestReturningItems:completionHandler:" 
+					selector: "completeRequestReturningItems:completionHandler:"
 				) {
 					ReturnType = ReturnTypeForInt (),
 					ParameterType = [ReturnTypeForString ()],
@@ -446,7 +446,7 @@ namespace NS {
 					ParameterBlockProxy = [null],
 				}
 			];
-			
+
 			const string intMethodRefParameter = @"
 using System;
 using ObjCBindings;
@@ -467,7 +467,7 @@ namespace NS {
 					isProperty: false,
 					isStatic: false,
 					name: "MyMethod",
-					selector: "completeRequestReturningItems:completionHandler:" 
+					selector: "completeRequestReturningItems:completionHandler:"
 				) {
 					ReturnType = ReturnTypeForInt (),
 					ParameterType = [ReturnTypeForString (), ReturnTypeForString ()],
@@ -476,7 +476,7 @@ namespace NS {
 					ParameterBlockProxy = [null, null],
 				}
 			];
-			
+
 			const string variadicVoidMethod = @"
 using System;
 using ObjCBindings;
@@ -497,7 +497,7 @@ namespace NS {
 					isProperty: false,
 					isStatic: false,
 					name: "MyMethod",
-					selector: "completeRequestReturningItems:completionHandler:" 
+					selector: "completeRequestReturningItems:completionHandler:"
 				) {
 					ReturnType = TypeInfo.Void,
 					ParameterType = [ReturnTypeForString ()],
@@ -507,7 +507,7 @@ namespace NS {
 					IsVariadic = true,
 				}
 			];
-			
+
 			const string simpleActionMethod = @"
 using System;
 using ObjCBindings;
@@ -528,7 +528,7 @@ namespace NS {
 					isProperty: false,
 					isStatic: false,
 					name: "MyMethod",
-					selector: "completeRequestReturningItems:completionHandler:" 
+					selector: "completeRequestReturningItems:completionHandler:"
 				) {
 					ReturnType = ReturnTypeForAction (),
 					ParameterType = [ReturnTypeForString ()],
@@ -537,7 +537,7 @@ namespace NS {
 					ParameterBlockProxy = [null],
 				}
 			];
-			
+
 			const string intMethodActionParameter = @"
 using System;
 using ObjCBindings;
@@ -558,7 +558,7 @@ namespace NS {
 					isProperty: false,
 					isStatic: false,
 					name: "MyMethod",
-					selector: "completeRequestReturningItems:completionHandler:" 
+					selector: "completeRequestReturningItems:completionHandler:"
 				) {
 					ReturnType = ReturnTypeForInt (),
 					ParameterType = [ReturnTypeForString (), ReturnTypeForAction ()],
@@ -567,7 +567,7 @@ namespace NS {
 					ParameterBlockProxy = [null, TypeInfo.CreateDelegateProxy (ReturnTypeForAction ())],
 				}
 			];
-			
+
 			const string optionalVoidMethod = @"
 using System;
 using ObjCBindings;
@@ -588,7 +588,7 @@ namespace NS {
 					isProperty: false,
 					isStatic: false,
 					name: "MyMethod",
-					selector: "completeRequestReturningItems:completionHandler:" 
+					selector: "completeRequestReturningItems:completionHandler:"
 				) {
 					ReturnType = TypeInfo.Void,
 					ParameterType = [ReturnTypeForString ()],
@@ -603,7 +603,7 @@ namespace NS {
 		IEnumerator IEnumerable.GetEnumerator ()
 			=> GetEnumerator ();
 	}
-	
+
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataFromMethodDeclaration>]
 	void FromMethodDeclaration (ApplePlatform platform, string inputText, ProtocolMemberData expectedAttributeData)

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Attributes/ProtocolMemberDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Attributes/ProtocolMemberDataTests.cs
@@ -1,0 +1,623 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma warning disable APL0003
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Attributes;
+using Microsoft.Macios.Generator.DataModel;
+using ObjCRuntime;
+using Xamarin.Tests;
+using Xamarin.Utils;
+using Xunit;
+using static Microsoft.Macios.Generator.Tests.TestDataFactory;
+namespace Microsoft.Macios.Generator.Tests.Attributes;
+
+public class ProtocolMemberDataTests : BaseGeneratorTestClass {
+
+	ProtocolMemberCustomEqualityComparer comparer = new();
+	
+	class TestDataFromPropertyDeclaration : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			const string simpleProperty = @"
+using System;
+using ObjCBindings;
+
+namespace Test;
+
+public class TestClass {
+
+	[Export<Property>(""name"")]
+	public string Name { get; }
+}
+";
+			yield return [
+				simpleProperty,
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: true,
+					isStatic: false,
+					name: "Name",
+					selector: "name"
+				) {
+					PropertyType = ReturnTypeForString (),
+					GetterSelector = "name",
+					SetterSelector = null,
+					ArgumentSemantic = ArgumentSemantic.None,
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [],
+				}
+			];
+			
+			const string optionalProperty = @"
+using System;
+using ObjCBindings;
+
+namespace Test;
+
+public class TestClass {
+
+	[Export<Property>(""name"", Property.Optional)]
+	public string Name { get; }
+}
+";
+			yield return [
+				optionalProperty,
+				new ProtocolMemberData (
+					isRequired: false,
+					isProperty: true,
+					isStatic: false,
+					name: "Name",
+					selector: "name"
+				) {
+					PropertyType = ReturnTypeForString (),
+					GetterSelector = "name",
+					SetterSelector = null,
+					ArgumentSemantic = ArgumentSemantic.None,
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [],
+				}
+			];
+
+			const string staticProperty = @"
+using System;
+using ObjCBindings;
+
+namespace Test;
+
+public class TestClass {
+
+	[Export<Property>(""name"")]
+	public static string Name { get; }
+}
+";
+			yield return [
+				staticProperty,
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: true,
+					isStatic: true,
+					name: "Name",
+					selector: "name"
+				) {
+					PropertyType = ReturnTypeForString (),
+					GetterSelector = "name",
+					SetterSelector = null,
+					ArgumentSemantic = ArgumentSemantic.None,
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [],
+				}
+			];
+			
+			const string getterSetterProperty = @"
+using System;
+using ObjCBindings;
+
+namespace Test;
+
+public class TestClass {
+
+	[Export<Property>(""name"")]
+	public string Name { get; set; }
+}
+";
+			yield return [
+				getterSetterProperty,
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: true,
+					isStatic: false,
+					name: "Name",
+					selector: "name"
+				) {
+					PropertyType = ReturnTypeForString (),
+					GetterSelector = "name",
+					SetterSelector = "setName:",
+					ArgumentSemantic = ArgumentSemantic.None,
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [],
+				}
+			];
+			
+			const string customSelectorsProperty = @"
+using System;
+using ObjCBindings;
+
+namespace Test;
+
+public class TestClass {
+
+	[Export<Property>(""name"")]
+	public string Name { 
+		[Export<Property>(""myName"")]
+		get; 
+		[Export<Property>(""setMyName:"")]
+		set; 
+	}
+}
+";
+			yield return [
+				customSelectorsProperty,
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: true,
+					isStatic: false,
+					name: "Name",
+					selector: "name"
+				) {
+					PropertyType = ReturnTypeForString (),
+					GetterSelector = "myName",
+					SetterSelector = "setMyName:",
+					ArgumentSemantic = ArgumentSemantic.None,
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [],
+				}
+			];
+			
+			const string argumentSemantic = @"
+using System;
+using ObjCRuntime;
+using ObjCBindings;
+
+namespace Test;
+
+public class TestClass {
+
+	[Export<Property>(""name"", ArgumentSemantic.Copy)]
+	public string Name { get; set; }
+}
+";
+			yield return [
+				argumentSemantic,
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: true,
+					isStatic: false,
+					name: "Name",
+					selector: "name"
+				) {
+					PropertyType = ReturnTypeForString (),
+					GetterSelector = "name",
+					SetterSelector = "setName:",
+					ArgumentSemantic = ArgumentSemantic.Copy,
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [],
+				}
+			];
+			
+			const string actionProperty = @"
+using System;
+using ObjCRuntime;
+using ObjCBindings;
+
+namespace Test;
+
+public class TestClass {
+
+	[Export<Property>(""callback"")]
+	public Action Name { get; set; }
+}
+";
+			yield return [
+				actionProperty,
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: true,
+					isStatic: false,
+					name: "Name",
+					selector: "callback"
+				) {
+					PropertyType = ReturnTypeForAction (),
+					GetterSelector = "callback",
+					SetterSelector = "setCallback:",
+					ArgumentSemantic = ArgumentSemantic.None,
+					ReturnTypeDelegateProxy = TypeInfo.CreateDelegateProxy (ReturnTypeForAction ()),
+					ParameterBlockProxy = [TypeInfo.CreateDelegateProxy (ReturnTypeForAction ())],
+				}
+			];
+			
+			const string genericActionProperty = @"
+using System;
+using ObjCRuntime;
+using ObjCBindings;
+
+namespace Test;
+
+public class TestClass {
+
+	[Export<Property>(""callback"")]
+	public Action<string, string> Name { get; set; }
+}
+";
+			yield return [
+				genericActionProperty,
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: true,
+					isStatic: false,
+					name: "Name",
+					selector: "callback"
+				) {
+					PropertyType = ReturnTypeForAction (null, "string", "string"),
+					GetterSelector = "callback",
+					SetterSelector = "setCallback:",
+					ArgumentSemantic = ArgumentSemantic.None,
+					ReturnTypeDelegateProxy = TypeInfo.CreateDelegateProxy (ReturnTypeForAction (null, "string", "string")),
+					ParameterBlockProxy = [TypeInfo.CreateDelegateProxy (ReturnTypeForAction (null, "string", "string"))],
+				}
+			];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator ()
+			=> GetEnumerator ();
+	}
+	
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataFromPropertyDeclaration>]
+	void FromPropertyDeclaration (ApplePlatform platform, string inputText, ProtocolMemberData expectedAttributeData)
+	{
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
+		Assert.Single (syntaxTrees);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ().OfType<PropertyDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		Assert.True (Property.TryCreate (declaration, semanticModel, out var changes));
+		Assert.NotNull (changes);
+		// get the extension methods from the property which we will use to construct the attr
+		var (getter, setter) = changes.Value.ToExtensionMethods (ReturnTypeForInterface ("Test.IMyProtocol", isProtocol: true));
+		var attr = new ProtocolMemberData (changes.Value, getter, setter);
+		Assert.Equal (expectedAttributeData, attr, comparer);
+	}
+	
+	class TestDataFromMethodDeclaration : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			const string simpleVoidMethod = @"
+using System;
+using ObjCBindings;
+using ObjCRuntime;
+
+namespace NS {
+	public class MyClass {
+
+		[Export<Method> (""completeRequestReturningItems:completionHandler:"")] 
+		public void MyMethod (string input) { }
+	}
+}
+";
+			yield return [
+				simpleVoidMethod,
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: false,
+					isStatic: false,
+					name: "MyMethod",
+					selector: "completeRequestReturningItems:completionHandler:" 
+				) {
+					ReturnType = TypeInfo.Void,
+					ParameterType = [ReturnTypeForString ()],
+					ParameterByRef = [false],
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [null],
+				}
+			];
+			
+			const string staticVoidMethod = @"
+using System;
+using ObjCBindings;
+using ObjCRuntime;
+
+namespace NS {
+	public class MyClass {
+
+		[Export<Method> (""completeRequestReturningItems:completionHandler:"")] 
+		public static void MyMethod (string input) { }
+	}
+}
+";
+			yield return [
+				staticVoidMethod,
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: false,
+					isStatic: true,
+					name: "MyMethod",
+					selector: "completeRequestReturningItems:completionHandler:" 
+				) {
+					ReturnType = TypeInfo.Void,
+					ParameterType = [ReturnTypeForString ()],
+					ParameterByRef = [false],
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [null],
+				}
+			];
+			
+			const string simpleIntMethod = @"
+using System;
+using ObjCBindings;
+using ObjCRuntime;
+
+namespace NS {
+	public class MyClass {
+
+		[Export<Method> (""completeRequestReturningItems:completionHandler:"")] 
+		public int MyMethod (string input) { }
+	}
+}
+";
+			yield return [
+				simpleIntMethod,
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: false,
+					isStatic: false,
+					name: "MyMethod",
+					selector: "completeRequestReturningItems:completionHandler:" 
+				) {
+					ReturnType = ReturnTypeForInt (),
+					ParameterType = [ReturnTypeForString ()],
+					ParameterByRef = [false],
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [null],
+				}
+			];
+			
+			const string intMethodMultiParameter = @"
+using System;
+using ObjCBindings;
+using ObjCRuntime;
+
+namespace NS {
+	public class MyClass {
+
+		[Export<Method> (""completeRequestReturningItems:completionHandler:"")] 
+		public int MyMethod (string input, string output) { }
+	}
+}
+";
+			yield return [
+				intMethodMultiParameter,
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: false,
+					isStatic: false,
+					name: "MyMethod",
+					selector: "completeRequestReturningItems:completionHandler:" 
+				) {
+					ReturnType = ReturnTypeForInt (),
+					ParameterType = [ReturnTypeForString (), ReturnTypeForString ()],
+					ParameterByRef = [false, false],
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [null, null],
+				}
+			];
+			
+			const string nullableParameter = @"
+using System;
+using ObjCBindings;
+using ObjCRuntime;
+
+namespace NS {
+	public class MyClass {
+
+		[Export<Method> (""completeRequestReturningItems:completionHandler:"")] 
+		public int MyMethod (string? input) { }
+	}
+}
+";
+			yield return [
+				nullableParameter,
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: false,
+					isStatic: false,
+					name: "MyMethod",
+					selector: "completeRequestReturningItems:completionHandler:" 
+				) {
+					ReturnType = ReturnTypeForInt (),
+					ParameterType = [ReturnTypeForString ()],
+					ParameterByRef = [false],
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [null],
+				}
+			];
+			
+			const string intMethodRefParameter = @"
+using System;
+using ObjCBindings;
+using ObjCRuntime;
+
+namespace NS {
+	public class MyClass {
+
+		[Export<Method> (""completeRequestReturningItems:completionHandler:"")] 
+		public int MyMethod (string input, out string output) { }
+	}
+}
+";
+			yield return [
+				intMethodRefParameter,
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: false,
+					isStatic: false,
+					name: "MyMethod",
+					selector: "completeRequestReturningItems:completionHandler:" 
+				) {
+					ReturnType = ReturnTypeForInt (),
+					ParameterType = [ReturnTypeForString (), ReturnTypeForString ()],
+					ParameterByRef = [false, true],
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [null, null],
+				}
+			];
+			
+			const string variadicVoidMethod = @"
+using System;
+using ObjCBindings;
+using ObjCRuntime;
+
+namespace NS {
+	public class MyClass {
+
+		[Export<Method> (""completeRequestReturningItems:completionHandler:"", Flags = Method.IsVariadic)] 
+		public void MyMethod (string input) { }
+	}
+}
+";
+			yield return [
+				variadicVoidMethod,
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: false,
+					isStatic: false,
+					name: "MyMethod",
+					selector: "completeRequestReturningItems:completionHandler:" 
+				) {
+					ReturnType = TypeInfo.Void,
+					ParameterType = [ReturnTypeForString ()],
+					ParameterByRef = [false],
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [null],
+					IsVariadic = true,
+				}
+			];
+			
+			const string simpleActionMethod = @"
+using System;
+using ObjCBindings;
+using ObjCRuntime;
+
+namespace NS {
+	public class MyClass {
+
+		[Export<Method> (""completeRequestReturningItems:completionHandler:"")] 
+		public Action MyMethod (string input) { }
+	}
+}
+";
+			yield return [
+				simpleActionMethod,
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: false,
+					isStatic: false,
+					name: "MyMethod",
+					selector: "completeRequestReturningItems:completionHandler:" 
+				) {
+					ReturnType = ReturnTypeForAction (),
+					ParameterType = [ReturnTypeForString ()],
+					ParameterByRef = [false],
+					ReturnTypeDelegateProxy = TypeInfo.CreateDelegateProxy (ReturnTypeForAction ()),
+					ParameterBlockProxy = [null],
+				}
+			];
+			
+			const string intMethodActionParameter = @"
+using System;
+using ObjCBindings;
+using ObjCRuntime;
+
+namespace NS {
+	public class MyClass {
+
+		[Export<Method> (""completeRequestReturningItems:completionHandler:"")] 
+		public int MyMethod (string input, Action callback) { }
+	}
+}
+";
+			yield return [
+				intMethodActionParameter,
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: false,
+					isStatic: false,
+					name: "MyMethod",
+					selector: "completeRequestReturningItems:completionHandler:" 
+				) {
+					ReturnType = ReturnTypeForInt (),
+					ParameterType = [ReturnTypeForString (), ReturnTypeForAction ()],
+					ParameterByRef = [false, false],
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [null, TypeInfo.CreateDelegateProxy (ReturnTypeForAction ())],
+				}
+			];
+			
+			const string optionalVoidMethod = @"
+using System;
+using ObjCBindings;
+using ObjCRuntime;
+
+namespace NS {
+	public class MyClass {
+
+		[Export<Method> (""completeRequestReturningItems:completionHandler:"", Flags = Method.Optional)] 
+		public void MyMethod (string input) { }
+	}
+}
+";
+			yield return [
+				optionalVoidMethod,
+				new ProtocolMemberData (
+					isRequired: false,
+					isProperty: false,
+					isStatic: false,
+					name: "MyMethod",
+					selector: "completeRequestReturningItems:completionHandler:" 
+				) {
+					ReturnType = TypeInfo.Void,
+					ParameterType = [ReturnTypeForString ()],
+					ParameterByRef = [false],
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [null],
+					IsVariadic = false,
+				}
+			];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator ()
+			=> GetEnumerator ();
+	}
+	
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataFromMethodDeclaration>]
+	void FromMethodDeclaration (ApplePlatform platform, string inputText, ProtocolMemberData expectedAttributeData)
+	{
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
+		Assert.Single (syntaxTrees);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ().OfType<MethodDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		Assert.True (Method.TryCreate (declaration, semanticModel, out var changes));
+		Assert.NotNull (changes);
+		var attr = new ProtocolMemberData (changes.Value);
+		Assert.Equal (expectedAttributeData, attr, comparer);
+	}
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
@@ -238,7 +238,7 @@ public partial class PropertyTests
 	protected internal PropertyTests (global::ObjCRuntime.NativeHandle handle) : base (handle) {}
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	object? __mt_Alphanumerics_var = null;
+	object? __mt_Alphanumerics_var_static = null;
 
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]
@@ -261,7 +261,7 @@ public partial class PropertyTests
 			}
 			global::System.GC.KeepAlive (this);
 			MarkDirty ();
-			__mt_Alphanumerics_var = ret;
+			__mt_Alphanumerics_var_static = ret;
 			return ret;
 		}
 
@@ -280,7 +280,7 @@ public partial class PropertyTests
 			global::System.GC.KeepAlive (this);
 			global::System.GC.KeepAlive (value);
 			MarkDirty ();
-			__mt_Alphanumerics_var = value;
+			__mt_Alphanumerics_var_static = value;
 		}
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
@@ -238,7 +238,7 @@ public partial class PropertyTests
 	protected internal PropertyTests (global::ObjCRuntime.NativeHandle handle) : base (handle) {}
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	object? __mt_Alphanumerics_var = null;
+	object? __mt_Alphanumerics_var_static = null;
 
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]
@@ -261,7 +261,7 @@ public partial class PropertyTests
 			}
 			global::System.GC.KeepAlive (this);
 			MarkDirty ();
-			__mt_Alphanumerics_var = ret;
+			__mt_Alphanumerics_var_static = ret;
 			return ret;
 		}
 
@@ -280,7 +280,7 @@ public partial class PropertyTests
 			global::System.GC.KeepAlive (this);
 			global::System.GC.KeepAlive (value);
 			MarkDirty ();
-			__mt_Alphanumerics_var = value;
+			__mt_Alphanumerics_var_static = value;
 		}
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
@@ -238,7 +238,7 @@ public partial class PropertyTests
 	protected internal PropertyTests (global::ObjCRuntime.NativeHandle handle) : base (handle) {}
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	object? __mt_Alphanumerics_var = null;
+	object? __mt_Alphanumerics_var_static = null;
 
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]
@@ -261,7 +261,7 @@ public partial class PropertyTests
 			}
 			global::System.GC.KeepAlive (this);
 			MarkDirty ();
-			__mt_Alphanumerics_var = ret;
+			__mt_Alphanumerics_var_static = ret;
 			return ret;
 		}
 
@@ -280,7 +280,7 @@ public partial class PropertyTests
 			global::System.GC.KeepAlive (this);
 			global::System.GC.KeepAlive (value);
 			MarkDirty ();
-			__mt_Alphanumerics_var = value;
+			__mt_Alphanumerics_var_static = value;
 		}
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests/FromDeclarationTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests/FromDeclarationTests.cs
@@ -960,4 +960,116 @@ namespace NS {
 		Assert.True (asyncMethod.ReturnType.IsTask);
 		Assert.Equal (changes.Value.Parameters.Length - 1, asyncMethod.Parameters.Length);
 	}
+	
+	class TestDataFromMethodDeclarationIsOptional : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			const string optionalMethod = @"
+using System;
+using ObjCBindings;
+using ObjCRuntime;
+
+namespace NS {
+	public class MyClass {
+
+		[Export<Method> (""completeRequestReturningItems:completionHandler:"", Flags = ObjCBindings.Method.Optional)] 
+		public void MyMethod (string[]? input) { }
+	}
+}
+";
+
+			yield return [optionalMethod, true];
+
+			const string notOptionalMethod = @"
+using System;
+using ObjCBindings;
+using ObjCRuntime;
+
+namespace NS {
+	public class MyClass {
+
+		[Export<Method> (""completeRequestReturningItems:completionHandler:"", Flags = ObjCBindings.Method.Default)] 
+		public void MyMethod (string[]? input) { }
+	}
+}
+";
+
+			yield return [notOptionalMethod, false];
+
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataFromMethodDeclarationIsOptional>]
+	void FromMethodDeclarationIsOptional(ApplePlatform platform, string inputText, bool expectedIsOptional)
+	{
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
+		Assert.Single (syntaxTrees);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ().OfType<MethodDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		Assert.True (Method.TryCreate (declaration, semanticModel, out var changes));
+		Assert.NotNull (changes);
+		Assert.Equal(expectedIsOptional, changes.Value.IsOptional);
+	}
+	
+	class TestDataFromMethodDeclarationIsVariadic: IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			const string variadicMethod = @"
+using System;
+using ObjCBindings;
+using ObjCRuntime;
+
+namespace NS {
+	public class MyClass {
+
+		[Export<Method> (""completeRequestReturningItems:completionHandler:"", Flags = ObjCBindings.Method.IsVariadic)] 
+		public void MyMethod (string[]? input) { }
+	}
+}
+";
+
+			yield return [variadicMethod, true];
+
+			const string notVariadicMethod = @"
+using System;
+using ObjCBindings;
+using ObjCRuntime;
+
+namespace NS {
+	public class MyClass {
+
+		[Export<Method> (""completeRequestReturningItems:completionHandler:"", Flags = ObjCBindings.Method.Default)] 
+		public void MyMethod (string[]? input) { }
+	}
+}
+";
+
+			yield return [notVariadicMethod, false];
+
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataFromMethodDeclarationIsVariadic>]
+	void FromMethodDeclarationIsVariadic(ApplePlatform platform, string inputText, bool expectedIsVariadic)
+	{
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
+		Assert.Single (syntaxTrees);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ().OfType<MethodDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		Assert.True (Method.TryCreate (declaration, semanticModel, out var changes));
+		Assert.NotNull (changes);
+		Assert.Equal(expectedIsVariadic, changes.Value.IsVariadic);
+	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests/FromDeclarationTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests/FromDeclarationTests.cs
@@ -960,7 +960,7 @@ namespace NS {
 		Assert.True (asyncMethod.ReturnType.IsTask);
 		Assert.Equal (changes.Value.Parameters.Length - 1, asyncMethod.Parameters.Length);
 	}
-	
+
 	class TestDataFromMethodDeclarationIsOptional : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -1000,10 +1000,10 @@ namespace NS {
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
-	
+
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataFromMethodDeclarationIsOptional>]
-	void FromMethodDeclarationIsOptional(ApplePlatform platform, string inputText, bool expectedIsOptional)
+	void FromMethodDeclarationIsOptional (ApplePlatform platform, string inputText, bool expectedIsOptional)
 	{
 		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
 		Assert.Single (syntaxTrees);
@@ -1014,10 +1014,10 @@ namespace NS {
 		Assert.NotNull (declaration);
 		Assert.True (Method.TryCreate (declaration, semanticModel, out var changes));
 		Assert.NotNull (changes);
-		Assert.Equal(expectedIsOptional, changes.Value.IsOptional);
+		Assert.Equal (expectedIsOptional, changes.Value.IsOptional);
 	}
-	
-	class TestDataFromMethodDeclarationIsVariadic: IEnumerable<object []> {
+
+	class TestDataFromMethodDeclarationIsVariadic : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
 			const string variadicMethod = @"
@@ -1056,10 +1056,10 @@ namespace NS {
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
-	
+
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataFromMethodDeclarationIsVariadic>]
-	void FromMethodDeclarationIsVariadic(ApplePlatform platform, string inputText, bool expectedIsVariadic)
+	void FromMethodDeclarationIsVariadic (ApplePlatform platform, string inputText, bool expectedIsVariadic)
 	{
 		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
 		Assert.Single (syntaxTrees);
@@ -1070,6 +1070,6 @@ namespace NS {
 		Assert.NotNull (declaration);
 		Assert.True (Method.TryCreate (declaration, semanticModel, out var changes));
 		Assert.NotNull (changes);
-		Assert.Equal(expectedIsVariadic, changes.Value.IsVariadic);
+		Assert.Equal (expectedIsVariadic, changes.Value.IsVariadic);
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/IO/TabbedStringBuilderTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/IO/TabbedStringBuilderTests.cs
@@ -441,7 +441,7 @@ Because we are using a raw string  we expected:
 		var result = block.ToCode ();
 		Assert.Equal (expectedString, result);
 	}
-	
+
 	public static IEnumerable<object []> AppendProtocolMemberDataTestData {
 		get {
 			yield return [
@@ -461,7 +461,7 @@ Because we are using a raw string  we expected:
 				},
 				"[ProtocolMember (IsRequired = true, IsProperty = true, IsStatic = false, Name = \"Name\", Selector = \"name\", PropertyType = typeof (string), GetterSelector = \"name\", SetterSelector = null, ArgumentSemantic = ArgumentSemantic.None)]\n"
 			];
-			
+
 			yield return [
 				new ProtocolMemberData (
 					isRequired: false,
@@ -761,7 +761,7 @@ Because we are using a raw string  we expected:
 			];
 		}
 	}
-	
+
 	[Theory]
 	[MemberData (nameof (AppendProtocolMemberDataTestData))]
 	void AppendProtocolMemberDataTest (ProtocolMemberData protocolMemberData, string expectedString)

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/IO/TabbedStringBuilderTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/IO/TabbedStringBuilderTests.cs
@@ -11,8 +11,11 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Availability;
 using Microsoft.Macios.Generator.IO;
+using ObjCRuntime;
 using Xunit;
+using static Microsoft.Macios.Generator.Tests.TestDataFactory;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
 
 namespace Microsoft.Macios.Generator.Tests.IO;
 
@@ -435,6 +438,336 @@ Because we are using a raw string  we expected:
 	{
 		var block = new TabbedStringBuilder (sb);
 		block.AppendMemberAvailability (availability);
+		var result = block.ToCode ();
+		Assert.Equal (expectedString, result);
+	}
+	
+	public static IEnumerable<object []> AppendProtocolMemberDataTestData {
+		get {
+			yield return [
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: true,
+					isStatic: false,
+					name: "Name",
+					selector: "name"
+				) {
+					PropertyType = ReturnTypeForString (),
+					GetterSelector = "name",
+					SetterSelector = null,
+					ArgumentSemantic = ArgumentSemantic.None,
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [],
+				},
+				"[ProtocolMember (IsRequired = true, IsProperty = true, IsStatic = false, Name = \"Name\", Selector = \"name\", PropertyType = typeof (string), GetterSelector = \"name\", SetterSelector = null, ArgumentSemantic = ArgumentSemantic.None]\n"
+			];
+			
+			yield return [
+				new ProtocolMemberData (
+					isRequired: false,
+					isProperty: true,
+					isStatic: false,
+					name: "Name",
+					selector: "name"
+				) {
+					PropertyType = ReturnTypeForString (),
+					GetterSelector = "name",
+					SetterSelector = null,
+					ArgumentSemantic = ArgumentSemantic.None,
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [],
+				},
+				"[ProtocolMember (IsRequired = false, IsProperty = true, IsStatic = false, Name = \"Name\", Selector = \"name\", PropertyType = typeof (string), GetterSelector = \"name\", SetterSelector = null, ArgumentSemantic = ArgumentSemantic.None]\n"
+			];
+
+			yield return [
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: true,
+					isStatic: true,
+					name: "Name",
+					selector: "name"
+				) {
+					PropertyType = ReturnTypeForString (),
+					GetterSelector = "name",
+					SetterSelector = null,
+					ArgumentSemantic = ArgumentSemantic.None,
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [],
+				},
+				"[ProtocolMember (IsRequired = true, IsProperty = true, IsStatic = true, Name = \"Name\", Selector = \"name\", PropertyType = typeof (string), GetterSelector = \"name\", SetterSelector = null, ArgumentSemantic = ArgumentSemantic.None]\n"
+			];
+
+			yield return [
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: true,
+					isStatic: false,
+					name: "Name",
+					selector: "name"
+				) {
+					PropertyType = ReturnTypeForString (),
+					GetterSelector = "name",
+					SetterSelector = "setName:",
+					ArgumentSemantic = ArgumentSemantic.None,
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [],
+				},
+				"[ProtocolMember (IsRequired = true, IsProperty = true, IsStatic = false, Name = \"Name\", Selector = \"name\", PropertyType = typeof (string), GetterSelector = \"name\", SetterSelector = \"setName:\", ArgumentSemantic = ArgumentSemantic.None]\n"
+			];
+
+			yield return [
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: true,
+					isStatic: false,
+					name: "Name",
+					selector: "name"
+				) {
+					PropertyType = ReturnTypeForString (),
+					GetterSelector = "myName",
+					SetterSelector = "setMyName:",
+					ArgumentSemantic = ArgumentSemantic.None,
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [],
+				},
+				"[ProtocolMember (IsRequired = true, IsProperty = true, IsStatic = false, Name = \"Name\", Selector = \"name\", PropertyType = typeof (string), GetterSelector = \"myName\", SetterSelector = \"setMyName:\", ArgumentSemantic = ArgumentSemantic.None]\n"
+			];
+
+			yield return [
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: true,
+					isStatic: false,
+					name: "Name",
+					selector: "name"
+				) {
+					PropertyType = ReturnTypeForString (),
+					GetterSelector = "name",
+					SetterSelector = "setName:",
+					ArgumentSemantic = ArgumentSemantic.Copy,
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [],
+				},
+				"[ProtocolMember (IsRequired = true, IsProperty = true, IsStatic = false, Name = \"Name\", Selector = \"name\", PropertyType = typeof (string), GetterSelector = \"name\", SetterSelector = \"setName:\", ArgumentSemantic = ArgumentSemantic.Copy]\n"
+			];
+
+			yield return [
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: true,
+					isStatic: false,
+					name: "Name",
+					selector: "callback"
+				) {
+					PropertyType = ReturnTypeForAction (),
+					GetterSelector = "callback",
+					SetterSelector = "setCallback:",
+					ArgumentSemantic = ArgumentSemantic.None,
+					ReturnTypeDelegateProxy = TypeInfo.CreateDelegateProxy (ReturnTypeForAction ()),
+					ParameterBlockProxy = [TypeInfo.CreateDelegateProxy (ReturnTypeForAction ())],
+				},
+				"[ProtocolMember (IsRequired = true, IsProperty = true, IsStatic = false, Name = \"Name\", Selector = \"callback\", PropertyType = typeof (global::System.Action), GetterSelector = \"callback\", SetterSelector = \"setCallback:\", ArgumentSemantic = ArgumentSemantic.None, ReturnTypeDelegateProxy = typeof (global::ObjCRuntime.Trampolines.SDAction), ParameterBlockProxy = new Type? [] { typeof (global::ObjCRuntime.Trampolines.SDAction) }]\n"
+			];
+
+			yield return [
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: true,
+					isStatic: false,
+					name: "Name",
+					selector: "callback"
+				) {
+					PropertyType = ReturnTypeForAction (null, "string", "string"),
+					GetterSelector = "callback",
+					SetterSelector = "setCallback:",
+					ArgumentSemantic = ArgumentSemantic.None,
+					ReturnTypeDelegateProxy = TypeInfo.CreateDelegateProxy (ReturnTypeForAction (null, "string", "string")),
+					ParameterBlockProxy = [TypeInfo.CreateDelegateProxy (ReturnTypeForAction (null, "string", "string"))],
+				},
+				"[ProtocolMember (IsRequired = true, IsProperty = true, IsStatic = false, Name = \"Name\", Selector = \"callback\", PropertyType = typeof (global::System.Action<string, string>), GetterSelector = \"callback\", SetterSelector = \"setCallback:\", ArgumentSemantic = ArgumentSemantic.None, ReturnTypeDelegateProxy = typeof (global::ObjCRuntime.Trampolines.SDActionArity2stringstring), ParameterBlockProxy = new Type? [] { typeof (global::ObjCRuntime.Trampolines.SDActionArity2stringstring) }]\n"
+			];
+
+			yield return [
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: false,
+					isStatic: false,
+					name: "MyMethod",
+					selector: "completeRequestReturningItems:completionHandler:"
+				) {
+					ReturnType = TypeInfo.Void,
+					ParameterType = [ReturnTypeForString ()],
+					ParameterByRef = [false],
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [null],
+				},
+				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (global::System.void), ParameterType = new Type [] { typeof (string) }, ParameterByRef = new bool [] { false }, ParameterBlockProxy = new Type? [] { null }]\n"
+			];
+
+			yield return [
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: false,
+					isStatic: true,
+					name: "MyMethod",
+					selector: "completeRequestReturningItems:completionHandler:"
+				) {
+					ReturnType = TypeInfo.Void,
+					ParameterType = [ReturnTypeForString ()],
+					ParameterByRef = [false],
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [null],
+				},
+				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = true, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (global::System.void), ParameterType = new Type [] { typeof (string) }, ParameterByRef = new bool [] { false }, ParameterBlockProxy = new Type? [] { null }]\n"
+			];
+
+			yield return [
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: false,
+					isStatic: false,
+					name: "MyMethod",
+					selector: "completeRequestReturningItems:completionHandler:"
+				) {
+					ReturnType = ReturnTypeForInt (),
+					ParameterType = [ReturnTypeForString ()],
+					ParameterByRef = [false],
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [null],
+				},
+				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (int), ParameterType = new Type [] { typeof (string) }, ParameterByRef = new bool [] { false }, ParameterBlockProxy = new Type? [] { null }]\n"
+			];
+
+			yield return [
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: false,
+					isStatic: false,
+					name: "MyMethod",
+					selector: "completeRequestReturningItems:completionHandler:"
+				) {
+					ReturnType = ReturnTypeForInt (),
+					ParameterType = [ReturnTypeForString (), ReturnTypeForString ()],
+					ParameterByRef = [false, false],
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [null, null],
+				},
+				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (int), ParameterType = new Type [] { typeof (string), typeof (string) }, ParameterByRef = new bool [] { false, false }, ParameterBlockProxy = new Type? [] { null, null }]\n"
+			];
+
+			yield return [
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: false,
+					isStatic: false,
+					name: "MyMethod",
+					selector: "completeRequestReturningItems:completionHandler:"
+				) {
+					ReturnType = ReturnTypeForInt (),
+					ParameterType = [ReturnTypeForString ()],
+					ParameterByRef = [false],
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [null],
+				},
+				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (int), ParameterType = new Type [] { typeof (string) }, ParameterByRef = new bool [] { false }, ParameterBlockProxy = new Type? [] { null }]\n"
+			];
+
+			yield return [
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: false,
+					isStatic: false,
+					name: "MyMethod",
+					selector: "completeRequestReturningItems:completionHandler:"
+				) {
+					ReturnType = ReturnTypeForInt (),
+					ParameterType = [ReturnTypeForString (), ReturnTypeForString ()],
+					ParameterByRef = [false, true],
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [null, null],
+				},
+				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (int), ParameterType = new Type [] { typeof (string), typeof (string) }, ParameterByRef = new bool [] { false, true }, ParameterBlockProxy = new Type? [] { null, null }]\n"
+			];
+
+			yield return [
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: false,
+					isStatic: false,
+					name: "MyMethod",
+					selector: "completeRequestReturningItems:completionHandler:"
+				) {
+					ReturnType = TypeInfo.Void,
+					ParameterType = [ReturnTypeForString ()],
+					ParameterByRef = [false],
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [null],
+					IsVariadic = true,
+				},
+				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (global::System.void), ParameterType = new Type [] { typeof (string) }, ParameterByRef = new bool [] { false }, ParameterBlockProxy = new Type? [] { null }]\n"
+			];
+
+			yield return [
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: false,
+					isStatic: false,
+					name: "MyMethod",
+					selector: "completeRequestReturningItems:completionHandler:"
+				) {
+					ReturnType = ReturnTypeForAction (),
+					ParameterType = [ReturnTypeForString ()],
+					ParameterByRef = [false],
+					ReturnTypeDelegateProxy = TypeInfo.CreateDelegateProxy (ReturnTypeForAction ()),
+					ParameterBlockProxy = [null],
+				},
+				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (global::System.Action), ParameterType = new Type [] { typeof (string) }, ParameterByRef = new bool [] { false }, ReturnTypeDelegateProxy = typeof (global::ObjCRuntime.Trampolines.SDAction), ParameterBlockProxy = new Type? [] { null }]\n"
+			];
+
+			yield return [
+				new ProtocolMemberData (
+					isRequired: true,
+					isProperty: false,
+					isStatic: false,
+					name: "MyMethod",
+					selector: "completeRequestReturningItems:completionHandler:"
+				) {
+					ReturnType = ReturnTypeForInt (),
+					ParameterType = [ReturnTypeForString (), ReturnTypeForAction ()],
+					ParameterByRef = [false, false],
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [null, TypeInfo.CreateDelegateProxy (ReturnTypeForAction ())],
+				},
+				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (int), ParameterType = new Type [] { typeof (string), typeof (global::System.Action) }, ParameterByRef = new bool [] { false, false }, ParameterBlockProxy = new Type? [] { null, typeof (global::ObjCRuntime.Trampolines.SDAction) }]\n"
+			];
+
+			yield return [
+				new ProtocolMemberData (
+					isRequired: false,
+					isProperty: false,
+					isStatic: false,
+					name: "MyMethod",
+					selector: "completeRequestReturningItems:completionHandler:"
+				) {
+					ReturnType = TypeInfo.Void,
+					ParameterType = [ReturnTypeForString ()],
+					ParameterByRef = [false],
+					ReturnTypeDelegateProxy = null,
+					ParameterBlockProxy = [null],
+					IsVariadic = false,
+				},
+				"[ProtocolMember (IsRequired = false, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (global::System.void), ParameterType = new Type [] { typeof (string) }, ParameterByRef = new bool [] { false }, ParameterBlockProxy = new Type? [] { null }]\n"
+			];
+		}
+	}
+	
+	[Theory]
+	[MemberData (nameof (AppendProtocolMemberDataTestData))]
+	void AppendProtocolMemberDataTest (ProtocolMemberData protocolMemberData, string expectedString)
+	{
+		var block = new TabbedStringBuilder (sb);
+		block.AppendProtocolMemberData (protocolMemberData);
 		var result = block.ToCode ();
 		Assert.Equal (expectedString, result);
 	}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/IO/TabbedStringBuilderTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/IO/TabbedStringBuilderTests.cs
@@ -459,7 +459,7 @@ Because we are using a raw string  we expected:
 					ReturnTypeDelegateProxy = null,
 					ParameterBlockProxy = [],
 				},
-				"[ProtocolMember (IsRequired = true, IsProperty = true, IsStatic = false, Name = \"Name\", Selector = \"name\", PropertyType = typeof (string), GetterSelector = \"name\", SetterSelector = null, ArgumentSemantic = ArgumentSemantic.None]\n"
+				"[ProtocolMember (IsRequired = true, IsProperty = true, IsStatic = false, Name = \"Name\", Selector = \"name\", PropertyType = typeof (string), GetterSelector = \"name\", SetterSelector = null, ArgumentSemantic = ArgumentSemantic.None)]\n"
 			];
 			
 			yield return [
@@ -477,7 +477,7 @@ Because we are using a raw string  we expected:
 					ReturnTypeDelegateProxy = null,
 					ParameterBlockProxy = [],
 				},
-				"[ProtocolMember (IsRequired = false, IsProperty = true, IsStatic = false, Name = \"Name\", Selector = \"name\", PropertyType = typeof (string), GetterSelector = \"name\", SetterSelector = null, ArgumentSemantic = ArgumentSemantic.None]\n"
+				"[ProtocolMember (IsRequired = false, IsProperty = true, IsStatic = false, Name = \"Name\", Selector = \"name\", PropertyType = typeof (string), GetterSelector = \"name\", SetterSelector = null, ArgumentSemantic = ArgumentSemantic.None)]\n"
 			];
 
 			yield return [
@@ -495,7 +495,7 @@ Because we are using a raw string  we expected:
 					ReturnTypeDelegateProxy = null,
 					ParameterBlockProxy = [],
 				},
-				"[ProtocolMember (IsRequired = true, IsProperty = true, IsStatic = true, Name = \"Name\", Selector = \"name\", PropertyType = typeof (string), GetterSelector = \"name\", SetterSelector = null, ArgumentSemantic = ArgumentSemantic.None]\n"
+				"[ProtocolMember (IsRequired = true, IsProperty = true, IsStatic = true, Name = \"Name\", Selector = \"name\", PropertyType = typeof (string), GetterSelector = \"name\", SetterSelector = null, ArgumentSemantic = ArgumentSemantic.None)]\n"
 			];
 
 			yield return [
@@ -513,7 +513,7 @@ Because we are using a raw string  we expected:
 					ReturnTypeDelegateProxy = null,
 					ParameterBlockProxy = [],
 				},
-				"[ProtocolMember (IsRequired = true, IsProperty = true, IsStatic = false, Name = \"Name\", Selector = \"name\", PropertyType = typeof (string), GetterSelector = \"name\", SetterSelector = \"setName:\", ArgumentSemantic = ArgumentSemantic.None]\n"
+				"[ProtocolMember (IsRequired = true, IsProperty = true, IsStatic = false, Name = \"Name\", Selector = \"name\", PropertyType = typeof (string), GetterSelector = \"name\", SetterSelector = \"setName:\", ArgumentSemantic = ArgumentSemantic.None)]\n"
 			];
 
 			yield return [
@@ -531,7 +531,7 @@ Because we are using a raw string  we expected:
 					ReturnTypeDelegateProxy = null,
 					ParameterBlockProxy = [],
 				},
-				"[ProtocolMember (IsRequired = true, IsProperty = true, IsStatic = false, Name = \"Name\", Selector = \"name\", PropertyType = typeof (string), GetterSelector = \"myName\", SetterSelector = \"setMyName:\", ArgumentSemantic = ArgumentSemantic.None]\n"
+				"[ProtocolMember (IsRequired = true, IsProperty = true, IsStatic = false, Name = \"Name\", Selector = \"name\", PropertyType = typeof (string), GetterSelector = \"myName\", SetterSelector = \"setMyName:\", ArgumentSemantic = ArgumentSemantic.None)]\n"
 			];
 
 			yield return [
@@ -549,7 +549,7 @@ Because we are using a raw string  we expected:
 					ReturnTypeDelegateProxy = null,
 					ParameterBlockProxy = [],
 				},
-				"[ProtocolMember (IsRequired = true, IsProperty = true, IsStatic = false, Name = \"Name\", Selector = \"name\", PropertyType = typeof (string), GetterSelector = \"name\", SetterSelector = \"setName:\", ArgumentSemantic = ArgumentSemantic.Copy]\n"
+				"[ProtocolMember (IsRequired = true, IsProperty = true, IsStatic = false, Name = \"Name\", Selector = \"name\", PropertyType = typeof (string), GetterSelector = \"name\", SetterSelector = \"setName:\", ArgumentSemantic = ArgumentSemantic.Copy)]\n"
 			];
 
 			yield return [
@@ -567,7 +567,7 @@ Because we are using a raw string  we expected:
 					ReturnTypeDelegateProxy = TypeInfo.CreateDelegateProxy (ReturnTypeForAction ()),
 					ParameterBlockProxy = [TypeInfo.CreateDelegateProxy (ReturnTypeForAction ())],
 				},
-				"[ProtocolMember (IsRequired = true, IsProperty = true, IsStatic = false, Name = \"Name\", Selector = \"callback\", PropertyType = typeof (global::System.Action), GetterSelector = \"callback\", SetterSelector = \"setCallback:\", ArgumentSemantic = ArgumentSemantic.None, ReturnTypeDelegateProxy = typeof (global::ObjCRuntime.Trampolines.SDAction), ParameterBlockProxy = new Type? [] { typeof (global::ObjCRuntime.Trampolines.SDAction) }]\n"
+				"[ProtocolMember (IsRequired = true, IsProperty = true, IsStatic = false, Name = \"Name\", Selector = \"callback\", PropertyType = typeof (global::System.Action), GetterSelector = \"callback\", SetterSelector = \"setCallback:\", ArgumentSemantic = ArgumentSemantic.None, ReturnTypeDelegateProxy = typeof (global::ObjCRuntime.Trampolines.SDAction), ParameterBlockProxy = new Type? [] { typeof (global::ObjCRuntime.Trampolines.SDAction) })]\n"
 			];
 
 			yield return [
@@ -585,7 +585,7 @@ Because we are using a raw string  we expected:
 					ReturnTypeDelegateProxy = TypeInfo.CreateDelegateProxy (ReturnTypeForAction (null, "string", "string")),
 					ParameterBlockProxy = [TypeInfo.CreateDelegateProxy (ReturnTypeForAction (null, "string", "string"))],
 				},
-				"[ProtocolMember (IsRequired = true, IsProperty = true, IsStatic = false, Name = \"Name\", Selector = \"callback\", PropertyType = typeof (global::System.Action<string, string>), GetterSelector = \"callback\", SetterSelector = \"setCallback:\", ArgumentSemantic = ArgumentSemantic.None, ReturnTypeDelegateProxy = typeof (global::ObjCRuntime.Trampolines.SDActionArity2stringstring), ParameterBlockProxy = new Type? [] { typeof (global::ObjCRuntime.Trampolines.SDActionArity2stringstring) }]\n"
+				"[ProtocolMember (IsRequired = true, IsProperty = true, IsStatic = false, Name = \"Name\", Selector = \"callback\", PropertyType = typeof (global::System.Action<string, string>), GetterSelector = \"callback\", SetterSelector = \"setCallback:\", ArgumentSemantic = ArgumentSemantic.None, ReturnTypeDelegateProxy = typeof (global::ObjCRuntime.Trampolines.SDActionArity2stringstring), ParameterBlockProxy = new Type? [] { typeof (global::ObjCRuntime.Trampolines.SDActionArity2stringstring) })]\n"
 			];
 
 			yield return [
@@ -602,7 +602,7 @@ Because we are using a raw string  we expected:
 					ReturnTypeDelegateProxy = null,
 					ParameterBlockProxy = [null],
 				},
-				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (global::System.void), ParameterType = new Type [] { typeof (string) }, ParameterByRef = new bool [] { false }, ParameterBlockProxy = new Type? [] { null }]\n"
+				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (global::System.void), ParameterType = new Type [] { typeof (string) }, ParameterByRef = new bool [] { false }, ParameterBlockProxy = new Type? [] { null })]\n"
 			];
 
 			yield return [
@@ -619,7 +619,7 @@ Because we are using a raw string  we expected:
 					ReturnTypeDelegateProxy = null,
 					ParameterBlockProxy = [null],
 				},
-				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = true, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (global::System.void), ParameterType = new Type [] { typeof (string) }, ParameterByRef = new bool [] { false }, ParameterBlockProxy = new Type? [] { null }]\n"
+				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = true, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (global::System.void), ParameterType = new Type [] { typeof (string) }, ParameterByRef = new bool [] { false }, ParameterBlockProxy = new Type? [] { null })]\n"
 			];
 
 			yield return [
@@ -636,7 +636,7 @@ Because we are using a raw string  we expected:
 					ReturnTypeDelegateProxy = null,
 					ParameterBlockProxy = [null],
 				},
-				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (int), ParameterType = new Type [] { typeof (string) }, ParameterByRef = new bool [] { false }, ParameterBlockProxy = new Type? [] { null }]\n"
+				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (int), ParameterType = new Type [] { typeof (string) }, ParameterByRef = new bool [] { false }, ParameterBlockProxy = new Type? [] { null })]\n"
 			];
 
 			yield return [
@@ -653,7 +653,7 @@ Because we are using a raw string  we expected:
 					ReturnTypeDelegateProxy = null,
 					ParameterBlockProxy = [null, null],
 				},
-				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (int), ParameterType = new Type [] { typeof (string), typeof (string) }, ParameterByRef = new bool [] { false, false }, ParameterBlockProxy = new Type? [] { null, null }]\n"
+				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (int), ParameterType = new Type [] { typeof (string), typeof (string) }, ParameterByRef = new bool [] { false, false }, ParameterBlockProxy = new Type? [] { null, null })]\n"
 			];
 
 			yield return [
@@ -670,7 +670,7 @@ Because we are using a raw string  we expected:
 					ReturnTypeDelegateProxy = null,
 					ParameterBlockProxy = [null],
 				},
-				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (int), ParameterType = new Type [] { typeof (string) }, ParameterByRef = new bool [] { false }, ParameterBlockProxy = new Type? [] { null }]\n"
+				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (int), ParameterType = new Type [] { typeof (string) }, ParameterByRef = new bool [] { false }, ParameterBlockProxy = new Type? [] { null })]\n"
 			];
 
 			yield return [
@@ -687,7 +687,7 @@ Because we are using a raw string  we expected:
 					ReturnTypeDelegateProxy = null,
 					ParameterBlockProxy = [null, null],
 				},
-				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (int), ParameterType = new Type [] { typeof (string), typeof (string) }, ParameterByRef = new bool [] { false, true }, ParameterBlockProxy = new Type? [] { null, null }]\n"
+				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (int), ParameterType = new Type [] { typeof (string), typeof (string) }, ParameterByRef = new bool [] { false, true }, ParameterBlockProxy = new Type? [] { null, null })]\n"
 			];
 
 			yield return [
@@ -705,7 +705,7 @@ Because we are using a raw string  we expected:
 					ParameterBlockProxy = [null],
 					IsVariadic = true,
 				},
-				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (global::System.void), ParameterType = new Type [] { typeof (string) }, ParameterByRef = new bool [] { false }, ParameterBlockProxy = new Type? [] { null }]\n"
+				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (global::System.void), ParameterType = new Type [] { typeof (string) }, ParameterByRef = new bool [] { false }, ParameterBlockProxy = new Type? [] { null })]\n"
 			];
 
 			yield return [
@@ -722,7 +722,7 @@ Because we are using a raw string  we expected:
 					ReturnTypeDelegateProxy = TypeInfo.CreateDelegateProxy (ReturnTypeForAction ()),
 					ParameterBlockProxy = [null],
 				},
-				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (global::System.Action), ParameterType = new Type [] { typeof (string) }, ParameterByRef = new bool [] { false }, ReturnTypeDelegateProxy = typeof (global::ObjCRuntime.Trampolines.SDAction), ParameterBlockProxy = new Type? [] { null }]\n"
+				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (global::System.Action), ParameterType = new Type [] { typeof (string) }, ParameterByRef = new bool [] { false }, ReturnTypeDelegateProxy = typeof (global::ObjCRuntime.Trampolines.SDAction), ParameterBlockProxy = new Type? [] { null })]\n"
 			];
 
 			yield return [
@@ -739,7 +739,7 @@ Because we are using a raw string  we expected:
 					ReturnTypeDelegateProxy = null,
 					ParameterBlockProxy = [null, TypeInfo.CreateDelegateProxy (ReturnTypeForAction ())],
 				},
-				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (int), ParameterType = new Type [] { typeof (string), typeof (global::System.Action) }, ParameterByRef = new bool [] { false, false }, ParameterBlockProxy = new Type? [] { null, typeof (global::ObjCRuntime.Trampolines.SDAction) }]\n"
+				"[ProtocolMember (IsRequired = true, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (int), ParameterType = new Type [] { typeof (string), typeof (global::System.Action) }, ParameterByRef = new bool [] { false, false }, ParameterBlockProxy = new Type? [] { null, typeof (global::ObjCRuntime.Trampolines.SDAction) })]\n"
 			];
 
 			yield return [
@@ -757,7 +757,7 @@ Because we are using a raw string  we expected:
 					ParameterBlockProxy = [null],
 					IsVariadic = false,
 				},
-				"[ProtocolMember (IsRequired = false, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (global::System.void), ParameterType = new Type [] { typeof (string) }, ParameterByRef = new bool [] { false }, ParameterBlockProxy = new Type? [] { null }]\n"
+				"[ProtocolMember (IsRequired = false, IsProperty = false, IsStatic = false, Name = \"MyMethod\", Selector = \"completeRequestReturningItems:completionHandler:\", ReturnType = typeof (global::System.void), ParameterType = new Type [] { typeof (string) }, ParameterByRef = new bool [] { false }, ParameterBlockProxy = new Type? [] { null })]\n"
 			];
 		}
 	}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/ProtocolMemberCustomEqualityComparer.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/ProtocolMemberCustomEqualityComparer.cs
@@ -12,8 +12,7 @@ namespace Microsoft.Macios.Generator.Tests;
 /// Custom equality comparer for <see cref="ProtocolMemberData"/> used in tests.
 /// Performs comparison based on the fully qualified names of type infos rather than reference equality.
 /// </summary>
-class ProtocolMemberCustomEqualityComparer : IEqualityComparer<ProtocolMemberData>
-{
+class ProtocolMemberCustomEqualityComparer : IEqualityComparer<ProtocolMemberData> {
 	TypeInfoCustomEqualityComparer typeComparer = new ();
 	/// <summary>
 	/// Determines whether the specified <see cref="ProtocolMemberData"/> objects are equal.
@@ -37,11 +36,11 @@ class ProtocolMemberCustomEqualityComparer : IEqualityComparer<ProtocolMemberDat
 			return false;
 		if (x.ReturnTypeDelegateProxy?.FullyQualifiedName != y.ReturnTypeDelegateProxy?.FullyQualifiedName)
 			return false;
-		if (!x.ParameterType.SequenceEqual (y.ParameterType, (l , r) => typeComparer.Equals (l, r)))
+		if (!x.ParameterType.SequenceEqual (y.ParameterType, (l, r) => typeComparer.Equals (l, r)))
 			return false;
 		if (!x.ParameterByRef.SequenceEqual (y.ParameterByRef))
 			return false;
-		if (!x.ParameterBlockProxy.SequenceEqual (y.ParameterBlockProxy, (l , r) => typeComparer.Equals (l, r)))
+		if (!x.ParameterBlockProxy.SequenceEqual (y.ParameterBlockProxy, (l, r) => typeComparer.Equals (l, r)))
 			return false;
 		if (x.IsVariadic != y.IsVariadic)
 			return false;
@@ -61,24 +60,24 @@ class ProtocolMemberCustomEqualityComparer : IEqualityComparer<ProtocolMemberDat
 	/// </summary>
 	/// <param name="obj">The <see cref="ProtocolMemberData"/> for which a hash code is to be returned.</param>
 	/// <returns>A hash code for the specified object.</returns>
-	public int GetHashCode(ProtocolMemberData obj)
+	public int GetHashCode (ProtocolMemberData obj)
 	{
-		var hashCode = new HashCode();
-		hashCode.Add(obj.IsRequired);
-		hashCode.Add(obj.IsProperty);
-		hashCode.Add(obj.IsStatic);
-		hashCode.Add(obj.Name);
-		hashCode.Add(obj.Selector);
-		hashCode.Add(obj.ReturnType);
-		hashCode.Add(obj.ReturnTypeDelegateProxy);
-		hashCode.Add(obj.ParameterType);
-		hashCode.Add(obj.ParameterByRef);
-		hashCode.Add(obj.ParameterBlockProxy);
-		hashCode.Add(obj.IsVariadic);
-		hashCode.Add(obj.PropertyType);
-		hashCode.Add(obj.GetterSelector);
-		hashCode.Add(obj.SetterSelector);
-		hashCode.Add((int)obj.ArgumentSemantic);
-		return hashCode.ToHashCode();
+		var hashCode = new HashCode ();
+		hashCode.Add (obj.IsRequired);
+		hashCode.Add (obj.IsProperty);
+		hashCode.Add (obj.IsStatic);
+		hashCode.Add (obj.Name);
+		hashCode.Add (obj.Selector);
+		hashCode.Add (obj.ReturnType);
+		hashCode.Add (obj.ReturnTypeDelegateProxy);
+		hashCode.Add (obj.ParameterType);
+		hashCode.Add (obj.ParameterByRef);
+		hashCode.Add (obj.ParameterBlockProxy);
+		hashCode.Add (obj.IsVariadic);
+		hashCode.Add (obj.PropertyType);
+		hashCode.Add (obj.GetterSelector);
+		hashCode.Add (obj.SetterSelector);
+		hashCode.Add ((int) obj.ArgumentSemantic);
+		return hashCode.ToHashCode ();
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/ProtocolMemberCustomEqualityComparer.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/ProtocolMemberCustomEqualityComparer.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Macios.Generator.Attributes;
+
+namespace Microsoft.Macios.Generator.Tests;
+
+/// <summary>
+/// Custom equality comparer for <see cref="ProtocolMemberData"/> used in tests.
+/// Performs comparison based on the fully qualified names of type infos rather than reference equality.
+/// </summary>
+class ProtocolMemberCustomEqualityComparer : IEqualityComparer<ProtocolMemberData>
+{
+	TypeInfoCustomEqualityComparer typeComparer = new ();
+	/// <summary>
+	/// Determines whether the specified <see cref="ProtocolMemberData"/> objects are equal.
+	/// </summary>
+	/// <param name="x">The first <see cref="ProtocolMemberData"/> to compare.</param>
+	/// <param name="y">The second <see cref="ProtocolMemberData"/> to compare.</param>
+	/// <returns><c>true</c> if the specified objects are equal; otherwise, <c>false</c>.</returns>
+	public bool Equals (ProtocolMemberData x, ProtocolMemberData y)
+	{
+		if (x.IsRequired != y.IsRequired)
+			return false;
+		if (x.IsProperty != y.IsProperty)
+			return false;
+		if (x.IsStatic != y.IsStatic)
+			return false;
+		if (x.Name != y.Name)
+			return false;
+		if (x.Selector != y.Selector)
+			return false;
+		if (!typeComparer.Equals (x.ReturnType, y.ReturnType))
+			return false;
+		if (x.ReturnTypeDelegateProxy?.FullyQualifiedName != y.ReturnTypeDelegateProxy?.FullyQualifiedName)
+			return false;
+		if (!x.ParameterType.SequenceEqual (y.ParameterType, (l , r) => typeComparer.Equals (l, r)))
+			return false;
+		if (!x.ParameterByRef.SequenceEqual (y.ParameterByRef))
+			return false;
+		if (!x.ParameterBlockProxy.SequenceEqual (y.ParameterBlockProxy, (l , r) => typeComparer.Equals (l, r)))
+			return false;
+		if (x.IsVariadic != y.IsVariadic)
+			return false;
+		if (!typeComparer.Equals (x.PropertyType, y.PropertyType))
+			return false;
+		if (x.GetterSelector != y.GetterSelector)
+			return false;
+		if (x.SetterSelector != y.SetterSelector)
+			return false;
+		if (x.ArgumentSemantic != y.ArgumentSemantic)
+			return false;
+		return true;
+	}
+
+	/// <summary>
+	/// Returns a hash code for the specified <see cref="ProtocolMemberData"/>.
+	/// </summary>
+	/// <param name="obj">The <see cref="ProtocolMemberData"/> for which a hash code is to be returned.</param>
+	/// <returns>A hash code for the specified object.</returns>
+	public int GetHashCode(ProtocolMemberData obj)
+	{
+		var hashCode = new HashCode();
+		hashCode.Add(obj.IsRequired);
+		hashCode.Add(obj.IsProperty);
+		hashCode.Add(obj.IsStatic);
+		hashCode.Add(obj.Name);
+		hashCode.Add(obj.Selector);
+		hashCode.Add(obj.ReturnType);
+		hashCode.Add(obj.ReturnTypeDelegateProxy);
+		hashCode.Add(obj.ParameterType);
+		hashCode.Add(obj.ParameterByRef);
+		hashCode.Add(obj.ParameterBlockProxy);
+		hashCode.Add(obj.IsVariadic);
+		hashCode.Add(obj.PropertyType);
+		hashCode.Add(obj.GetterSelector);
+		hashCode.Add(obj.SetterSelector);
+		hashCode.Add((int)obj.ArgumentSemantic);
+		return hashCode.ToHashCode();
+	}
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
@@ -544,6 +544,8 @@ static class TestDataFactory {
 			isReferenceType: true
 		) {
 			IsDelegate = true,
+			IsGenericType = parameters.Length > 0,
+			TypeArguments = [..parameters],
 			Delegate = delegateInfo,
 			Parents = [
 				"System.MulticastDelegate",
@@ -553,7 +555,7 @@ static class TestDataFactory {
 			Interfaces = [
 				"System.ICloneable",
 				"System.Runtime.Serialization.ISerializable",
-			]
+			],
 		};
 
 	public static TypeInfo ReturnTypeForFunc (DelegateInfo? delegateInfo = null, params string [] parameters)

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
@@ -545,7 +545,7 @@ static class TestDataFactory {
 		) {
 			IsDelegate = true,
 			IsGenericType = parameters.Length > 0,
-			TypeArguments = [..parameters],
+			TypeArguments = [.. parameters],
 			Delegate = delegateInfo,
 			Parents = [
 				"System.MulticastDelegate",

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TypeInfoCustomEqualityComparer.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TypeInfoCustomEqualityComparer.cs
@@ -8,8 +8,18 @@ using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
 
 namespace Microsoft.Macios.Generator.Tests;
 
+/// <summary>
+/// Custom equality comparer for <see cref="TypeInfo"/> used in tests.
+/// Performs comparison based on the fully qualified names of types rather than reference equality.
+/// </summary>
 class TypeInfoCustomEqualityComparer : IEqualityComparer<TypeInfo?>{
 	
+	/// <summary>
+	/// Determines whether the specified <see cref="TypeInfo"/> objects are equal.
+	/// </summary>
+	/// <param name="x">The first <see cref="TypeInfo"/> to compare.</param>
+	/// <param name="y">The second <see cref="TypeInfo"/> to compare.</param>
+	/// <returns><c>true</c> if the specified objects are equal; otherwise, <c>false</c>.</returns>
 	public bool Equals (TypeInfo? x, TypeInfo? y)
 	{
 		if (x is null)
@@ -22,8 +32,16 @@ class TypeInfoCustomEqualityComparer : IEqualityComparer<TypeInfo?>{
 		return x?.FullyQualifiedName == y?.FullyQualifiedName;
 	}
 
+	/// <summary>
+	/// Returns a hash code for the specified <see cref="TypeInfo"/>.
+	/// </summary>
+	/// <param name="obj">The <see cref="TypeInfo"/> for which a hash code is to be returned.</param>
+	/// <returns>A hash code for the specified object.</returns>
 	public int GetHashCode ([DisallowNull] TypeInfo? obj)
 	{
-		throw new System.NotImplementedException();
+		if (obj.Value.SpecialType == SpecialType.System_Void)
+			return SpecialType.System_Void.GetHashCode ();
+		
+		return obj.Value.FullyQualifiedName?.GetHashCode () ?? 0;
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TypeInfoCustomEqualityComparer.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TypeInfoCustomEqualityComparer.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
+
+namespace Microsoft.Macios.Generator.Tests;
+
+class TypeInfoCustomEqualityComparer : IEqualityComparer<TypeInfo?>{
+	
+	public bool Equals (TypeInfo? x, TypeInfo? y)
+	{
+		if (x is null)
+			return y is null;
+		if (y is null)
+			return false;
+		if (x.Value.SpecialType == SpecialType.System_Void)
+			return y.Value.SpecialType == SpecialType.System_Void;
+		
+		return x?.FullyQualifiedName == y?.FullyQualifiedName;
+	}
+
+	public int GetHashCode ([DisallowNull] TypeInfo? obj)
+	{
+		throw new System.NotImplementedException();
+	}
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TypeInfoCustomEqualityComparer.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TypeInfoCustomEqualityComparer.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Macios.Generator.Tests;
 /// Custom equality comparer for <see cref="TypeInfo"/> used in tests.
 /// Performs comparison based on the fully qualified names of types rather than reference equality.
 /// </summary>
-class TypeInfoCustomEqualityComparer : IEqualityComparer<TypeInfo?>{
-	
+class TypeInfoCustomEqualityComparer : IEqualityComparer<TypeInfo?> {
+
 	/// <summary>
 	/// Determines whether the specified <see cref="TypeInfo"/> objects are equal.
 	/// </summary>
@@ -28,7 +28,7 @@ class TypeInfoCustomEqualityComparer : IEqualityComparer<TypeInfo?>{
 			return false;
 		if (x.Value.SpecialType == SpecialType.System_Void)
 			return y.Value.SpecialType == SpecialType.System_Void;
-		
+
 		return x?.FullyQualifiedName == y?.FullyQualifiedName;
 	}
 
@@ -41,7 +41,7 @@ class TypeInfoCustomEqualityComparer : IEqualityComparer<TypeInfo?>{
 	{
 		if (obj.Value.SpecialType == SpecialType.System_Void)
 			return SpecialType.System_Void.GetHashCode ();
-		
+
 		return obj.Value.FullyQualifiedName?.GetHashCode () ?? 0;
 	}
 }


### PR DESCRIPTION
Add a new structure that represents the data of the attr and several methods that allow to create the structure from the data found in a protocol declaration.

This changes will be used to create al the attrs needed by the static registrar in a protocol definition.