### PR TITLE
[RGen] Refactor EmitMethods to allow to emit a single method.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitterExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitterExtensions.cs
@@ -4,6 +4,7 @@
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.Context;
 using Microsoft.Macios.Generator.DataModel;
 using Microsoft.Macios.Generator.Extensions;
@@ -168,6 +169,68 @@ if (IsDirectBinding) {{
 	}
 
 	/// <summary>
+	/// Emits the code for a given method, including its async version if applicable.
+	/// </summary>
+	/// <param name="self">The class emitter.</param>
+	/// <param name="context">The current binding context.</param>
+	/// <param name="method">The method to emit.</param>
+	/// <param name="classBlock">The current class block writer.</param>
+	/// <param name="uiThreadCheck">An optional UI thread check expression. If not provided, it will be created based on the context.</param>
+	public static void EmitMethod (this IClassEmitter self, in BindingContext context, in Method method,
+		TabbedWriter<StringWriter> classBlock, ExpressionStatementSyntax? uiThreadCheck = null)
+	{
+
+		// if not passed as an argument, we will create the ui thread check based on the context
+		if (uiThreadCheck is null) {
+			uiThreadCheck = (context.NeedsThreadChecks)
+				? EnsureUiThread (context.RootContext.CurrentPlatform)
+				: null;
+		}
+
+		classBlock.WriteLine ();
+		classBlock.AppendMemberAvailability (method.SymbolAvailability);
+		classBlock.AppendGeneratedCodeAttribute (optimizable: true);
+
+		using (var methodBlock = classBlock.CreateBlock (method.ToDeclaration ().ToString (), block: true)) {
+			// write any possible thread check at the beginning of the method
+			if (uiThreadCheck is not null) {
+				methodBlock.WriteLine (uiThreadCheck.ToString ());
+				methodBlock.WriteLine ();
+			}
+
+			// retrieve the method invocation via the factory, this will generate the necessary arguments
+			// transformations and the invocation
+			var invocations = GetInvocations (method);
+
+			if (method.ReturnType.IsVoid) {
+				EmitVoidMethodBody (method, invocations, methodBlock);
+			} else {
+				EmitReturnMethodBody (method, invocations, methodBlock);
+			}
+		}
+
+		if (!method.IsAsync)
+			return;
+
+		// if the method is an async method, generate its async version
+		classBlock.WriteLine ();
+		classBlock.AppendMemberAvailability (method.SymbolAvailability);
+		classBlock.AppendGeneratedCodeAttribute (optimizable: true);
+
+		var asyncMethod = method.ToAsync ();
+		using (var methodBlock = classBlock.CreateBlock (asyncMethod.ToDeclaration ().ToString (), block: true)) {
+			// we need to create the tcs for the the async method
+			var tcsType = asyncMethod.ReturnType.ToTaskCompletionSource ();
+			var tcsName = Nomenclator.GetTaskCompletionSourceName ();
+			methodBlock.WriteRaw (
+$@"{tcsType.GetIdentifierSyntax ()} {tcsName} = new ();
+{ExpressionStatement (ExecuteSyncCall (method))}
+return {tcsName}.Task;
+");
+		}
+	}
+
+	/// <summary>
 	/// Emit the code for all the methods in the class.
 	/// </summary>
 	/// <param name="context">The current binding context.</param>
@@ -177,47 +240,7 @@ if (IsDirectBinding) {{
 		var uiThreadCheck = (context.NeedsThreadChecks)
 			? EnsureUiThread (context.RootContext.CurrentPlatform) : null;
 		foreach (var method in context.Changes.Methods.OrderBy (m => m.Name)) {
-			classBlock.WriteLine ();
-			classBlock.AppendMemberAvailability (method.SymbolAvailability);
-			classBlock.AppendGeneratedCodeAttribute (optimizable: true);
-
-			using (var methodBlock = classBlock.CreateBlock (method.ToDeclaration ().ToString (), block: true)) {
-				// write any possible thread check at the beginning of the method
-				if (uiThreadCheck is not null) {
-					methodBlock.WriteLine (uiThreadCheck.ToString ());
-					methodBlock.WriteLine ();
-				}
-
-				// retrieve the method invocation via the factory, this will generate the necessary arguments
-				// transformations and the invocation
-				var invocations = GetInvocations (method);
-
-				if (method.ReturnType.IsVoid) {
-					EmitVoidMethodBody (method, invocations, methodBlock);
-				} else {
-					EmitReturnMethodBody (method, invocations, methodBlock);
-				}
-			}
-
-			if (!method.IsAsync)
-				continue;
-
-			// if the method is an async method, generate its async version
-			classBlock.WriteLine ();
-			classBlock.AppendMemberAvailability (method.SymbolAvailability);
-			classBlock.AppendGeneratedCodeAttribute (optimizable: true);
-
-			var asyncMethod = method.ToAsync ();
-			using (var methodBlock = classBlock.CreateBlock (asyncMethod.ToDeclaration ().ToString (), block: true)) {
-				// we need to create the tcs for the the async method
-				var tcsType = asyncMethod.ReturnType.ToTaskCompletionSource ();
-				var tcsName = Nomenclator.GetTaskCompletionSourceName ();
-				methodBlock.WriteRaw (
-$@"{tcsType.GetIdentifierSyntax ()} {tcsName} = new ();
-{ExpressionStatement (ExecuteSyncCall (method))}
-return {tcsName}.Task;
-");
-			}
+			EmitMethod (self, context, method, classBlock, uiThreadCheck);
 		}
 	}
 


### PR DESCRIPTION
This will come useful when we want to emit protocols in such a way that we have:

- Getter method
- Setter method
- Property

This way we mimic the way bgen generates this methods.