### PR TITLE
[RGen] Remove boxing of Nullable<FieldInfo> in properties.

### DIFF
--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Microsoft.Macios.Bindings.Analyzer.csproj
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Microsoft.Macios.Bindings.Analyzer.csproj
@@ -45,6 +45,9 @@
         <Compile Include="../Microsoft.Macios.Generator/DictionaryComparer.cs" >
             <Link>Generator/DictionaryComparer.cs</Link>
         </Compile>
+        <Compile Include="../Microsoft.Macios.Generator/StructState.cs" >
+            <Link>Generator/StructState.cs</Link>
+        </Compile>
         <Compile Include="../Microsoft.Macios.Generator/Attributes/BindFromData.cs" >
             <Link>Generator/Attributes/BindFromData.cs</Link>
         </Compile>
@@ -71,9 +74,6 @@
         </Compile>
         <Compile Include="../Microsoft.Macios.Generator/Attributes/UnsupportedOSPlatformData.cs" >
             <Link>Generator/Attributes/UnsupportedOSPlatformData.cs</Link>
-        </Compile>
-        <Compile Include="../Microsoft.Macios.Generator/DataModel/StructState.cs" >
-            <Link>DataModel/StructState.cs</Link>
         </Compile>
         <Compile Include="../Microsoft.Macios.Generator/DataModel/AttributeCodeChange.cs" >
             <Link>DataModel/AttributeCodeChange.cs</Link>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Binding.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Binding.Generator.cs
@@ -55,9 +55,9 @@ readonly partial struct Binding {
 
 			// return those libs needed by field properties
 			foreach (var property in Properties) {
-				if (property.ExportFieldData is null)
+				if (property.ExportFieldData.IsNullOrDefault)
 					continue;
-				var (_, libraryName, libraryPath) = property.ExportFieldData.Value;
+				var (_, libraryName, libraryPath) = property.ExportFieldData;
 				if (visited.Add (libraryName)) // if already visited, we cannot add it
 					yield return (libraryName, libraryPath);
 			}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/FieldInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/FieldInfo.cs
@@ -12,6 +12,20 @@ namespace Microsoft.Macios.Generator.DataModel;
 /// </summary>
 readonly struct FieldInfo<T> : IEquatable<FieldInfo<T>> where T : Enum {
 
+	/// <summary>
+	/// The initialization state of the struct.
+	/// </summary>
+	StructState State { get; init; } = StructState.Default;
+
+	/// <summary>
+	/// Gets the default, uninitialized instance of <see cref="TypeInfo"/>.
+	/// </summary>
+	public static FieldInfo<T> Default { get; } = new (StructState.Default);
+
+	/// <summary>
+	/// Gets a value indicating whether the instance is the default, uninitialized instance.
+	/// </summary>
+	public bool IsNullOrDefault => State == StructState.Default;
 
 	/// <summary>
 	/// Name of the library that contains the smart enum definition.
@@ -28,13 +42,37 @@ readonly struct FieldInfo<T> : IEquatable<FieldInfo<T>> where T : Enum {
 	/// </summary>
 	public FieldData<T> FieldData { get; }
 
-	public FieldInfo (FieldData<T> fieldData, string libraryName, string? libraryPath = null)
+	/// <summary>
+	/// Initializes a new instance of the <see cref="FieldInfo{T}"/> struct.
+	/// </summary>
+	/// <param name="state">The initialization state.</param>
+	public FieldInfo (StructState state)
+	{
+		State = state;
+		LibraryName = string.Empty;
+		LibraryPath = null;
+		FieldData = default;
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="FieldInfo{T}"/> struct.
+	/// </summary>
+	/// <param name="fieldData">The field data.</param>
+	/// <param name="libraryName">The library name.</param>
+	/// <param name="libraryPath">The library path.</param>
+	public FieldInfo (FieldData<T> fieldData, string libraryName, string? libraryPath = null) : this (StructState.Initialized)
 	{
 		LibraryName = libraryName;
 		LibraryPath = libraryPath;
 		FieldData = fieldData;
 	}
 
+	/// <summary>
+	/// Deconstructs the <see cref="FieldInfo{T}"/> into its components.
+	/// </summary>
+	/// <param name="fieldData">The field data.</param>
+	/// <param name="libraryName">The library name.</param>
+	/// <param name="libraryPath">The library path.</param>
 	public void Deconstruct (out FieldData<T> fieldData, out string libraryName, out string? libraryPath)
 	{
 		fieldData = FieldData;
@@ -45,6 +83,8 @@ readonly struct FieldInfo<T> : IEquatable<FieldInfo<T>> where T : Enum {
 	/// <inheritdoc />
 	public bool Equals (FieldInfo<T> other)
 	{
+		if (State == StructState.Default && other.State == StructState.Default)
+			return true;
 		if (FieldData != other.FieldData)
 			return false;
 		if (LibraryName != other.LibraryName)
@@ -64,11 +104,23 @@ readonly struct FieldInfo<T> : IEquatable<FieldInfo<T>> where T : Enum {
 		return HashCode.Combine (FieldData, LibraryName, LibraryPath);
 	}
 
+	/// <summary>
+	/// Compares two <see cref="FieldInfo{T}"/> instances for equality.
+	/// </summary>
+	/// <param name="x">The first instance.</param>
+	/// <param name="y">The second instance.</param>
+	/// <returns><c>true</c> if the instances are equal, <c>false</c> otherwise.</returns>
 	public static bool operator == (FieldInfo<T> x, FieldInfo<T> y)
 	{
 		return x.Equals (y);
 	}
 
+	/// <summary>
+	/// Compares two <see cref="FieldInfo{T}"/> instances for inequality.
+	/// </summary>
+	/// <param name="x">The first instance.</param>
+	/// <param name="y">The second instance.</param>
+	/// <returns><c>true</c> if the instances are not equal, <c>false</c> otherwise.</returns>
 	public static bool operator != (FieldInfo<T> x, FieldInfo<T> y)
 	{
 		return !(x == y);
@@ -77,7 +129,7 @@ readonly struct FieldInfo<T> : IEquatable<FieldInfo<T>> where T : Enum {
 	/// <inheritdoc />
 	public override string ToString ()
 	{
-		return $"FieldData = {FieldData}, LibraryName = {LibraryName}, LibraryPath = {LibraryPath ?? "null"}";
+		return $"{{ State = {State}, FieldData = {FieldData}, LibraryName = {LibraryName}, LibraryPath = {LibraryPath ?? "null"} }}";
 	}
 
 }

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/FieldInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/FieldInfo.cs
@@ -18,7 +18,7 @@ readonly struct FieldInfo<T> : IEquatable<FieldInfo<T>> where T : Enum {
 	StructState State { get; init; } = StructState.Default;
 
 	/// <summary>
-	/// Gets the default, uninitialized instance of <see cref="TypeInfo"/>.
+	/// Gets the default, uninitialized instance of <see cref="FieldInfo{T}"/>.
 	/// </summary>
 	public static FieldInfo<T> Default { get; } = new (StructState.Default);
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
@@ -22,19 +22,18 @@ readonly partial struct Property {
 	/// <summary>
 	/// The data of the field attribute used to mark the value as a field binding. 
 	/// </summary>
-	public FieldInfo<ObjCBindings.Property>? ExportFieldData { get; init; }
+	public FieldInfo<ObjCBindings.Property> ExportFieldData { get; init; } = FieldInfo<ObjCBindings.Property>.Default;
 
 	/// <summary>
 	/// True if the property represents a Objc field.
 	/// </summary>
-	[MemberNotNullWhen (true, nameof (ExportFieldData))]
-	public bool IsField => ExportFieldData is not null;
+	public bool IsField => !ExportFieldData.IsNullOrDefault;
 
 	/// <summary>
 	/// Returns if the field was marked as a notification.
 	/// </summary>
 	public bool IsNotification
-		=> IsField && ExportFieldData.Value.FieldData.Flags.HasFlag (ObjCBindings.Property.Notification);
+		=> IsField && ExportFieldData.FieldData.Flags.HasFlag (ObjCBindings.Property.Notification);
 
 	/// <summary>
 	/// The data of the field attribute used to mark the value as a property binding. 
@@ -188,7 +187,7 @@ readonly partial struct Property {
 	public string? Selector {
 		get {
 			if (IsField) {
-				return ExportFieldData.Value.FieldData.SymbolName;
+				return ExportFieldData.FieldData.SymbolName;
 			}
 			if (IsProperty) {
 				return ExportPropertyData.Value.Selector;
@@ -279,7 +278,7 @@ readonly partial struct Property {
 			accessors: accessorCodeChanges) {
 			BindAs = propertySymbol.GetBindFromData (),
 			ForcedType = propertySymbol.GetForceTypeData (),
-			ExportFieldData = GetFieldInfo (context, propertySymbol),
+			ExportFieldData = GetFieldInfo (context, propertySymbol) ?? FieldInfo<ObjCBindings.Property>.Default,
 			ExportPropertyData = propertySymbol.GetExportData<ObjCBindings.Property> (),
 			ExportStrongPropertyData = propertySymbol.GetExportData<ObjCBindings.StrongDictionaryProperty> (),
 		};
@@ -365,8 +364,9 @@ readonly partial struct Property {
 	/// <inheritdoc />
 	public override string ToString ()
 	{
+		var fieldInfo = ExportFieldData.IsNullOrDefault ? "null" : ExportFieldData.ToString ();
 		var sb = new StringBuilder (
-			$"Name: '{Name}', Type: {ReturnType}, Supported Platforms: {SymbolAvailability}, ExportFieldData: '{ExportFieldData?.ToString () ?? "null"}', ExportPropertyData: '{ExportPropertyData?.ToString () ?? "null"}', ");
+			$"Name: '{Name}', Type: {ReturnType}, Supported Platforms: {SymbolAvailability}, ExportFieldData: '{fieldInfo}', ExportPropertyData: '{ExportPropertyData?.ToString () ?? "null"}', ");
 		sb.Append ($"IsTransient: '{IsTransient}', ");
 		sb.Append ($"NeedsBackingField: '{NeedsBackingField}', ");
 		sb.Append ($"RequiresDirtyCheck: '{RequiresDirtyCheck}', ");

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
@@ -670,8 +670,8 @@ static partial class BindingSyntaxFactory {
 			throw new NotSupportedException ("Cannot retrieve getter for non field property.");
 
 		// retrieve all the necessary data from the info field of the property
-		var libraryName = property.ExportFieldData.Value.LibraryName;
-		var symbolName = property.ExportFieldData.Value.FieldData.SymbolName;
+		var libraryName = property.ExportFieldData.LibraryName;
+		var symbolName = property.ExportFieldData.FieldData.SymbolName;
 		return FieldConstantGetterSetter (property).Getter (libraryName, symbolName);
 	}
 
@@ -692,8 +692,8 @@ static partial class BindingSyntaxFactory {
 			throw new NotSupportedException ("Cannot retrieve getter for non field property.");
 
 		// retrieve all the necessary data from the info field of the property
-		var libraryName = property.ExportFieldData.Value.LibraryName;
-		var symbolName = property.ExportFieldData.Value.FieldData.SymbolName;
+		var libraryName = property.ExportFieldData.LibraryName;
+		var symbolName = property.ExportFieldData.FieldData.SymbolName;
 		return FieldConstantGetterSetter (property).Setter (libraryName, symbolName, variableName);
 	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
@@ -294,8 +294,12 @@ if (!(value is null) && rvalue is null) {{
 			foreach (var notification in properties) {
 				var count = 12; // == "Notification".Length;
 				var name = $"Observe{notification.Name [..^count]}";
-				var notificationCenter = notification.ExportFieldData?.FieldData.NotificationCenter ?? $"{NotificationCenter}.DefaultCenter";
-				var eventType = notification.ExportFieldData?.FieldData.Type ?? NSNotificationEventArgs.ToString ();
+				var notificationCenter = notification.ExportFieldData.IsNullOrDefault || notification.ExportFieldData.FieldData.NotificationCenter is null
+					? $"{NotificationCenter}.DefaultCenter"
+					: notification.ExportFieldData.FieldData.NotificationCenter;
+				var eventType = notification.ExportFieldData.IsNullOrDefault || notification.ExportFieldData.FieldData.Type is null
+					? NSNotificationEventArgs.ToString ()
+					: notification.ExportFieldData.FieldData.Type;
 				// use the raw writer which makes it easier to read in this case
 				notificationClass.WriteRaw (
 @$"public static {NSObject} {name} ({EventHandler}<{eventType}> handler)

--- a/src/rgen/Microsoft.Macios.Generator/StructState.cs
+++ b/src/rgen/Microsoft.Macios.Generator/StructState.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace Microsoft.Macios.Generator.DataModel;
+namespace Microsoft.Macios.Generator;
 
 /// <summary>
 /// Represents the initialization state of a struct.

--- a/src/rgen/Microsoft.Macios.Transformer/Microsoft.Macios.Transformer.csproj
+++ b/src/rgen/Microsoft.Macios.Transformer/Microsoft.Macios.Transformer.csproj
@@ -44,6 +44,9 @@
         <Compile Include="../Microsoft.Macios.Generator/CollectionComparer.cs">
             <Link>CollectionComparer.cs</Link>
         </Compile>
+        <Compile Include="../Microsoft.Macios.Generator/StructState.cs" >
+            <Link>Generator/StructState.cs</Link>
+        </Compile>
         <Compile Include="../Microsoft.Macios.Generator/IO/TabbedWriter.cs">
             <Link>IO/TabbedWriter.cs</Link>
         </Compile>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumMemberCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumMemberCodeChangesTests.cs
@@ -279,7 +279,7 @@ public class EnumMemberCodeChangesTests {
 				attributes: []);
 			yield return [
 				fieldDataEnum,
-				"{ Name: 'EnumValue' SymbolAvailability: [] FieldInfo: FieldData = { SymbolName: 'x', LibraryName: 'libName', Type: 'null', NotificationCenter: 'null', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library Attributes: [] }",
+				"{ Name: 'EnumValue' SymbolAvailability: [] FieldInfo: { State = Initialized, FieldData = { SymbolName: 'x', LibraryName: 'libName', Type: 'null', NotificationCenter: 'null', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library } Attributes: [] }",
 			];
 
 			var builder = SymbolAvailability.CreateBuilder ();
@@ -294,7 +294,7 @@ public class EnumMemberCodeChangesTests {
 				attributes: []);
 			yield return [
 				availabilityEnum,
-				"{ Name: 'EnumValue' SymbolAvailability: [{ Platform: 'iOS', Supported: '0.0', Unsupported: [], Obsoleted: [] }] FieldInfo: FieldData = { SymbolName: 'x', LibraryName: 'libName', Type: 'null', NotificationCenter: 'null', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library Attributes: [] }",
+				"{ Name: 'EnumValue' SymbolAvailability: [{ Platform: 'iOS', Supported: '0.0', Unsupported: [], Obsoleted: [] }] FieldInfo: { State = Initialized, FieldData = { SymbolName: 'x', LibraryName: 'libName', Type: 'null', NotificationCenter: 'null', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library } Attributes: [] }",
 			];
 
 			var attrsEnum = new EnumMember (
@@ -309,7 +309,7 @@ public class EnumMemberCodeChangesTests {
 				]);
 			yield return [
 				attrsEnum,
-				"{ Name: 'EnumValue' SymbolAvailability: [{ Platform: 'iOS', Supported: '0.0', Unsupported: [], Obsoleted: [] }] FieldInfo: FieldData = { SymbolName: 'x', LibraryName: 'libName', Type: 'null', NotificationCenter: 'null', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library Attributes: [{ Name: Attribute1, Arguments: [] }, { Name: Attribute2, Arguments: [] }] }",
+				"{ Name: 'EnumValue' SymbolAvailability: [{ Platform: 'iOS', Supported: '0.0', Unsupported: [], Obsoleted: [] }] FieldInfo: { State = Initialized, FieldData = { SymbolName: 'x', LibraryName: 'libName', Type: 'null', NotificationCenter: 'null', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library } Attributes: [{ Name: Attribute1, Arguments: [] }, { Name: Attribute2, Arguments: [] }] }",
 			];
 		}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests/GeneralPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests/GeneralPropertyTests.cs
@@ -28,7 +28,7 @@ public class GeneralPropertyTests {
 			modifiers: [Token (SyntaxKind.StaticKeyword)],
 			accessors: []
 		) {
-			ExportFieldData = new ()
+			ExportFieldData = new (StructState.Initialized)
 		};
 		Assert.Equal ($"_{propertyName}", property.BackingField);
 	}
@@ -47,7 +47,7 @@ public class GeneralPropertyTests {
 			modifiers: isStatic ? [Token (SyntaxKind.StaticKeyword)] : [],
 			accessors: []
 		) {
-			ExportFieldData = null,
+			ExportFieldData = FieldInfo<ObjCBindings.Property>.Default,
 		};
 		Assert.Equal (Nomenclator.GetPropertyBackingFieldName (propertyName, isStatic), property.BackingField);
 	}


### PR DESCRIPTION
Remove the need to create a heap Nullable object for the FieldInfo attribute in properties, this is done to reduce the GC pressure and improve performance. A follow up PR will do the same for the ExportData attr.