### PR TITLE
[RGen] Remove the boxing of the ExportData in properties.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Attributes/ExportData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/ExportData.cs
@@ -15,6 +15,21 @@ namespace Microsoft.Macios.Generator.Attributes;
 /// </summary>
 /// <typeparam name="T">The configuration flags used on the exported element.</typeparam>
 readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
+	
+	/// <summary>
+	/// The initialization state of the struct.
+	/// </summary>
+	StructState State { get; init; } = StructState.Default;
+
+	/// <summary>
+	/// Gets the default, uninitialized instance of <see cref="ExportData{T}"/>.
+	/// </summary>
+	public static ExportData<T> Default { get; } = new (StructState.Default);
+
+	/// <summary>
+	/// Gets a value indicating whether the instance is the default, uninitialized instance.
+	/// </summary>
+	public bool IsNullOrDefault => State == StructState.Default;
 
 	/// <summary>
 	/// The exported native selector.
@@ -24,7 +39,7 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 	/// <summary>
 	/// The configuration flags used on the exported member.
 	/// </summary>
-	public T? Flags { get; init; }
+	public T Flags { get; init; }
 
 	/// <summary>
 	/// Argument semantics to use with the selector.
@@ -90,20 +105,50 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 	/// </summary>
 	public TypeInfo StrongDictionaryKeyClass { get; init; } = TypeInfo.Default;
 
-	public ExportData () { }
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ExportData{T}"/> struct.
+	/// </summary>
+	public ExportData () : this (StructState.Initialized) { }
 
-	public ExportData (string? selector)
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ExportData{T}"/> struct.
+	/// </summary>
+	/// <param name="state">The initialization state.</param>
+	public ExportData (StructState state)
 	{
-		Selector = selector;
+		State = state;
+		Flags = default!;
 	}
 
-	public ExportData (string? selector, ArgumentSemantic argumentSemantic)
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ExportData{T}"/> struct.
+	/// </summary>
+	/// <param name="selector">The exported native selector.</param>
+	public ExportData (string? selector) : this (StructState.Initialized)
+	{
+		Selector = selector;
+		Flags = default!;
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ExportData{T}"/> struct.
+	/// </summary>
+	/// <param name="selector">The exported native selector.</param>
+	/// <param name="argumentSemantic">Argument semantics to use with the selector.</param>
+	public ExportData (string? selector, ArgumentSemantic argumentSemantic) : this (StructState.Initialized)
 	{
 		Selector = selector;
 		ArgumentSemantic = argumentSemantic;
+		Flags = default!;
 	}
 
-	public ExportData (string? selector, ArgumentSemantic argumentSemantic, T flags)
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ExportData{T}"/> struct.
+	/// </summary>
+	/// <param name="selector">The exported native selector.</param>
+	/// <param name="argumentSemantic">Argument semantics to use with the selector.</param>
+	/// <param name="flags">The configuration flags used on the exported member.</param>
+	public ExportData (string? selector, ArgumentSemantic argumentSemantic, T flags) : this (StructState.Initialized)
 	{
 		Selector = selector;
 		ArgumentSemantic = argumentSemantic;
@@ -121,7 +166,7 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 	{
 		data = null;
 		var count = attributeData.ConstructorArguments.Length;
-		string? selector = null;
+		string? selector;
 		ArgumentSemantic argumentSemantic = ArgumentSemantic.None;
 		T? flags = default;
 
@@ -281,6 +326,8 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 	/// <inheritdoc />
 	public bool Equals (ExportData<T> other)
 	{
+		if (State == StructState.Default && other.State == StructState.Default)
+			return true;
 		if (Selector != other.Selector)
 			return false;
 		if (ArgumentSemantic != other.ArgumentSemantic)
@@ -305,7 +352,7 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 			(null, null) => true,
 			(null, _) => false,
 			(_, null) => false,
-			(_, _) => Flags!.Equals (other.Flags)
+			(_, _) => Flags.Equals (other.Flags)
 		};
 	}
 
@@ -321,11 +368,23 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 		return HashCode.Combine (Selector, Flags);
 	}
 
+	/// <summary>
+	/// Compares two <see cref="ExportData{T}"/> instances for equality.
+	/// </summary>
+	/// <param name="x">The first instance.</param>
+	/// <param name="y">The second instance.</param>
+	/// <returns><c>true</c> if the instances are equal, <c>false</c> otherwise.</returns>
 	public static bool operator == (ExportData<T> x, ExportData<T> y)
 	{
 		return x.Equals (y);
 	}
 
+	/// <summary>
+	/// Compares two <see cref="ExportData{T}"/> instances for inequality.
+	/// </summary>
+	/// <param name="x">The first instance.</param>
+	/// <param name="y">The second instance.</param>
+	/// <returns><c>true</c> if the instances are not equal, <c>false</c> otherwise.</returns>
 	public static bool operator != (ExportData<T> x, ExportData<T> y)
 	{
 		return !(x == y);

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/ProtocolMemberData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/ProtocolMemberData.cs
@@ -114,7 +114,9 @@ readonly struct ProtocolMemberData : IEquatable<ProtocolMemberData> {
 		PropertyType = property.ReturnType.WithNullable (isNullable: false);
 		GetterSelector = getter?.Selector;
 		SetterSelector = setter?.Selector;
-		ArgumentSemantic = property.ExportPropertyData?.ArgumentSemantic ?? ArgumentSemantic.None;
+		ArgumentSemantic = property.ExportPropertyData.IsNullOrDefault
+			? ArgumentSemantic.None
+			: property.ExportPropertyData.ArgumentSemantic;
 		ReturnTypeDelegateProxy = property.ReturnType.IsDelegate
 			? TypeInfo.CreateDelegateProxy (property.ReturnType)
 			: null;

--- a/src/rgen/Microsoft.Macios.Generator/Configuration.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Configuration.cs
@@ -9,7 +9,7 @@ public static class GeneratorConfiguration {
 	/// Use the global namespace for the generated code.
 	/// </summary>
 	public const bool UseGlobalNamespace = true;
-
+	
 	/// <summary>
 	/// Generate code compatible with bgen output for backward compatibility.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Event.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Event.Generator.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Context;
 using Microsoft.Macios.Generator.Extensions;
 
@@ -36,7 +37,7 @@ readonly partial struct Event {
 				accessorsBucket.Add (new (
 					accessorKind: kind,
 					symbolAvailability: accessorSymbol.GetSupportedPlatforms (),
-					exportPropertyData: null,
+					exportPropertyData: ExportData<ObjCBindings.Property>.Default, 
 					attributes: accessorAttributeChanges,
 					modifiers: [.. accessorDeclaration.Modifiers]));
 			}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
@@ -38,13 +38,13 @@ readonly partial struct Property {
 	/// <summary>
 	/// The data of the field attribute used to mark the value as a property binding. 
 	/// </summary>
-	public ExportData<ObjCBindings.Property>? ExportPropertyData { get; init; }
+	public ExportData<ObjCBindings.Property> ExportPropertyData { get; init; } = ExportData<ObjCBindings.Property>.Default;
 
 	/// <summary>
 	/// True if the property represents a Objc property.
 	/// </summary>
-	[MemberNotNullWhen (true, nameof (ExportPropertyData))]
-	public bool IsProperty => ExportPropertyData is not null;
+	[MemberNotNullWhen (true, nameof(ExportPropertyData))]
+	public bool IsProperty => !ExportPropertyData.IsNullOrDefault;
 
 	/// <summary>
 	/// The data of the export attribute used to mark the value as a strong dictionary property binding.
@@ -75,13 +75,13 @@ readonly partial struct Property {
 	/// Returns if the property was marked as thread safe.
 	/// </summary>
 	public bool IsThreadSafe =>
-		IsProperty && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.IsThreadSafe);
+		IsProperty && ExportPropertyData.Flags.HasFlag (ObjCBindings.Property.IsThreadSafe);
 
 	/// <summary>
 	/// True if the method was exported with the MarshalNativeExceptions flag allowing it to support native exceptions.
 	/// </summary>
 	public bool MarshalNativeExceptions
-		=> IsProperty && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.MarshalNativeExceptions);
+		=> IsProperty && ExportPropertyData.Flags.HasFlag (ObjCBindings.Property.MarshalNativeExceptions);
 
 	/// <summary>
 	/// Returns the bind from data if present in the binding.
@@ -96,51 +96,51 @@ readonly partial struct Property {
 	/// <summary>
 	/// True if the property should be generated without a backing field.
 	/// </summary>
-	public bool IsTransient => IsProperty && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.Transient);
+	public bool IsTransient => IsProperty && ExportPropertyData.Flags.HasFlag (ObjCBindings.Property.Transient);
 
 	/// <summary>
 	/// True if the property was marked to DisableZeroCopy.
 	/// </summary>
 	public bool DisableZeroCopy
-		=> IsProperty && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.DisableZeroCopy);
+		=> IsProperty && ExportPropertyData.Flags.HasFlag (ObjCBindings.Property.DisableZeroCopy);
 
 	/// <summary>
 	/// True if the generator should not use a NSString for marshalling.
 	/// </summary>
 	public bool UsePlainString
-		=> IsProperty && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.PlainString);
+		=> IsProperty && ExportPropertyData.Flags.HasFlag (ObjCBindings.Property.PlainString);
 
 	/// <summary>
 	/// Return if the method invocation should be wrapped by a NSAutoReleasePool.
 	/// </summary>
-	public bool AutoRelease => IsProperty && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.AutoRelease);
+	public bool AutoRelease => IsProperty && ExportPropertyData.Flags.HasFlag (ObjCBindings.Property.AutoRelease);
 
 	/// <summary>
 	/// True if the generated code should retain the return value.
 	/// </summary>
 	public bool RetainReturnValue
-		=> IsProperty && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.RetainReturnValue);
+		=> IsProperty && ExportPropertyData.Flags.HasFlag (ObjCBindings.Property.RetainReturnValue);
 
 	/// <summary>
 	/// True if the generated code should release the return value.
 	/// </summary>
 	public bool ReleaseReturnValue
-		=> IsProperty && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.ReleaseReturnValue);
+		=> IsProperty && ExportPropertyData.Flags.HasFlag (ObjCBindings.Property.ReleaseReturnValue);
 
 	/// <summary>
 	/// True if the return type of the method was returned as a proxy object.
 	/// </summary>
-	public bool IsProxy => IsProperty && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.Proxy);
+	public bool IsProxy => IsProperty && ExportPropertyData.Flags.HasFlag (ObjCBindings.Property.Proxy);
 
 	/// <summary>
 	/// True if the property was marked as a weak delegate.
 	/// </summary>
-	public bool IsWeakDelegate => IsProperty && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.WeakDelegate);
+	public bool IsWeakDelegate => IsProperty && ExportPropertyData.Flags.HasFlag (ObjCBindings.Property.WeakDelegate);
 
 	/// <summary>
 	/// States if a property is optional in a protocol definition.
 	/// </summary>
-	public bool IsOptional => IsProperty && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.Optional);
+	public bool IsOptional => IsProperty && ExportPropertyData.Flags.HasFlag (ObjCBindings.Property.Optional);
 
 	readonly bool? needsBackingField = null;
 	/// <summary>
@@ -168,7 +168,7 @@ readonly partial struct Property {
 				return requiresDirtyCheck.Value;
 			if (!IsProperty)
 				return false;
-			switch (ExportPropertyData.Value.ArgumentSemantic) {
+			switch (ExportPropertyData.ArgumentSemantic) {
 			case ArgumentSemantic.Copy:
 			case ArgumentSemantic.Retain:
 			case ArgumentSemantic.None:
@@ -190,7 +190,7 @@ readonly partial struct Property {
 				return ExportFieldData.FieldData.SymbolName;
 			}
 			if (IsProperty) {
-				return ExportPropertyData.Value.Selector;
+				return ExportPropertyData.Selector;
 			}
 			return null;
 		}
@@ -249,7 +249,7 @@ readonly partial struct Property {
 					accessorDeclaration.GetAttributeCodeChanges (context.SemanticModel);
 				accessorsBucket.Add (new (
 					accessorKind: kind,
-					exportPropertyData: accessorSymbol.GetExportData<ObjCBindings.Property> (),
+					exportPropertyData: accessorSymbol.GetExportData<ObjCBindings.Property> () ?? ExportData<ObjCBindings.Property>.Default,
 					symbolAvailability: accessorSymbol.GetSupportedPlatforms (),
 					attributes: accessorAttributeChanges,
 					modifiers: [.. accessorDeclaration.Modifiers]));
@@ -264,7 +264,7 @@ readonly partial struct Property {
 			accessorCodeChanges = [new (
 				accessorKind: AccessorKind.Getter,
 				symbolAvailability: propertySupportedPlatforms,
-				exportPropertyData: null,
+				exportPropertyData: ExportData<ObjCBindings.Property>.Default, 
 				attributes: [],
 				modifiers: [])
 			];
@@ -279,7 +279,7 @@ readonly partial struct Property {
 			BindAs = propertySymbol.GetBindFromData (),
 			ForcedType = propertySymbol.GetForceTypeData (),
 			ExportFieldData = GetFieldInfo (context, propertySymbol) ?? FieldInfo<ObjCBindings.Property>.Default,
-			ExportPropertyData = propertySymbol.GetExportData<ObjCBindings.Property> (),
+			ExportPropertyData = propertySymbol.GetExportData<ObjCBindings.Property> () ?? ExportData<ObjCBindings.Property>.Default,
 			ExportStrongPropertyData = propertySymbol.GetExportData<ObjCBindings.StrongDictionaryProperty> (),
 		};
 		return true;
@@ -305,13 +305,13 @@ readonly partial struct Property {
 	public Property ToStrongDelegate ()
 	{
 		// has to be a property, weak delegate and have its strong delegate type set
-		if (!IsProperty || !IsWeakDelegate || ExportPropertyData.Value.StrongDelegateType.IsNullOrDefault)
+		if (!IsProperty || !IsWeakDelegate || ExportPropertyData.StrongDelegateType.IsNullOrDefault)
 			return this;
 
 		// update the return type, all the rest is the same
 		return this with {
-			Name = ExportPropertyData.Value.StrongDelegateName ?? Name.Remove (0, 4 /* "Weak".Length */),
-			ReturnType = ExportPropertyData.Value.StrongDelegateType.WithNullable (true),
+			Name = ExportPropertyData.StrongDelegateName ?? Name.Remove (0, 4 /* "Weak".Length */),
+			ReturnType = ExportPropertyData.StrongDelegateType.WithNullable (true),
 		};
 	}
 
@@ -365,8 +365,9 @@ readonly partial struct Property {
 	public override string ToString ()
 	{
 		var fieldInfo = ExportFieldData.IsNullOrDefault ? "null" : ExportFieldData.ToString ();
+		var propertyInfo = ExportPropertyData.IsNullOrDefault ? "null" : ExportPropertyData.ToString ();
 		var sb = new StringBuilder (
-			$"Name: '{Name}', Type: {ReturnType}, Supported Platforms: {SymbolAvailability}, ExportFieldData: '{fieldInfo}', ExportPropertyData: '{ExportPropertyData?.ToString () ?? "null"}', ");
+			$"Name: '{Name}', Type: {ReturnType}, Supported Platforms: {SymbolAvailability}, ExportFieldData: '{fieldInfo}', ExportPropertyData: '{propertyInfo}', ");
 		sb.Append ($"IsTransient: '{IsTransient}', ");
 		sb.Append ($"NeedsBackingField: '{NeedsBackingField}', ");
 		sb.Append ($"RequiresDirtyCheck: '{RequiresDirtyCheck}', ");

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -909,15 +909,11 @@ static partial class BindingSyntaxFactory {
 				withType: NativeHandle.WithTrailingTrivia ((Space))).WithModifiers (modifiers);
 	}
 
-	static string? GetObjCMessageSendMethodName<T> (ExportData<T> exportData,
+	static string GetObjCMessageSendMethodName<T> (ExportData<T> exportData,
 		in TypeInfo returnType, ImmutableArray<Parameter> parameters, bool isSuper = false, bool isStret = false)
 		where T : Enum
 	{
 		var flags = exportData.Flags;
-		if (flags is null)
-			// flags are not set, should be a bug, but we will return null
-			return null;
-
 		// the name of the objcSend method is calculated in the following way	
 		// {CustomMarshallPrefix}_{MarshallTypeOfReturnType}_{objcSendMsg}{stret?_stret}_{string.Join('_', MarshallTypeArgs)}{nativeException?_exception}{CustomMarsahllPostfix}
 		// we will use a sb to make things easy to follow

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Property.cs
@@ -27,9 +27,11 @@ static partial class BindingSyntaxFactory {
 			var getter = property.GetAccessor (AccessorKind.Getter);
 			string? getterMsgSend = null;
 			if (!getter.IsNullOrDefault) {
-				var getterExportData = getter.ExportPropertyData ?? property.ExportPropertyData;
-				if (getterExportData is not null) {
-					getterMsgSend = GetObjCMessageSendMethodName (getterExportData.Value, property.BindAs?.Type ?? property.ReturnType, [],
+				var getterExportData = getter.ExportPropertyData.IsNullOrDefault 
+					? property.ExportPropertyData 
+					: getter.ExportPropertyData;
+				if (!getterExportData.IsNullOrDefault) {
+					getterMsgSend = GetObjCMessageSendMethodName (getterExportData, property.BindAs?.Type ?? property.ReturnType, [],
 						isSuper, isStret);
 				}
 			}
@@ -42,9 +44,11 @@ static partial class BindingSyntaxFactory {
 				var valueParameter = property.BindAs is null
 					? property.ValueParameter
 					: new Parameter (0, property.BindAs.Value.Type, "value");
-				var setterExportData = setter.ExportPropertyData ?? property.ExportPropertyData;
-				if (setterExportData is not null) {
-					setterMsgSend = GetObjCMessageSendMethodName (setterExportData.Value, TypeInfo.Void,
+				var setterExportData = setter.ExportPropertyData.IsNullOrDefault 
+					? property.ExportPropertyData 
+					: setter.ExportPropertyData;
+				if (!setterExportData.IsNullOrDefault) {
+					setterMsgSend = GetObjCMessageSendMethodName (setterExportData, TypeInfo.Void,
 						[valueParameter], isSuper, isStret);
 				}
 			}

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
@@ -248,7 +248,7 @@ $@"if (IsDirectBinding) {{
 			// if the property is a weak delegate and has the strong delegate type set, we need to emit the
 			// strong delegate property
 			if (property is { IsProperty: true, IsWeakDelegate: true }
-				&& !property.ExportPropertyData.Value.StrongDelegateType.IsNullOrDefault) {
+				&& !property.ExportPropertyData.StrongDelegateType.IsNullOrDefault) {
 				classBlock.WriteLine ();
 				var strongDelegate = property.ToStrongDelegate ();
 				using (var propertyBlock =

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/AccessorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/AccessorTests.cs
@@ -18,13 +18,13 @@ public class AccessorTests {
 		var x = new Accessor (
 			accessorKind: AccessorKind.Getter,
 			symbolAvailability: new (),
-			exportPropertyData: null,
+			exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 			attributes: [],
 			modifiers: []);
 		var y = new Accessor (
 			accessorKind: AccessorKind.Setter,
 			symbolAvailability: new (),
-			exportPropertyData: null,
+			exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 			attributes: [],
 			modifiers: []);
 
@@ -62,7 +62,7 @@ public class AccessorTests {
 		var x = new Accessor (
 			accessorKind: AccessorKind.Getter,
 			symbolAvailability: new (),
-			exportPropertyData: null,
+			exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 			attributes: [
 				new ("First"),
 				new ("Second"),
@@ -71,7 +71,7 @@ public class AccessorTests {
 		var y = new Accessor (
 			accessorKind: AccessorKind.Getter,
 			symbolAvailability: new (),
-			exportPropertyData: null,
+			exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 			attributes: [
 				new ("First"),
 			],
@@ -88,7 +88,7 @@ public class AccessorTests {
 		var x = new Accessor (
 			accessorKind: AccessorKind.Getter,
 			symbolAvailability: new (),
-			exportPropertyData: null,
+			exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 			attributes: [
 				new ("First"),
 				new ("Second"),
@@ -97,7 +97,7 @@ public class AccessorTests {
 		var y = new Accessor (
 			accessorKind: AccessorKind.Getter,
 			symbolAvailability: new (),
-			exportPropertyData: null,
+			exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 			attributes: [
 				new ("Third"),
 				new ("Fourth"),
@@ -116,7 +116,7 @@ public class AccessorTests {
 		var x = new Accessor (
 			accessorKind: AccessorKind.Getter,
 			symbolAvailability: new (),
-			exportPropertyData: null,
+			exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 			attributes: [
 				new ("First"),
 				new ("Second"),
@@ -125,7 +125,7 @@ public class AccessorTests {
 		var y = new Accessor (
 			accessorKind: AccessorKind.Getter,
 			symbolAvailability: new (),
-			exportPropertyData: null,
+			exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 			attributes: [
 				new ("Second"),
 				new ("First"),
@@ -144,7 +144,7 @@ public class AccessorTests {
 		var x = new Accessor (
 			accessorKind: AccessorKind.Getter,
 			symbolAvailability: new (),
-			exportPropertyData: null,
+			exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 			attributes: [
 				new ("First"),
 				new ("Second"),
@@ -156,7 +156,7 @@ public class AccessorTests {
 		var y = new Accessor (
 			accessorKind: AccessorKind.Getter,
 			symbolAvailability: new (),
-			exportPropertyData: null,
+			exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 			attributes: [
 				new ("Second"),
 				new ("First"),
@@ -177,7 +177,7 @@ public class AccessorTests {
 		var x = new Accessor (
 			accessorKind: AccessorKind.Getter,
 			symbolAvailability: new (),
-			exportPropertyData: null,
+			exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 			attributes: [
 				new ("First"),
 				new ("Second"),
@@ -189,7 +189,7 @@ public class AccessorTests {
 		var y = new Accessor (
 			accessorKind: AccessorKind.Getter,
 			symbolAvailability: new (),
-			exportPropertyData: null,
+			exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 			attributes: [
 				new ("Second"),
 				new ("First"),
@@ -211,7 +211,7 @@ public class AccessorTests {
 		var x = new Accessor (
 			accessorKind: AccessorKind.Getter,
 			symbolAvailability: new (),
-			exportPropertyData: null,
+			exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 			attributes: [
 				new ("First"),
 				new ("Second"),
@@ -223,7 +223,7 @@ public class AccessorTests {
 		var y = new Accessor (
 			accessorKind: AccessorKind.Getter,
 			symbolAvailability: new (),
-			exportPropertyData: null,
+			exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 			attributes: [
 				new ("Second"),
 				new ("First"),
@@ -247,7 +247,7 @@ public class AccessorTests {
 		var x = new Accessor (
 			accessorKind: AccessorKind.Getter,
 			symbolAvailability: builder.ToImmutable (),
-			exportPropertyData: null,
+			exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 			attributes: [
 				new ("First"),
 				new ("Second"),
@@ -261,7 +261,7 @@ public class AccessorTests {
 		var y = new Accessor (
 			accessorKind: AccessorKind.Getter,
 			symbolAvailability: builder.ToImmutable (),
-			exportPropertyData: null,
+			exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 			attributes: [
 				new ("Second"),
 				new ("First"),
@@ -284,7 +284,7 @@ public class AccessorTests {
 		var x = new Accessor (
 			accessorKind: AccessorKind.Getter,
 			symbolAvailability: builder.ToImmutable (),
-			exportPropertyData: null,
+			exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 			attributes: [
 				new ("First"),
 				new ("Second"),
@@ -296,7 +296,7 @@ public class AccessorTests {
 		var y = new Accessor (
 			accessorKind: AccessorKind.Getter,
 			symbolAvailability: builder.ToImmutable (),
-			exportPropertyData: null,
+			exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 			attributes: [
 				new ("Second"),
 				new ("First"),
@@ -329,7 +329,7 @@ public class AccessorTests {
 		var accessor = new Accessor (
 			accessorKind: AccessorKind.Getter,
 			symbolAvailability: new (),
-			exportPropertyData: null,
+			exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 			attributes: [
 				new ("First"),
 				new ("Second"),
@@ -359,7 +359,7 @@ public class AccessorTests {
 		var accessor = new Accessor (
 			accessorKind: AccessorKind.Getter,
 			symbolAvailability: new (),
-			exportPropertyData: null,
+			exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 			attributes: [
 				new ("First"),
 				new ("Second"),
@@ -371,7 +371,7 @@ public class AccessorTests {
 
 		var selector = accessor.GetSelector (property);
 		Assert.NotNull (selector);
-		Assert.Equal (property.ExportPropertyData.Value.Selector, selector);
+		Assert.Equal (property.ExportPropertyData.Selector, selector);
 	}
 
 	[Fact]
@@ -424,7 +424,7 @@ public class AccessorTests {
 		var accessor = new Accessor (
 			accessorKind: AccessorKind.Setter,
 			symbolAvailability: new (),
-			exportPropertyData: null,
+			exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 			attributes: [
 				new ("First"),
 				new ("Second"),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/AccessorsEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/AccessorsEqualityComparerTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma warning disable APL0003
 using System.Collections.Immutable;
+using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.DataModel;
 using Xunit;
 
@@ -24,13 +26,13 @@ public class AccessorsEqualityComparerTests {
 			new (
 				accessorKind: AccessorKind.Getter,
 				symbolAvailability: new (),
-				exportPropertyData: null,
+				exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 				attributes: [],
 				modifiers: []),
 			new (
 				accessorKind: AccessorKind.Setter,
 				symbolAvailability: new (),
-				exportPropertyData: null,
+				exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 				attributes: [],
 				modifiers: []),
 		];
@@ -38,7 +40,7 @@ public class AccessorsEqualityComparerTests {
 			new (
 				accessorKind: AccessorKind.Getter,
 				symbolAvailability: new (),
-				exportPropertyData: null,
+				exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 				attributes: [],
 				modifiers: []),
 		];
@@ -53,13 +55,13 @@ public class AccessorsEqualityComparerTests {
 			new (
 				accessorKind: AccessorKind.Getter,
 				symbolAvailability: new (),
-				exportPropertyData: null,
+				exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 				attributes: [],
 				modifiers: []),
 			new (
 				accessorKind: AccessorKind.Setter,
 				symbolAvailability: new (),
-				exportPropertyData: null,
+				exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 				attributes: [],
 				modifiers: []),
 		];
@@ -67,13 +69,13 @@ public class AccessorsEqualityComparerTests {
 			new (
 				accessorKind: AccessorKind.Add,
 				symbolAvailability: new (),
-				exportPropertyData: null,
+				exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 				attributes: [],
 				modifiers: []),
 			new (
 				accessorKind: AccessorKind.Remove,
 				symbolAvailability: new (),
-				exportPropertyData: null,
+				exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 				attributes: [],
 				modifiers: []),
 		];
@@ -88,13 +90,13 @@ public class AccessorsEqualityComparerTests {
 			new (
 				accessorKind: AccessorKind.Getter,
 				symbolAvailability: new (),
-				exportPropertyData: null,
+				exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 				attributes: [],
 				modifiers: []),
 			new (
 				accessorKind: AccessorKind.Setter,
 				symbolAvailability: new (),
-				exportPropertyData: null,
+				exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 				attributes: [],
 				modifiers: []),
 		];
@@ -102,13 +104,13 @@ public class AccessorsEqualityComparerTests {
 			new (
 				accessorKind: AccessorKind.Setter,
 				symbolAvailability: new (),
-				exportPropertyData: null,
+				exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 				attributes: [],
 				modifiers: []),
 			new (
 				accessorKind: AccessorKind.Getter,
 				symbolAvailability: new (),
-				exportPropertyData: null,
+				exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 				attributes: [],
 				modifiers: []),
 		];
@@ -123,13 +125,13 @@ public class AccessorsEqualityComparerTests {
 			new (
 				accessorKind: AccessorKind.Getter,
 				symbolAvailability: new (),
-				exportPropertyData: null,
+				exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 				attributes: [],
 				modifiers: []),
 			new (
 				accessorKind: AccessorKind.Setter,
 				symbolAvailability: new (),
-				exportPropertyData: null,
+				exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 				attributes: [],
 				modifiers: []),
 		];
@@ -138,13 +140,13 @@ public class AccessorsEqualityComparerTests {
 			new (
 				accessorKind: AccessorKind.Getter,
 				symbolAvailability: new (),
-				exportPropertyData: null,
+				exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 				attributes: [],
 				modifiers: []),
 			new (
 				accessorKind: AccessorKind.Setter,
 				symbolAvailability: new (),
-				exportPropertyData: null,
+				exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 				attributes: [],
 				modifiers: []),
 		];

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingComparerTests.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma warning disable APL0003
+
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Availability;
@@ -276,7 +278,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -285,7 +287,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -321,7 +323,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -330,7 +332,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -349,7 +351,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -358,7 +360,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -389,7 +391,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -398,7 +400,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -419,7 +421,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -428,7 +430,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -463,7 +465,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -472,7 +474,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -491,7 +493,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -500,7 +502,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -531,7 +533,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							], modifiers: []
@@ -539,7 +541,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -560,7 +562,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -569,7 +571,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -604,7 +606,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -613,7 +615,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -632,7 +634,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -641,7 +643,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -660,7 +662,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []),
 					]),
@@ -688,7 +690,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -697,7 +699,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -718,7 +720,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -727,7 +729,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -762,7 +764,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -771,7 +773,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -790,7 +792,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -799,7 +801,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -818,7 +820,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []),
 					]),
@@ -832,14 +834,14 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
 						new (
 							accessorKind: AccessorKind.Remove,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -868,7 +870,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -877,7 +879,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -898,7 +900,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -907,7 +909,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -924,14 +926,14 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
 						new (
 							accessorKind: AccessorKind.Remove,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -946,7 +948,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -982,7 +984,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -991,7 +993,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -1010,7 +1012,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -1019,7 +1021,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -1038,7 +1040,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []),
 					]),
@@ -1066,7 +1068,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -1075,7 +1077,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -1096,7 +1098,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -1105,7 +1107,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -1124,7 +1126,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -1159,7 +1161,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -1168,7 +1170,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -1187,7 +1189,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -1196,7 +1198,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -1215,7 +1217,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -1230,14 +1232,14 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
 						new (
 							accessorKind: AccessorKind.Remove,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -1305,7 +1307,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -1314,7 +1316,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -1335,7 +1337,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -1344,7 +1346,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -1361,13 +1363,13 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []),
 						new (
 							accessorKind: AccessorKind.Remove,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -1382,7 +1384,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -1442,7 +1444,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -1451,7 +1453,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -1470,7 +1472,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -1479,7 +1481,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -1498,7 +1500,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -1513,14 +1515,14 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
 						new (
 							accessorKind: AccessorKind.Remove,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -1588,7 +1590,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -1597,7 +1599,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -1618,7 +1620,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -1627,7 +1629,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -1644,14 +1646,14 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
 						new (
 							accessorKind: AccessorKind.Remove,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -1666,7 +1668,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -1741,7 +1743,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -1750,7 +1752,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -1769,7 +1771,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -1778,7 +1780,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -1797,7 +1799,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -1812,14 +1814,14 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
 						new (
 							accessorKind: AccessorKind.Remove,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -1864,7 +1866,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -1873,7 +1875,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -1894,7 +1896,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -1903,7 +1905,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -1920,14 +1922,14 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
 						new (
 							accessorKind: AccessorKind.Remove,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -1942,7 +1944,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -2006,7 +2008,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -2015,7 +2017,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -2034,7 +2036,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -2043,7 +2045,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -2062,7 +2064,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -2077,14 +2079,14 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
 						new (
 							accessorKind: AccessorKind.Remove,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -2152,7 +2154,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -2161,7 +2163,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -2182,11 +2184,11 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 							new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							], modifiers: []),
-						new (AccessorKind.Setter, new (), null, [], []),
+						new (AccessorKind.Setter, new (), ExportData<ObjCBindings.Property>.Default, [], []),
 					]),
 			],
 			Events = [
@@ -2200,14 +2202,14 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
 						new (
 							accessorKind: AccessorKind.Remove,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -2222,7 +2224,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -2300,7 +2302,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -2309,7 +2311,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -2328,7 +2330,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -2337,7 +2339,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -2356,7 +2358,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -2371,14 +2373,14 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
 						new (
 							accessorKind: AccessorKind.Remove,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -2446,7 +2448,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -2455,7 +2457,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -2476,7 +2478,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							], modifiers: []
@@ -2484,7 +2486,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -2501,14 +2503,14 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
 						new (
 							accessorKind: AccessorKind.Remove,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -2523,7 +2525,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingEqualityComparerTests.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma warning disable APL0003
+
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.DataModel;
 using Xunit;
 using static Microsoft.Macios.Generator.Tests.TestDataFactory;
@@ -194,7 +197,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -203,7 +206,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -241,7 +244,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -250,7 +253,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -269,7 +272,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -278,7 +281,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -309,7 +312,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -318,7 +321,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -339,7 +342,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -348,7 +351,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -383,7 +386,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -392,7 +395,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -411,7 +414,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -420,7 +423,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -451,7 +454,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -460,7 +463,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -481,7 +484,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -490,7 +493,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -525,7 +528,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -534,7 +537,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -553,7 +556,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -562,7 +565,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -594,7 +597,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -603,7 +606,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -624,7 +627,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -633,7 +636,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -671,7 +674,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -680,7 +683,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -699,7 +702,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -708,7 +711,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -742,7 +745,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -751,7 +754,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -772,7 +775,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -781,7 +784,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -825,7 +828,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -834,7 +837,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -853,7 +856,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -862,7 +865,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -903,7 +906,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -912,7 +915,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -933,7 +936,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -942,7 +945,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -987,7 +990,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -996,7 +999,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -1015,7 +1018,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -1024,7 +1027,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -1065,7 +1068,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -1074,7 +1077,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -1094,7 +1097,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -1103,7 +1106,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -1152,7 +1155,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -1161,7 +1164,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -1180,7 +1183,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -1189,7 +1192,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -1235,7 +1238,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -1244,7 +1247,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios18.0"]),
 							],
@@ -1265,7 +1268,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -1274,7 +1277,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingTests.cs
@@ -318,14 +318,14 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -404,14 +404,14 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
 						new (
 							accessorKind: AccessorKind.Remove,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						)

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassBindingTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassBindingTests.cs
@@ -424,14 +424,14 @@ public partial class MyClass {
 								new (
 									accessorKind: AccessorKind.Getter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Setter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
@@ -495,14 +495,14 @@ public partial class MyClass {
 								new (
 									accessorKind: AccessorKind.Getter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Setter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
@@ -565,14 +565,14 @@ public partial class MyClass {
 								new (
 									accessorKind: AccessorKind.Getter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Setter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
@@ -631,14 +631,14 @@ public partial class MyClass {
 								new (
 									accessorKind: AccessorKind.Getter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Setter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
@@ -700,14 +700,14 @@ public partial class MyClass {
 								new (
 									accessorKind: AccessorKind.Getter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Setter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
@@ -773,14 +773,14 @@ public class UIApplicationLaunchEventArgs {}
 								new (
 									accessorKind: AccessorKind.Getter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Setter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
@@ -845,14 +845,14 @@ public partial class MyClass {
 								new (
 									accessorKind: AccessorKind.Getter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Setter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
@@ -916,14 +916,14 @@ public partial class MyClass {
 								new (
 									accessorKind: AccessorKind.Getter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Setter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
@@ -982,14 +982,14 @@ public partial class MyClass {
 								new (
 									accessorKind: AccessorKind.Getter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Setter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
@@ -1057,14 +1057,14 @@ public partial class MyClass {
 								new (
 									accessorKind: AccessorKind.Getter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Setter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
@@ -1087,14 +1087,14 @@ public partial class MyClass {
 								new (
 									accessorKind: AccessorKind.Getter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Setter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
@@ -1332,14 +1332,14 @@ public partial class MyClass {
 								new (
 									accessorKind: AccessorKind.Add,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Remove,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								)
@@ -1395,14 +1395,14 @@ public partial class MyClass {
 								new (
 									accessorKind: AccessorKind.Add,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Remove,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								)
@@ -1420,14 +1420,14 @@ public partial class MyClass {
 								new (
 									accessorKind: AccessorKind.Add,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Remove,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								)

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EventEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EventEqualityComparerTests.cs
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma warning disable APL0003
+
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.DataModel;
 using Xunit;
 
@@ -35,7 +38,7 @@ public class EventEqualityComparerTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -52,7 +55,7 @@ public class EventEqualityComparerTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -71,7 +74,7 @@ public class EventEqualityComparerTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -97,7 +100,7 @@ public class EventEqualityComparerTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -116,7 +119,7 @@ public class EventEqualityComparerTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -142,7 +145,7 @@ public class EventEqualityComparerTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -161,7 +164,7 @@ public class EventEqualityComparerTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EventTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EventTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma warning disable APL0003
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -43,13 +44,13 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []),
 						new (
 							accessorKind: AccessorKind.Remove,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -82,7 +83,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -115,14 +116,14 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
 						new (
 							accessorKind: AccessorKind.Remove,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: [
 								SyntaxFactory.Token (SyntaxKind.InternalKeyword)
@@ -164,14 +165,14 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
 						new (
 							accessorKind: AccessorKind.Remove,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: [
 								SyntaxFactory.Token (SyntaxKind.InternalKeyword)
@@ -212,7 +213,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: eventAvailabilityBuilder.ToImmutable (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -259,7 +260,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Add,
 							symbolAvailability: accessorAvailabilityBuilder.ToImmutable (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],
@@ -268,7 +269,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Remove,
 							symbolAvailability: accessorAvailabilityBuilder.ToImmutable (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new ("System.Runtime.Versioning.SupportedOSPlatformAttribute", ["ios17.0"]),
 							],

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
@@ -178,14 +178,14 @@ public partial interface IProtocol {
 								new (
 									accessorKind: AccessorKind.Getter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Setter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
@@ -247,14 +247,14 @@ public partial interface IProtocol {
 								new (
 									accessorKind: AccessorKind.Getter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Setter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
@@ -315,14 +315,14 @@ public partial interface IProtocol {
 								new (
 									accessorKind: AccessorKind.Getter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Setter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
@@ -379,14 +379,14 @@ public partial interface IProtocol {
 								new (
 									accessorKind: AccessorKind.Getter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Setter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
@@ -447,14 +447,14 @@ public partial interface IProtocol {
 								new (
 									accessorKind: AccessorKind.Getter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Setter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
@@ -513,14 +513,14 @@ public partial interface MyClass {
 								new (
 									accessorKind: AccessorKind.Getter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Setter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
@@ -586,14 +586,14 @@ public partial interface IProtocol {
 								new (
 									accessorKind: AccessorKind.Getter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Setter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
@@ -616,14 +616,14 @@ public partial interface IProtocol {
 								new (
 									accessorKind: AccessorKind.Getter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Setter,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
@@ -853,14 +853,14 @@ public partial interface IProtocol {
 								new (
 									accessorKind: AccessorKind.Add,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Remove,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								)
@@ -914,14 +914,14 @@ public partial interface IProtocol {
 								new (
 									accessorKind: AccessorKind.Add,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Remove,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								)
@@ -939,14 +939,14 @@ public partial interface IProtocol {
 								new (
 									accessorKind: AccessorKind.Add,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								),
 								new (
 									accessorKind: AccessorKind.Remove,
 									symbolAvailability: new (),
-									exportPropertyData: null,
+									exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 									attributes: [],
 									modifiers: []
 								)

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests/FromDeclarationTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests/FromDeclarationTests.cs
@@ -51,7 +51,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						)
@@ -89,7 +89,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						)
@@ -127,7 +127,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						)
@@ -209,14 +209,14 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						)
@@ -302,7 +302,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -332,7 +332,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -364,14 +364,14 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -404,14 +404,14 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -443,14 +443,14 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: [
 								SyntaxFactory.Token (kind: SyntaxKind.InternalKeyword),
@@ -495,14 +495,14 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: propertyAvailabilityBuilder.ToImmutable (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: propertyAvailabilityBuilder.ToImmutable (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -546,7 +546,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: getterAvailabilityBuilder.ToImmutable (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new (name: "System.Runtime.Versioning.SupportedOSPlatformAttribute", arguments: ["ios17.0"]),
 							],
@@ -555,7 +555,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: propertyAvailabilityBuilder.ToImmutable (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -602,7 +602,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: getterAvailabilityBuilder.ToImmutable (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new (name: "System.Runtime.Versioning.SupportedOSPlatformAttribute", arguments: ["ios17.0"]),
 							],
@@ -611,7 +611,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: setterAvailabilityBuilder.ToImmutable (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new (name: "System.Runtime.Versioning.SupportedOSPlatformAttribute", arguments: ["ios18.0"]),
 							],
@@ -663,7 +663,7 @@ namespace Test {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: getterAvailabilityBuilder.ToImmutable (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new (name: "System.Runtime.Versioning.SupportedOSPlatformAttribute", arguments: ["ios17.0"]),
 							],
@@ -672,7 +672,7 @@ namespace Test {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: setterAvailabilityBuilder.ToImmutable (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new (name: "System.Runtime.Versioning.SupportedOSPlatformAttribute", arguments: ["ios18.0"]),
 							],
@@ -716,7 +716,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: getterAvailabilityBuilder.ToImmutable (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new (name: "System.Runtime.Versioning.SupportedOSPlatformAttribute", arguments: ["ios17.0"]),
 							],
@@ -725,7 +725,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: propertyAvailabilityBuilder.ToImmutable (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -768,7 +768,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: getterAvailabilityBuilder.ToImmutable (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new (name: "System.Runtime.Versioning.SupportedOSPlatformAttribute", arguments: ["ios17.0"]),
 							],
@@ -777,7 +777,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: propertyAvailabilityBuilder.ToImmutable (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -821,7 +821,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: getterAvailabilityBuilder.ToImmutable (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [
 								new (name: "System.Runtime.Versioning.SupportedOSPlatformAttribute", arguments: ["ios17.0"]),
 							],
@@ -830,7 +830,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Setter,
 							symbolAvailability: propertyAvailabilityBuilder.ToImmutable (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						),
@@ -866,7 +866,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						)
@@ -907,7 +907,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						)
@@ -949,7 +949,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						)
@@ -996,7 +996,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						)
@@ -1038,7 +1038,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						)
@@ -1079,7 +1079,7 @@ public class TestClass {
 						new (
 							accessorKind: AccessorKind.Getter,
 							symbolAvailability: new (),
-							exportPropertyData: null,
+							exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 							attributes: [],
 							modifiers: []
 						)

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests/GeneralPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests/GeneralPropertyTests.cs
@@ -303,14 +303,14 @@ public class GeneralPropertyTests {
 			new (
 				accessorKind: AccessorKind.Getter,
 				symbolAvailability: new (),
-				exportPropertyData: null,
+				exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 				attributes: [],
 				modifiers: []
 			),
 			new (
 				accessorKind: AccessorKind.Setter,
 				symbolAvailability: new (),
-				exportPropertyData: null,
+				exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 				attributes: [],
 				modifiers: []
 			),
@@ -324,7 +324,7 @@ public class GeneralPropertyTests {
 			new (
 				accessorKind: AccessorKind.Getter,
 				symbolAvailability: new (),
-				exportPropertyData: null,
+				exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 				attributes: [],
 				modifiers: []
 			),
@@ -386,14 +386,14 @@ public class GeneralPropertyTests {
 			new (
 				accessorKind: AccessorKind.Getter,
 				symbolAvailability: new (),
-				exportPropertyData: null,
+				exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 				attributes: [],
 				modifiers: []
 			),
 			new (
 				accessorKind: AccessorKind.Setter,
 				symbolAvailability: new (),
-				exportPropertyData: null,
+				exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 				attributes: [],
 				modifiers: []
 			),
@@ -407,14 +407,14 @@ public class GeneralPropertyTests {
 			new (
 				accessorKind: AccessorKind.Getter,
 				symbolAvailability: new (),
-				exportPropertyData: null,
+				exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 				attributes: [],
 				modifiers: []
 			),
 			new (
 				accessorKind: AccessorKind.Setter,
 				symbolAvailability: new (),
-				exportPropertyData: null,
+				exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 				attributes: [],
 				modifiers: []
 			),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests/PropertiesEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests/PropertiesEqualityComparerTests.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#pragma warning disable APL0003
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.DataModel;
 using Xunit;
 
@@ -36,7 +38,7 @@ public class PropertiesEqualityComparerTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -53,7 +55,7 @@ public class PropertiesEqualityComparerTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -72,7 +74,7 @@ public class PropertiesEqualityComparerTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -98,7 +100,7 @@ public class PropertiesEqualityComparerTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -117,7 +119,7 @@ public class PropertiesEqualityComparerTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -143,7 +145,7 @@ public class PropertiesEqualityComparerTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -162,7 +164,7 @@ public class PropertiesEqualityComparerTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -188,7 +190,7 @@ public class PropertiesEqualityComparerTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -207,7 +209,7 @@ public class PropertiesEqualityComparerTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryPropertyTests.cs
@@ -5,6 +5,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
+using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.DataModel;
 using ObjCRuntime;
 using Xunit;
@@ -30,14 +31,14 @@ public class BindingSyntaxFactoryPropertyTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),
 					new (
 						accessorKind: AccessorKind.Setter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -64,14 +65,14 @@ public class BindingSyntaxFactoryPropertyTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),
 					new (
 						accessorKind: AccessorKind.Setter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -98,14 +99,14 @@ public class BindingSyntaxFactoryPropertyTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),
 					new (
 						accessorKind: AccessorKind.Setter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -132,14 +133,14 @@ public class BindingSyntaxFactoryPropertyTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),
 					new (
 						accessorKind: AccessorKind.Setter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -166,14 +167,14 @@ public class BindingSyntaxFactoryPropertyTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),
 					new (
 						accessorKind: AccessorKind.Setter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -200,14 +201,14 @@ public class BindingSyntaxFactoryPropertyTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),
 					new (
 						accessorKind: AccessorKind.Setter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -234,14 +235,14 @@ public class BindingSyntaxFactoryPropertyTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),
 					new (
 						accessorKind: AccessorKind.Setter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -268,14 +269,14 @@ public class BindingSyntaxFactoryPropertyTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),
 					new (
 						accessorKind: AccessorKind.Setter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -302,14 +303,14 @@ public class BindingSyntaxFactoryPropertyTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),
 					new (
 						accessorKind: AccessorKind.Setter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -336,14 +337,14 @@ public class BindingSyntaxFactoryPropertyTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),
 					new (
 						accessorKind: AccessorKind.Setter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -370,14 +371,14 @@ public class BindingSyntaxFactoryPropertyTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),
 					new (
 						accessorKind: AccessorKind.Setter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -405,14 +406,14 @@ public class BindingSyntaxFactoryPropertyTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),
 					new (
 						accessorKind: AccessorKind.Setter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -440,14 +441,14 @@ public class BindingSyntaxFactoryPropertyTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),
 					new (
 						accessorKind: AccessorKind.Setter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -475,14 +476,14 @@ public class BindingSyntaxFactoryPropertyTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),
 					new (
 						accessorKind: AccessorKind.Setter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					)
@@ -510,14 +511,14 @@ public class BindingSyntaxFactoryPropertyTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),
 					new (
 						accessorKind: AccessorKind.Setter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),
@@ -545,14 +546,14 @@ public class BindingSyntaxFactoryPropertyTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),
 					new (
 						accessorKind: AccessorKind.Setter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),
@@ -580,14 +581,14 @@ public class BindingSyntaxFactoryPropertyTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),
 					new (
 						accessorKind: AccessorKind.Setter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),
@@ -615,14 +616,14 @@ public class BindingSyntaxFactoryPropertyTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),
 					new (
 						accessorKind: AccessorKind.Setter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),
@@ -650,14 +651,14 @@ public class BindingSyntaxFactoryPropertyTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),
 					new (
 						accessorKind: AccessorKind.Setter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),
@@ -686,7 +687,7 @@ public class BindingSyntaxFactoryPropertyTests {
 					new (
 						accessorKind: AccessorKind.Getter,
 						symbolAvailability: new (),
-						exportPropertyData: null,
+						exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 						attributes: [],
 						modifiers: []
 					),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/ReturnInfoTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/ReturnInfoTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#pragma warning disable APL0003
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Macios.Generator.Attributes;
@@ -27,7 +28,7 @@ public class ReturnInfoTests {
 				new (
 					accessorKind: AccessorKind.Getter,
 					symbolAvailability: new (),
-					exportPropertyData: null,
+					exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 					attributes: [],
 					modifiers: []
 				)
@@ -58,7 +59,7 @@ public class ReturnInfoTests {
 				new (
 					accessorKind: AccessorKind.Getter,
 					symbolAvailability: new (),
-					exportPropertyData: null,
+					exportPropertyData: ExportData<ObjCBindings.Property>.Default,
 					attributes: [],
 					modifiers: []
 				)


### PR DESCRIPTION
Remove the boxing that happens when we use Nullable in the ExportData structure. This reduces the GC preasure by esnuring that there are no refs to the struct from a ref object.