### PR TITLE
[runtime] Call mono_jit_cleanup upon exit.

### DIFF
--- a/runtime/exports.t4
+++ b/runtime/exports.t4
@@ -603,15 +603,14 @@
 			XamarinRuntime = RuntimeMode.MonoVM,
 		},
 
-		new Export ("MonoDomain *", "mono_jit_init_version",
-			"const char *", "root_domain_name",
-			"const char *", "runtime_version"
+		new Export ("MonoDomain *", "mono_jit_init",
+			"const char *", "file"
 		) {
 			XamarinRuntime = RuntimeMode.MonoVM,
 		},
 
-		new Export ("MonoDomain *", "mono_jit_init",
-			"const char *", "file"
+		new Export ("MonoDomain *", "mono_jit_cleanup",
+			"MonoDomain *", "domain"
 		) {
 			XamarinRuntime = RuntimeMode.MonoVM,
 		},

--- a/runtime/monovm-bridge.m
+++ b/runtime/monovm-bridge.m
@@ -76,7 +76,7 @@ xamarin_bridge_initialize ()
 	mono_install_unhandled_exception_hook (xamarin_unhandled_exception_handler, NULL);
 	mono_install_ftnptr_eh_callback (xamarin_ftnptr_exception_handler);
 
-	mono_jit_init_version ("MonoTouch", "mobile");
+	mono_jit_init ("RootDomain");
 	/*
 	  As part of mono initialization a preload hook is added that overrides ours, so we need to re-instate it here.
 	  This is wasteful, but there's no way to manipulate the preload hook list except by adding to it.
@@ -88,6 +88,7 @@ xamarin_bridge_initialize ()
 void
 xamarin_bridge_shutdown ()
 {
+	mono_jit_cleanup (mono_domain_get ());
 }
 
 static MonoClass *


### PR DESCRIPTION
Call `mono_jit_cleanup` upon exit, because profilers depend on this to flush
buffers, etc.

Also use `mono_jit_init` instead of `mono_jit_init_version`, because the
latter is deprecated.

Ref: https://github.com/dotnet/diagnostics/issues/5529#issuecomment-3138842754