### PR TITLE
[release/10.0.1xx-preview7] [devops] Use a zip file with all the certificates and provisioning profiles.

### DIFF
--- a/tools/devops/automation/templates/common/install-qa-provisioning-profiles.yml
+++ b/tools/devops/automation/templates/common/install-qa-provisioning-profiles.yml
@@ -2,57 +2,30 @@ parameters:
 - name: env
   type: object
 
-- name: secureFiles
-  type: object
-  default:
-    [
-      { 'name': 'AppleWWDRCAG3-2.cer', 'secureFile': 'macios-AppleWWDRCAG3-2.cer' },
-      { 'name': 'developer-id-application-luis-aguilera-jul-2029.p12', 'secureFile': 'macios-developer-id-application-luis-aguilera-jul-2029.p12' },
-      { 'name': 'developer-id-installer-luis-aguilera-jul-2029.p12', 'secureFile': 'macios-developer-id-installer-luis-aguilera-jul-2029.p12' },
-      { 'name': 'la_dev_apple.p12', 'secureFile': 'macios-la-dev-apple.p12' },
-      { 'name': 'la_dev_iPhone.p12', 'secureFile': 'macios-la-dev-iPhone.p12' },
-      { 'name': 'la_distr_apple.p12', 'secureFile': 'macios-la-distr-apple.p12' },
-      { 'name': 'la_distr_iphone.p12', 'secureFile': 'macios-la-distr-iphone.p12' },
-      { 'name': 'la_mac_app_dev.p12', 'secureFile': 'macios-la-mac-app-dev.p12' },
-      { 'name': 'la_mac_app_distr.p12', 'secureFile': 'macios-la-mac-app-distr.p12' },
-      { 'name': 'la_mac_installer_distr.p12', 'secureFile': 'macios-la-mac-installer-distr.p12' },
-      { 'name': 'vseng-xamarin-mac-devices-2.p12', 'secureFile': 'macios-vseng-xamarin-mac-devices-2.p12' },
-      { 'name': 'vseng-xamarin-mac-devices.p12', 'secureFile': 'macios-vseng-xamarin-mac-devices.p12' },
-      { 'name': 'vsengxamarinmacdevices.mobileprovision', 'secureFile': 'macios-vsengxamarinmacdevices.mobileprovision' },
-      { 'name': 'WildCardiOSDevelopment.mobileprovision', 'secureFile': 'macios-WildCardiOSDevelopment.mobileprovision' },
-      { 'name': 'WildCardiOSDistribution.mobileprovision', 'secureFile': 'macios-WildCardiOSDistribution.mobileprovision' },
-      { 'name': 'WildCardMacAppDevelopment.provisionprofile', 'secureFile': 'macios-WildCardMacAppDevelopment.provisionprofile' },
-      { 'name': 'WildCardMacDistribution.provisionprofile', 'secureFile': 'macios-WildCardMacDistribution.provisionprofile' },
-      { 'name': 'WildCardtvOSDevelopment.mobileprovision', 'secureFile': 'macios-WildCardtvOSDevelopment.mobileprovision' },
-      { 'name': 'WildCardtvOSDistribution.mobileprovision', 'secureFile': 'macios-WildCardtvOSDistribution.mobileprovision' },
-    ]
 - name: xamarinMaciosPath
   type: string
   default: $(Build.SourcesDirectory)/$(BUILD_REPOSITORY_TITLE)
-  
+
 steps:
 - pwsh: |
     New-Item $(Build.SourcesDirectory)/maccore/tools/provisioning-profiles/certificates-and-profiles -ItemType Directory -Force
   displayName: 'Create secret files folder'
 
-- ${{ each secureFile in parameters.secureFiles }}:
-  - task: DownloadSecureFile@1
-    displayName: 'Download ${{ secureFile.name }}'
-    inputs:
-      secureFile: ${{ secureFile.secureFile }}
+- task: DownloadSecureFile@1
+  displayName: 'Download macios-certificates-and-provisioning-profiles.zip'
+  inputs:
+    secureFile: macios-certificates-and-provisioning-profiles.zip
+
 - pwsh: |
     gci $(Agent.TempDirectory)
+    unzip -l $(Agent.TempDirectory)/macios-certificates-and-provisioning-profiles.zip
   displayName: 'List secure files'
-- pwsh: |
-    $secureFiles = '${{ convertToJson(parameters.secureFiles) }}' | ConvertFrom-Json
-    foreach ($secureFile in $secureFiles) {
-        $sourcePath = Join-Path -Path $env:AGENT_TEMPDIRECTORY -ChildPath $secureFile.secureFile
-        $destinationPath = Join-Path -Path "$env:BUILD_SOURCESDIRECTORY/maccore/tools/provisioning-profiles/certificates-and-profiles" -ChildPath $secureFile.name
 
-        Copy-Item -Path $sourcePath -Destination $destinationPath -Force
-    }
+- pwsh: |
+    mkdir -p $Env:BUILD_SOURCESDIRECTORY/maccore/tools/provisioning-profiles/certificates-and-profiles
+    unzip -d $Env:BUILD_SOURCESDIRECTORY/maccore/tools/provisioning-profiles/certificates-and-profiles/ $(Agent.TempDirectory)/macios-certificates-and-provisioning-profiles.zip
   displayName: 'Copy Certificates and Profiles'
-  
+
 - pwsh: |
     gci $(Build.SourcesDirectory)/maccore/tools/provisioning-profiles/certificates-and-profiles
   displayName: 'List Certificates and Profiles'


### PR DESCRIPTION
Azure DevOps' UI to add and modify secure files is utterly horrible.

* There's no way to modify a secure file, you have to delete it and re-add it.
* There's no documented way to add/remove a secure file using the REST API,
  although there's apparently an un-official REST API
  (https://github.com/microsoft/azure-pipelines-tasks/issues/9172#issuecomment-466024682),
  which was apparently supposed to become documented, which was over 6 years
  ago and in the meantime the only thing that happened was that the issue got
  closed.
* There's no way to update the security settings for a secure file using the
  REST API that I could find, and the UI to do so is _sloooooow_ and clunky.

So instead of going through the pain of adding/deleting/updating 19 different
files, add them all in a single zip file, and feel the pain only once (per year).

Backport of #23448.