### PR TITLE
[src] Remove some outdated docs about how our event model work.

### DIFF
--- a/docs/api/UIKit/UIActionSheet.xml
+++ b/docs/api/UIKit/UIActionSheet.xml
@@ -29,14 +29,6 @@ protected void HandleBtnActionSheetWithOtherButtonsTouchUpInside (object sender,
       <para>
         <img href="~/UIKit/_images/UIKit.UIActionSheet.png" alt="Screenshot showing the UIActionSheet" />
       </para>
-      <para>
-   The Xamarin API supports two styles of event notification: the Objective-C style that uses a delegate class or the C# style using event notifications.  
-</para>
-      <para>
-   The C# style allows the user to add or remove event handlers at runtime by assigning to the events of properties of this class.    Event handlers can be anyone of a method, an anonymous methods or a lambda expression.  Using the C# style events or properties will override any manual settings to the Objective-C Delegate or WeakDelegate settings.
-</para>
-      <para>The Objective-C style requires the user to create a new class derived from <see cref="UIKit.UIActionSheetDelegate" /> class and assign it to the <see cref="UIKit.Delegate" /> property.   Alternatively, for low-level control, by creating a class derived from <see cref="Foundation.NSObject" /> which has every entry point properly decorated with an [Export] attribute.   The instance of this object can then be assigned to the <see cref="UIKit.UIActionSheet.WeakDelegate" /> property.   
-</para>
     </remarks>
     <related type="externalDocumentation" href="https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIActionSheet_Class/index.html">Apple documentation for <c>UIActionSheet</c></related>
   </Docs>

--- a/docs/api/UIKit/UINavigationBar.xml
+++ b/docs/api/UIKit/UINavigationBar.xml
@@ -2,14 +2,6 @@
   <Docs DocId="T:UIKit.UINavigationBar">
     <summary>A <see cref="UIKit.UIView" /> that displays the standard hierarchical navigation metaphor for iOS.</summary>
     <remarks>
-      <para>
-        The Xamarin API supports two styles of event notification: the Objective-C style that uses a delegate class or the C# style using event notifications.  
-      </para>
-      <para>
-        The C# style allows the user to add or remove event handlers at runtime by assigning to the events of properties of this class.    Event handlers can be anyone of a method, an anonymous methods or a lambda expression.  Using the C# style events or properties will override any manual settings to the Objective-C Delegate or WeakDelegate settings.
-      </para>
-      <para>The Objective-C style requires the user to create a new class derived from <see cref="UIKit.UINavigationBarDelegate" /> class and assign it to the <see cref="UIKit.Delegate" /> property.   Alternatively, for low-level control, by creating a class derived from <see cref="Foundation.NSObject" /> which has every entry point properly decorated with an [Export] attribute.   The instance of this object can then be assigned to the <see cref="UIKit.UINavigationBar.WeakDelegate" /> property.   
-      </para>
       <format type="text/html">
         <h2>Structure</h2>
       </format>

--- a/docs/api/UIKit/UINavigationController.xml
+++ b/docs/api/UIKit/UINavigationController.xml
@@ -2,14 +2,6 @@
   <Docs DocId="T:UIKit.UINavigationController">
     <summary>A UIViewController for managing hierarchical navigation.</summary>
     <remarks>
-      <para>
-   The Xamarin API supports two styles of event notification: the Objective-C style that uses a delegate class or the C# style using event notifications.  
-</para>
-      <para>
-   The C# style allows the user to add or remove event handlers at runtime by assigning to the events of properties of this class.    Event handlers can be anyone of a method, an anonymous methods or a lambda expression.  Using the C# style events or properties will override any manual settings to the Objective-C Delegate or WeakDelegate settings.
-</para>
-      <para>The Objective-C style requires the user to create a new class derived from <see cref="UIKit.UINavigationControllerDelegate" /> class and assign it to the <see cref="UIKit.Delegate" /> property.   Alternatively, for low-level control, by creating a class derived from <see cref="Foundation.NSObject" /> which has every entry point properly decorated with an [Export] attribute.   The instance of this object can then be assigned to the <see cref="UIKit.UINavigationController.WeakDelegate" /> property.   
-      </para>
       <para>Prior to iOS 7, the screen area covered by the <see cref="UIKit.UINavigationController.NavigationBar" /> and <see cref="UIKit.UINavigationController.Toolbar" /> was excluded from the area of the <see cref="UIKit.UINavigationController.VisibleViewController" />. In iOS 7, the <see cref="UIKit.UINavigationController.NavigationBar" /> and <see cref="UIKit.UINavigationController.Toolbar" /> float over the child controllers' <see cref="UIKit.UIViewController.View" />. Application developers who wish to modify this behavior should manipulate the <see cref="UIKit.UIViewController.EdgesForExtendedLayout" /> property.</para>
       <para>The following illustration shows how layout of a <see cref="UIKit.UINavigationController" /> is affected with <see cref="UIKit.UIViewController.EdgesForExtendedLayout" />. With the default value of <see cref="UIKit.UIRectEdge.All" />, the <see cref="UIKit.UIView.Frame" /> of the <see cref="UIKit.UINavigationController" />'s <see cref="UIKit.UIViewController.View" /> includes the whole screen, extending beneath the toolbar at the bottom, the navigation bar, and even the status bar. The second image shows the <see cref="UIKit.UIView.Frame" /> property when <see cref="UIKit.UIViewController.EdgesForExtendedLayout" /> is set to <see cref="UIKit.UIRectEdge.None" />.</para>
       <para>

--- a/docs/api/UIKit/UIScrollView.xml
+++ b/docs/api/UIKit/UIScrollView.xml
@@ -274,23 +274,6 @@ else
       <format type="text/html">
         <h2>Event-handling</h2>
       </format>
-      <para>
-                The Xamarin API supports two styles of event notification: the
-                Objective-C style that uses a delegate class or the C# style using event notifications.  
-            </para>
-      <para>
-                The C# style allows the user to add or remove event handlers at runtime by assigning to the events of properties of this class.    Event handlers
-                can be anyone of a method, an anonymous methods or a lambda expression.  Using the C# style events or properties will override any manual settings
-                to the Objective-C Delegate or <see cref="UIKit.UIScrollView.WeakDelegate" /> settings.
-            </para>
-      <para>
-                The Objective-C style requires the user to create a new class derived from <see cref="UIKit.UIScrollViewDelegate" /> class and assign it
-                to
-                the <see cref="UIKit.UIScrollView.Delegate" /> property.   Alternatively, for
-                low-level control, by creating a class derived from 
-                <see cref="Foundation.NSObject" /> which has every entry point properly decorated with an [Export] attribute (see <see cref="Foundation.ExportAttribute" />).   The instance of this object
-                can then be assigned to the <see cref="UIKit.UIScrollView.WeakDelegate" /> property.
-            </para>
     </remarks>
     <related type="recipe" href="https://developer.xamarin.com/ios/Recipes/Content_Controls/Scroll_View/Implement_Tap-to-Zoom">Implement Tap-to-Zoom Recipe</related>
     <related type="recipe" href="https://developer.xamarin.com/ios/Recipes/Content_Controls/Scroll_View/Create_a_Horizontal_Scrolling_Button_List">Create a Horizontal Scrolling Button List</related>

--- a/docs/api/UIKit/UISearchBar.xml
+++ b/docs/api/UIKit/UISearchBar.xml
@@ -1,16 +1,6 @@
 <Documentation>
   <Docs DocId="T:UIKit.UISearchBar">
     <summary>A <see cref="UIKit.UIView" /> that displays a search bar.</summary>
-    <remarks>
-      <para>
-   The Xamarin API supports two styles of event notification: the Objective-C style that uses a delegate class or the C# style using event notifications.  
-</para>
-      <para>
-   The C# style allows the user to add or remove event handlers at runtime by assigning to the events of properties of this class.    Event handlers can be anyone of a method, an anonymous methods or a lambda expression.  Using the C# style events or properties will override any manual settings to the Objective-C Delegate or WeakDelegate settings.
-</para>
-      <para>The Objective-C style requires the user to create a new class derived from <see cref="UIKit.UISearchBarDelegate" /> class and assign it to the <see cref="UIKit.Delegate" /> property.   Alternatively, for low-level control, by creating a class derived from <see cref="Foundation.NSObject" /> which has every entry point properly decorated with an [Export] attribute.   The instance of this object can then be assigned to the <see cref="UIKit.UISearchBar.WeakDelegate" /> property.   
-</para>
-    </remarks>
     <related type="externalDocumentation" href="https://developer.apple.com/library/ios/documentation/UIKit/Reference/UISearchBar_Class/index.html">Apple documentation for <c>UISearchBar</c></related>
   </Docs>
 </Documentation>

--- a/docs/api/UIKit/UITextField.xml
+++ b/docs/api/UIKit/UITextField.xml
@@ -1,16 +1,6 @@
 <Documentation>
   <Docs DocId="T:UIKit.UITextField">
     <summary>A text entry control.</summary>
-    <remarks>
-      <para>
-   The Xamarin API supports two styles of event notification: the Objective-C style that uses a delegate class or the C# style using event notifications.  
-</para>
-      <para>
-   The C# style allows the user to add or remove event handlers at runtime by assigning to the events of properties of this class.    Event handlers can be anyone of a method, an anonymous methods or a lambda expression.  Using the C# style events or properties will override any manual settings to the Objective-C Delegate or WeakDelegate settings.
-</para>
-      <para>The Objective-C style requires the user to create a new class derived from <see cref="UIKit.UITextFieldDelegate" /> class and assign it to the <see cref="UIKit.Delegate" /> property.   Alternatively, for low-level control, by creating a class derived from <see cref="Foundation.NSObject" /> which has every entry point properly decorated with an [Export] attribute.   The instance of this object can then be assigned to the <see cref="UIKit.UITextField.WeakDelegate" /> property.   
-</para>
-    </remarks>
     <related type="externalDocumentation" href="https://developer.apple.com/library/ios/documentation/UIKit/Reference/UITextField_Class/index.html">Apple documentation for <c>UITextField</c></related>
   </Docs>
 </Documentation>

--- a/docs/api/UIKit/UITextView.xml
+++ b/docs/api/UIKit/UITextView.xml
@@ -90,14 +90,6 @@ public class MyView : UIView
       <format type="text/html">
         <br />
       </format>
-      <para>
-        The Xamarin API supports two styles of event notification: the Objective-C style that uses a delegate class or the C# style using event notifications.  
-      </para>
-      <para>
-        The C# style allows the user to add or remove event handlers at runtime by assigning to the events of properties of this class.    Event handlers can be anyone of a method, an anonymous methods or a lambda expression.  Using the C# style events or properties will override any manual settings to the Objective-C Delegate or WeakDelegate settings.
-      </para>
-      <para>The Objective-C style requires the user to create a new class derived from <see cref="UIKit.UITextViewDelegate" /> class and assign it to the <see cref="UIKit.Delegate" /> property.   Alternatively, for low-level control, by creating a class derived from <see cref="Foundation.NSObject" /> which has every entry point properly decorated with an [Export] attribute.   The instance of this object can then be assigned to the <see cref="UIKit.UITextView.WeakDelegate" /> property.   
-      </para>
     </remarks>
     <related type="externalDocumentation" href="https://developer.apple.com/library/ios/documentation/UIKit/Reference/UITextView_Class/index.html">Apple documentation for <c>UITextView</c></related>
   </Docs>

--- a/docs/api/UIKit/UIWebView.xml
+++ b/docs/api/UIKit/UIWebView.xml
@@ -1,16 +1,6 @@
 <Documentation>
   <Docs DocId="T:UIKit.UIWebView">
     <summary>A <see cref="UIKit.UIView" /> that displays a web browser.</summary>
-    <remarks>
-      <para>
-   The Xamarin API supports two styles of event notification: the Objective-C style that uses a delegate class or the C# style using event notifications.  
-</para>
-      <para>
-   The C# style allows the user to add or remove event handlers at runtime by assigning to the events of properties of this class.    Event handlers can be anyone of a method, an anonymous methods or a lambda expression.  Using the C# style events or properties will override any manual settings to the Objective-C Delegate or WeakDelegate settings.
-</para>
-      <para>The Objective-C style requires the user to create a new class derived from <see cref="UIKit.UIWebViewDelegate" /> class and assign it to the <see cref="UIKit.Delegate" /> property.   Alternatively, for low-level control, by creating a class derived from <see cref="Foundation.NSObject" /> which has every entry point properly decorated with an [Export] attribute.   The instance of this object can then be assigned to the <see cref="UIKit.UIWebView.WeakDelegate" /> property.   
-</para>
-    </remarks>
     <related type="recipe" href="https://developer.xamarin.com/ios/Recipes/Content_Controls/Web_View/Load_a_Web_Page">Load a Web Page</related>
     <related type="recipe" href="https://developer.xamarin.com/ios/Recipes/Content_Controls/Web_View/Load_Local_Content">Load Local Content</related>
     <related type="recipe" href="https://developer.xamarin.com/ios/Recipes/Content_Controls/Web_View/Load_Non-Web_Documents">Load Non-Web Documents</related>


### PR DESCRIPTION
Explaining how our event model is better done in a single document instead of
repeatedly everywhere we expose events.