### PR TITLE
[Windows] Fix _CompileNativeExecutable inputs/outputs

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileNativeCode.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileNativeCode.cs
@@ -37,6 +37,11 @@ namespace Xamarin.MacDev.Tasks {
 		public string DotNetRoot { get; set; } = "";
 		#endregion
 
+		#region Outputs
+		[Output]
+		public ITaskItem [] CompiledOutputFiles { get; set; } = Array.Empty<ITaskItem> ();
+		#endregion
+
 		public override bool Execute ()
 		{
 			if (ShouldExecuteRemotely ()) {
@@ -70,6 +75,7 @@ namespace Xamarin.MacDev.Tasks {
 			var compileInfo = sortedCompileInfo.Select (v => v.Item).ToArray ();
 
 			var processes = new Task<Execution> [compileInfo.Length];
+			var outputFiles = new string [compileInfo.Length];
 
 			for (var i = 0; i < compileInfo.Length; i++) {
 				var info = compileInfo [i];
@@ -127,6 +133,7 @@ namespace Xamarin.MacDev.Tasks {
 				var outputFile = info.GetMetadata ("OutputFile");
 				if (string.IsNullOrEmpty (outputFile))
 					outputFile = Path.ChangeExtension (src, ".o");
+				outputFiles [i] = outputFile; // We keep the relative path for remote builds
 				outputFile = Path.GetFullPath (outputFile);
 				arguments.Add ("-o");
 				arguments.Add (outputFile);
@@ -138,6 +145,11 @@ namespace Xamarin.MacDev.Tasks {
 			}
 
 			System.Threading.Tasks.Task.WaitAll (processes);
+
+			// Collect all output files (regardless of compilation success)
+			CompiledOutputFiles = outputFiles
+				.Select (file => new TaskItem (file))
+				.ToArray ();
 
 			return !Log.HasLoggedErrors;
 		}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ILLink.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ILLink.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
@@ -10,7 +11,7 @@ using Xamarin.Messaging.Build.Client;
 #nullable enable
 
 namespace Xamarin.MacDev.Tasks {
-	public class ILLink : global::ILLink.Tasks.ILLink {
+	public class ILLink : global::ILLink.Tasks.ILLink, ITaskCallback {
 		public string SessionId { get; set; } = string.Empty;
 
 		public ITaskItem [] DebugSymbols { get; set; } = Array.Empty<ITaskItem> ();
@@ -18,8 +19,14 @@ namespace Xamarin.MacDev.Tasks {
 		[Required]
 		public string LinkerItemsDirectory { get; set; } = string.Empty;
 
+		[Required]
+		public string LinkerCacheDirectory { get; set; } = string.Empty;
+
 		[Output]
 		public ITaskItem [] LinkerOutputItems { get; set; } = Array.Empty<ITaskItem> ();
+
+		[Output]
+		public ITaskItem [] LinkerCacheItems { get; set; } = Array.Empty<ITaskItem> ();
 
 		[Output]
 		public ITaskItem [] LinkedItems { get; set; } = Array.Empty<ITaskItem> ();
@@ -29,25 +36,16 @@ namespace Xamarin.MacDev.Tasks {
 			if (this.ShouldExecuteRemotely (SessionId))
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
+			// Capture execution start time for Mac-side detection
+			var executionStartTime = DateTime.UtcNow;
 			var result = base.Execute ();
 
-			var linkerItems = new List<ITaskItem> ();
-			var linkedItems = new List<ITaskItem> ();
-
 			if (result) {
-				// Adds all the files in the linker-items dir
-				foreach (var item in Directory.EnumerateFiles (LinkerItemsDirectory)) {
-					linkerItems.Add (new TaskItem (item));
-				}
-
-				// Adds all the files in the linked output dir
-				foreach (var item in Directory.EnumerateFiles (OutputDirectory.ItemSpec)) {
-					linkedItems.Add (new TaskItem (item));
-				}
+				// Collect all files and tag those modified during this execution
+				LinkerOutputItems = GetAllFilesWithMetadata (LinkerItemsDirectory, executionStartTime);
+				LinkedItems = GetAllFilesWithMetadata (OutputDirectory.ItemSpec, executionStartTime);
+				LinkerCacheItems = GetAllFilesWithMetadata (LinkerCacheDirectory, executionStartTime);
 			}
-
-			LinkerOutputItems = linkerItems.ToArray ();
-			LinkedItems = linkedItems.ToArray ();
 
 			return result;
 		}
@@ -59,5 +57,52 @@ namespace Xamarin.MacDev.Tasks {
 			else
 				base.Cancel ();
 		}
+
+		ITaskItem [] GetAllFilesWithMetadata (string directory, DateTime executionStartTime)
+		{
+			if (string.IsNullOrEmpty (directory) || !Directory.Exists (directory))
+				return Array.Empty<ITaskItem> ();
+
+			return Directory.EnumerateFiles (directory)
+				.Select (file => {
+					var fileInfo = new FileInfo (file);
+					var item = new TaskItem (file);
+					
+					// Check if file was created or modified during this execution
+					var wasModified = fileInfo.CreationTimeUtc >= executionStartTime || 
+					                  fileInfo.LastWriteTimeUtc >= executionStartTime;
+					
+					// Tag files that were modified during this execution
+					item.SetMetadata ("Modified", wasModified.ToString ());
+					
+					return item;
+				})
+				.ToArray ();
+		}
+
+		// ITaskCallback implementation
+		public bool ShouldCopyToBuildServer (ITaskItem item) => true;
+
+		public bool ShouldCreateOutputFile (ITaskItem item)
+		{
+			var modifiedMetadata = item.GetMetadata ("Modified");
+			var wasModified = bool.TryParse (modifiedMetadata, out var modified) && modified;
+			
+			// Create output file if it was modified during this execution
+			if (wasModified) {
+				Log.LogMessage (MessageImportance.Low, "Output file '{0}' was modified during execution", item.ItemSpec);
+				return true;
+			}
+			
+			// Create output file if it doesn't exist on Windows. We assume if it exists on the Mac we also need it on Windows.
+			if (!File.Exists (item.ItemSpec)) {
+				Log.LogMessage (MessageImportance.Low, "Output file '{0}' does not exist", item.ItemSpec);
+				return true;
+			}
+			
+			return false;
+		}
+
+		public IEnumerable<ITaskItem> GetAdditionalItemsToBeCopied () => Array.Empty<ITaskItem> ();
 	}
 }

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
@@ -419,11 +419,10 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 				ToolPath="$(_DotNetHostDirectory)"
 				ILLinkPath="$(_RemoteILLinkPath)"
 				LinkerItemsDirectory="$(_LinkerItemsDirectory)"
+				LinkerCacheDirectory="$(_LinkerCacheDirectory)"
 				DebugSymbols="@(_ILLinkDebugSymbols)"
 				ContinueOnError="ErrorAndContinue">
 			<Output TaskParameter="ExitCode" PropertyName="_ILLinkExitCode" />
-			<Output TaskParameter="LinkedItems" ItemName="_XamarinLinkedItems" />
-			<Output TaskParameter="LinkerOutputItems" ItemName="_XamarinLinkerItems" />
 		</Xamarin.MacDev.Tasks.ILLink>
 
 		<PropertyGroup>


### PR DESCRIPTION
`_CompileNativeExecutable` was always being executed from Windows being its inputs and outputs were never generated:
- **ILLink**: we were not creating outputs for the `linker-cache` directory. Also, the previous behavior would always create an output file for all the Macs for the analyzed directories, but not all of them actually changed on each run, making the Windows side outputs to be incorrectly updated (and forcing other targets execution).
- **CompileNativeCode**: was not reporting the compiled output files, forcing `_CompileNativeExecutable` to always run.

Finally, removed the `Xamarin.MacDev.Tasks.ILLink` output parameters we don't use from the targets. The task contains those outputs mainly to create the empty output files on Windows.

I'll add a test for this in an upcoming PR.

Fixes https://github.com/dotnet/macios/issues/19609