### PR TITLE
[Windows] Make LinkNativeCode create output file

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1686,7 +1686,7 @@
 			<_NativeReferences Include="@(_FileNativeReference)" Condition="'%(_FileNativeReference.LinkToExecutable)' != 'false'" />
 		</ItemGroup>
 
-		<WriteLinesToFile SessionId="$(BuildSessionId)" File="$(_MtouchSymbolsList)" Lines="@(_ProcessedReferenceNativeSymbol)" Overwrite="true" />
+		<WriteLinesToFile File="$(_MtouchSymbolsList)" Lines="@(_ProcessedReferenceNativeSymbol)" Overwrite="true" />
 
 		<PropertyGroup>
 			<!-- There are known bugs in the classic linker with Xcode 15, so keep use the classic linker in that case -->
@@ -1859,7 +1859,6 @@
 			<Output TaskParameter="Lines" ItemName="_AllExecutableSymbols" />
 		</ReadLinesFromFile>
 		<WriteLinesToFile
-			SessionId="$(BuildSessionId)"
 			File="$(_MtouchSymbolsList)"
 			Lines="@(_AllExecutableSymbols->DistinctWithCase())"
 			Overwrite="true" />

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/LinkNativeCode.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/LinkNativeCode.cs
@@ -31,7 +31,8 @@ namespace Xamarin.MacDev.Tasks {
 		public string SdkRoot { get; set; } = string.Empty;
 
 		[Required]
-		public string OutputFile { get; set; } = string.Empty;
+		[Output]
+		public ITaskItem OutputFile { get; set; } = null!;
 
 		[Required]
 		public ITaskItem [] ObjectFiles { get; set; } = Array.Empty<ITaskItem> ();
@@ -56,7 +57,7 @@ namespace Xamarin.MacDev.Tasks {
 		public override bool Execute ()
 		{
 			if (ShouldExecuteRemotely ()) {
-				outputPath = PathUtils.ConvertToMacPath (Path.GetDirectoryName (OutputFile));
+				outputPath = PathUtils.ConvertToMacPath (Path.GetDirectoryName (OutputFile.ItemSpec));
 
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 			}
@@ -205,7 +206,7 @@ namespace Xamarin.MacDev.Tasks {
 			arguments.AddRange (GetEmbedEntitlementsWithDerInExecutableLinkerFlags (EntitlementsInExecutable));
 
 			arguments.Add ("-o");
-			arguments.Add (Path.GetFullPath (OutputFile));
+			arguments.Add (Path.GetFullPath (OutputFile.ItemSpec));
 
 			if (LinkerFlags is not null) {
 				foreach (var flag in LinkerFlags)
@@ -306,7 +307,7 @@ namespace Xamarin.MacDev.Tasks {
 		// and the ones on Windows are empty, so we will break the build
 		public bool ShouldCopyToBuildServer (ITaskItem item) => !PathUtils.ConvertToMacPath (item.ItemSpec).StartsWith (outputPath);
 
-		public bool ShouldCreateOutputFile (ITaskItem item) => false;
+		public bool ShouldCreateOutputFile (ITaskItem item) => true;
 
 		public IEnumerable<ITaskItem> GetAdditionalItemsToBeCopied () => Enumerable.Empty<ITaskItem> ();
 	}


### PR DESCRIPTION
The `_LinkNativeExecutable` always runs because its inputs/outputs are not created on Windows. Its own output file was never created because the task was not configured to do so.

Also, the `_MtouchSymbolsList` was being written remotely so it was never found on Windows when checking the outputs. It's safe to write this locally as it will be copied as part of running this task as it is one of its declared dependencies.

Fixes https://github.com/dotnet/macios/issues/19610