### PR TITLE
[net10.0] Update the default value for 'EventSourceSupport' and 'MetricsSupport'.

### DIFF
--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -386,6 +386,18 @@ Enables the concurrent mode for the SGen garbage collector.
 
 Only applicable to iOS, tvOS and Mac Catalyst (when not using NativeAOT).
 
+## EventSourceSupport
+
+When set to `false`, disables .NET's [EventSource][eventsource] support from
+trimmed applications. Disabling this feature would prevent .NET diagnostic
+tools like `dotnet-counters` from functioning, but at the benefit of reduced
+application size.
+
+Default: set to `false` when `Optimize` is set to `true` (which is the default
+for `Release` builds), unless `$(EnableDiagnostics)` is enabled.
+
+[eventsource]: https://learn.microsoft.com/dotnet/core/diagnostics/eventsource
+
 ## GenerateApplicationManifest
 
 If an application manifest (`Info.plist`) should be generated.
@@ -582,6 +594,18 @@ The default behavior is to use `xcrun metallib`.
 The full path to the Metal compiler.
 
 The default behavior is to use `xcrun metal`.
+
+## MetricsSupport
+
+When set to `false`, disables .NET's [Metrics][dotnetmetrics] support from
+trimmed applications. Disabling this feature would prevent APIs such as
+`System.Diagnostics.Metrics` from functioning, but at the benefit of reduced
+application size.
+
+Default: set to `false` when `Optimize` is set to `true` (which is the default
+for `Release` builds), unless `$(EnableDiagnostics)` is enabled.
+
+[dotnetmetrics]: https://learn.microsoft.com/dotnet/core/diagnostics/metrics
 
 ## MmpDebug
 

--- a/docs/configuration-properties.md
+++ b/docs/configuration-properties.md
@@ -32,6 +32,7 @@ These are options that are set when the `Optimize` property is `true` (which hap
 
 | **Property**                   | **Value**  |
 |--------------------------------|------------|
+| EventSourceSupport             | false      |
 | HttpActivityPropagationSupport | false      |
 | MetricsSupport                 | false      |
 

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -113,9 +113,9 @@
 		<EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization Condition="'$(EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization)' == ''">false</EnableUnsafeBinaryFormatterInDesigntimeLicenseContextSerialization>
 		<EnableUnsafeBinaryFormatterSerialization Condition="'$(EnableUnsafeBinaryFormatterSerialization)' == ''">false</EnableUnsafeBinaryFormatterSerialization>
 		<EnableUnsafeUTF7Encoding Condition="'$(EnableUnsafeUTF7Encoding)' == ''">false</EnableUnsafeUTF7Encoding>
-		<EventSourceSupport Condition="'$(EventSourceSupport)' == ''">false</EventSourceSupport>
+		<EventSourceSupport Condition="'$(EventSourceSupport)' == '' And '$(Optimize)' == 'true' And '$(EnableDiagnostics)' != 'true'">false</EventSourceSupport>
 		<HttpActivityPropagationSupport Condition="'$(HttpActivityPropagationSupport)' == '' and '$(Optimize)' == 'true'">false</HttpActivityPropagationSupport>
-		<MetricsSupport Condition="'$(MetricsSupport)' == '' And '$(Optimize)' == 'true'">false</MetricsSupport>
+		<MetricsSupport Condition="'$(MetricsSupport)' == '' And '$(Optimize)' == 'true' And '$(EnableDiagnostics)' != 'true'">false</MetricsSupport>
 		<Http3Support Condition="'$(Http3Support)' == ''">false</Http3Support>
 		<InvariantGlobalization Condition="'$(InvariantGlobalization)' == ''">false</InvariantGlobalization>
 		<!-- Enable HybridGlobalization by default-->


### PR DESCRIPTION
Context: dotnet/maui#31058
Context: dotnet/android#10388

We are in the process of adding `Metrics` to .NET MAUI to enable `dotnet-counters` such as:

    > dotnet-counters monitor --dsrouter ios --counters Microsoft.Maui
    Press p to pause, r to resume, q to quit.
    Status: Running

    Name                                      Current Value
    [Microsoft.Maui]
        maui.layout.arrange_count ({times})               6
        maui.layout.arrange_duration (ns)
            Percentile
            50                                      518,656
            95                                    2,367,488
            99                                    2,367,488
        maui.layout.measure_count ({times})              11
        maui.layout.measure_duration (ns)
            Percentile
            50                                      389,632
            95                                   28,475,392
            99                                   28,475,392

For this to work, you'd unfortunately need to build the app with:

    dotnet build -c Release -p:EnableDiagnostics=true -p:MetricsSupport=true -p:EventSourceSupport=true

That's way too many properties to mess with!

So, we should make the defaults:

* For `Release` mode, `$(Optimize)` is `true`.

* Only if `$(EnableDiagnostics)` is not `true`, then:

  * `$(MetricsSupport)` is `false`.

  * `$(EventSourceSupport)` is `false`.