### PR TITLE
[devops] Make a failing API diff fail the corresponding job.

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -1214,7 +1214,7 @@ namespace Foundation {
 		NotSet = 0,
 		Personal,
 		Reflexive,
-		Possessive = 666,
+		Possessive,
 	}
 
 	[TV (17, 0), Mac (14, 0), iOS (17, 0), MacCatalyst (17, 0)]

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -1214,7 +1214,7 @@ namespace Foundation {
 		NotSet = 0,
 		Personal,
 		Reflexive,
-		Possessive,
+		Possessive = 666,
 	}
 
 	[TV (17, 0), Mac (14, 0), iOS (17, 0), MacCatalyst (17, 0)]

--- a/tools/compare-commits.sh
+++ b/tools/compare-commits.sh
@@ -486,10 +486,12 @@ if [ -z ${DOTNET_TFM+x} ]; then DOTNET_TFM=$(make -C "$ROOT_DIR"/tools/devops pr
 
 # Create the GH comment
 
+EXITCODE=0
 if test -n "$ENABLE_API_DIFF"; then
 	if grep BreakingChangesDetected "$APIDIFF_RESULTS_DIR/api-diff.md" >/dev/null 2>&1; then
 		EMOJII=":heavy_exclamation_mark:"
 		MSG=" (Breaking changes)"
+		EXITCODE=1
 	else
 		EMOJII=":white_check_mark:"
 		MSG=""
@@ -504,6 +506,7 @@ if test -n "$ENABLE_STABLE_API_COMPARISON"; then
 	if grep BreakingChangesDetected "$STABLE_API_COMPARISON_RESULTS_DIR/api-diff.md" >/dev/null 2>&1; then
 		EMOJII=":heavy_exclamation_mark:"
 		MSG=" (Breaking changes)"
+		EXITCODE=1
 	else
 		EMOJII=":white_check_mark:"
 		MSG=""
@@ -526,3 +529,4 @@ if test -n "$ENABLE_GENERATOR_DIFF"; then
 	fi
 fi
 
+exit $EXITCODE

--- a/tools/compare-commits.sh
+++ b/tools/compare-commits.sh
@@ -487,11 +487,14 @@ if [ -z ${DOTNET_TFM+x} ]; then DOTNET_TFM=$(make -C "$ROOT_DIR"/tools/devops pr
 # Create the GH comment
 
 EXITCODE=0
+EXITREASON=
+
 if test -n "$ENABLE_API_DIFF"; then
 	if grep BreakingChangesDetected "$APIDIFF_RESULTS_DIR/api-diff.md" >/dev/null 2>&1; then
 		EMOJII=":heavy_exclamation_mark:"
 		MSG=" (Breaking changes)"
 		EXITCODE=1
+		EXITREASON="Error: failing comparison because there are breaking changes"
 	else
 		EMOJII=":white_check_mark:"
 		MSG=""
@@ -507,6 +510,7 @@ if test -n "$ENABLE_STABLE_API_COMPARISON"; then
 		EMOJII=":heavy_exclamation_mark:"
 		MSG=" (Breaking changes)"
 		EXITCODE=1
+		EXITREASON="Error: failing comparison because there are breaking changes"
 	else
 		EMOJII=":white_check_mark:"
 		MSG=""
@@ -529,4 +533,7 @@ if test -n "$ENABLE_GENERATOR_DIFF"; then
 	fi
 fi
 
+if test -n "$EXITREASON"; then
+	echo "$EXITREASON"
+fi
 exit $EXITCODE

--- a/tools/devops/automation/templates/build/api-diff-build-and-detect.yml
+++ b/tools/devops/automation/templates/build/api-diff-build-and-detect.yml
@@ -52,7 +52,6 @@ steps:
   displayName: 'Detect API changes'
   condition: succeeded()
   name: detectChanges
-  continueOnError: true # this isn't fatal, the github comment will show how bad this really is
   env:
     PR_ID: ${{ parameters.prID }} # reusing jenkins vars, to be fixed
     AUTH_TOKEN_GITHUB_COM: ${{ parameters.gitHubToken }}

--- a/tools/devops/automation/templates/build/api-diff-stage.yml
+++ b/tools/devops/automation/templates/build/api-diff-stage.yml
@@ -72,7 +72,7 @@ jobs:
   timeoutInMinutes: 1000
   dependsOn: # can start as soon as the api diff is done
   - api_diff
-  condition: or(eq(dependencies.api_diff.result, 'Succeeded'), eq(dependencies.api_diff.result, 'SucceededWithIssues'))
+  condition: succeededOrFailed()
   pool:
     vmImage: 'windows-latest'
     workspace:


### PR DESCRIPTION
We used to have the API diff be non-fatal, because it would fail the entire
build.

However, this isn't the case anymore, so treat API diff like any other test:
if it fails, fail the job.