### PR TITLE
[Windows] Add inputs/outputs to _CreatePkgInfo

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CreatePkgInfo.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CreatePkgInfo.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -9,12 +11,13 @@ using Xamarin.Messaging.Build.Client;
 #nullable enable
 
 namespace Xamarin.MacDev.Tasks {
-	public class CreatePkgInfo : XamarinTask, ICancelableTask {
+	public class CreatePkgInfo : XamarinTask, ICancelableTask, ITaskCallback {
 		static readonly byte [] PkgInfoData = { 0X41, 0X50, 0X50, 0X4C, 0x3f, 0x3f, 0x3f, 0x3f };
 		#region Inputs
 
 		[Required]
-		public string OutputPath { get; set; } = "";
+		[Output]
+		public ITaskItem OutputPath { get; set; } = null!;
 
 		#endregion
 
@@ -23,10 +26,10 @@ namespace Xamarin.MacDev.Tasks {
 			if (ShouldExecuteRemotely ())
 				return new TaskRunner (SessionId, BuildEngine4).RunAsync (this).Result;
 
-			if (!File.Exists (OutputPath)) {
-				Directory.CreateDirectory (Path.GetDirectoryName (OutputPath));
+			if (!File.Exists (OutputPath.ItemSpec)) {
+				Directory.CreateDirectory (Path.GetDirectoryName (OutputPath.ItemSpec));
 
-				using (var stream = File.OpenWrite (OutputPath)) {
+				using (var stream = File.OpenWrite (OutputPath.ItemSpec)) {
 					stream.Write (PkgInfoData, 0, PkgInfoData.Length);
 				}
 			}
@@ -39,5 +42,11 @@ namespace Xamarin.MacDev.Tasks {
 			if (ShouldExecuteRemotely ())
 				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
+
+		public bool ShouldCopyToBuildServer (ITaskItem item) => false;
+
+		public bool ShouldCreateOutputFile (ITaskItem item) => true;
+
+		public IEnumerable<ITaskItem> GetAdditionalItemsToBeCopied () => Enumerable.Empty<ITaskItem> ();
 	}
 }

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1339,7 +1339,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		</PropertyGroup>
 	</Target>
 
-	<Target Name="_CreatePkgInfo" Condition="'$(IsAppExtension)' == 'false'" DependsOnTargets="_ComputePkgInfoPath" Outputs="$(_PkgInfoPath)">
+	<Target Name="_CreatePkgInfo" Condition="'$(IsAppExtension)' == 'false'" DependsOnTargets="_ComputePkgInfoPath" Inputs="$(_PkgInfoPath)" Outputs="$(_PkgInfoPath)">
 		<CreatePkgInfo SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" OutputPath="$(_PkgInfoPath)" />
 	</Target>
 


### PR DESCRIPTION
Makes the `CreatePkgInfo` task to produce an output file on Windows, and add the same as input of the `_CreatePkgInfo` target so if won't run again while the file exists as it is a static file.

This is a minor improvement but affects every single incremental build.

Fixes https://github.com/dotnet/macios/issues/19608.