### PR TITLE
[devops] Enable the generation of minidumps if dotnet crashes.

### DIFF
--- a/tools/devops/automation/scripts/bash/collect-and-upload-crash-reports.sh
+++ b/tools/devops/automation/scripts/bash/collect-and-upload-crash-reports.sh
@@ -22,3 +22,10 @@ else
     set -x
   fi
 fi
+
+for file in "$AGENT_TEMPDIRECTORY"/*.minidump; do
+  if ! test -f "$file"; then continue; fi
+  set +x
+  echo "##vso[artifact.upload containerfolder=minidumps;artifactname=minidumps]$file"
+  set -x
+done

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -164,9 +164,9 @@ steps:
     condition: and(succeeded(), ne('${{ parameters.disableCodeQL }}', 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
   - bash: |
-      echo "##vso[task.setvariable variable=DOTNET_DbgEnableMiniDump]1
-      echo "##vso[task.setvariable variable=DOTNET_DbgMiniDumpType]4
-      echo "##vso[task.setvariable variable=DOTNET_DbgMiniDumpName]$(AGENT_TEMPDIRECTORY)/dotnet_%t_%p.minidump
+      echo "##vso[task.setvariable variable=DOTNET_DbgEnableMiniDump]1"
+      echo "##vso[task.setvariable variable=DOTNET_DbgMiniDumpType]4"
+      echo "##vso[task.setvariable variable=DOTNET_DbgMiniDumpName]$(AGENT_TEMPDIRECTORY)/dotnet_%t_%p.minidump"
     displayName: Enable minidumps
     continueOnError: true
 

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -166,7 +166,7 @@ steps:
   - bash: |
       echo "##vso[task.setvariable variable=DOTNET_DbgEnableMiniDump]1"
       echo "##vso[task.setvariable variable=DOTNET_DbgMiniDumpType]4"
-      echo "##vso[task.setvariable variable=DOTNET_DbgMiniDumpName]$(AGENT_TEMPDIRECTORY)/dotnet_%t_%p.minidump"
+      echo "##vso[task.setvariable variable=DOTNET_DbgMiniDumpName]$AGENT_TEMPDIRECTORY/dotnet_%t_%p.minidump"
     displayName: Enable minidumps
     continueOnError: true
 

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -163,13 +163,6 @@ steps:
     displayName: CodeQL 3000 Init
     condition: and(succeeded(), ne('${{ parameters.disableCodeQL }}', 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
-  - bash: |
-      echo "##vso[task.setvariable variable=DOTNET_DbgEnableMiniDump]1"
-      echo "##vso[task.setvariable variable=DOTNET_DbgMiniDumpType]4"
-      echo "##vso[task.setvariable variable=DOTNET_DbgMiniDumpName]$AGENT_TEMPDIRECTORY/dotnet_%t_%p.minidump"
-    displayName: Enable minidumps
-    continueOnError: true
-
   # Actual build of the project
   - bash: $(System.DefaultWorkingDirectory)/$(BUILD_REPOSITORY_TITLE)/tools/devops/automation/scripts/bash/build-macios.sh
     name: build
@@ -178,6 +171,9 @@ steps:
     timeoutInMinutes: 180
     env:
       MAKE_PARALLELISM: ${{ parameters.makeParallelism }}
+      DOTNET_DbgEnableMiniDump: 1
+      DOTNET_DbgMiniDumpType: 4
+      DOTNET_DbgMiniDumpName: $(Agent.TempDirectory)/dotnet_%t_%p.minidump
 
   - ${{ each step in parameters.buildSteps }}:
       - ${{ each pair in step }}:

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -163,6 +163,13 @@ steps:
     displayName: CodeQL 3000 Init
     condition: and(succeeded(), ne('${{ parameters.disableCodeQL }}', 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
+  - bash: |
+      echo "##vso[task.setvariable variable=DOTNET_DbgEnableMiniDump]1
+      echo "##vso[task.setvariable variable=DOTNET_DbgMiniDumpType]4
+      echo "##vso[task.setvariable variable=DOTNET_DbgMiniDumpName]$(AGENT_TEMPDIRECTORY)/dotnet_%t_%p.minidump
+    displayName: Enable minidumps
+    continueOnError: true
+
   # Actual build of the project
   - bash: $(System.DefaultWorkingDirectory)/$(BUILD_REPOSITORY_TITLE)/tools/devops/automation/scripts/bash/build-macios.sh
     name: build


### PR DESCRIPTION
This makes it easier to diagnose bugs elsewhere if they cause .NET to crash.