### PR TITLE
[release/9.0.1xx] Bump mlaunch to get a version that works with Xcode 26.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -10,7 +10,7 @@ endif
 
 # Available versions can be seen here:
 # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.Tools.Mlaunch/versions
-MLAUNCH_NUGET_VERSION=1.0.272
+MLAUNCH_NUGET_VERSION=1.1.72
 
 define CheckVersionTemplate
 check-$(1)::

--- a/tests/dotnet/UnitTests/MlaunchTest.cs
+++ b/tests/dotnet/UnitTests/MlaunchTest.cs
@@ -52,9 +52,9 @@ namespace Xamarin.Tests {
 		public static object [] GetMlaunchRunArgumentsTestCases ()
 		{
 			return new object [] {
-				new object [] {ApplePlatform.iOS, "iossimulator-x64;iossimulator-arm64", $":v2:runtime=com.apple.CoreSimulator.SimRuntime.iOS-{SdkVersions.iOS.Replace('.', '-')},devicetype=com.apple.CoreSimulator.SimDeviceType.iPhone-16e" },
+				new object [] {ApplePlatform.iOS, "iossimulator-x64;iossimulator-arm64", $":v2:runtime=com.apple.CoreSimulator.SimRuntime.iOS-{SdkVersions.iOS.Replace('.', '-')},devicetype=com.apple.CoreSimulator.SimDeviceType.iPhone-.*" },
 				new object [] {ApplePlatform.iOS, "ios-arm64", "" },
-				new object [] {ApplePlatform.TVOS, "tvossimulator-arm64", $":v2:runtime=com.apple.CoreSimulator.SimRuntime.tvOS-{SdkVersions.TVOS.Replace('.', '-')},devicetype=com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-3rd-generation-1080p" },
+				new object [] {ApplePlatform.TVOS, "tvossimulator-arm64", $":v2:runtime=com.apple.CoreSimulator.SimRuntime.tvOS-{SdkVersions.TVOS.Replace('.', '-')},devicetype=com.apple.CoreSimulator.SimDeviceType.Apple-TV-.*" },
 			};
 		}
 
@@ -93,11 +93,11 @@ namespace Xamarin.Tests {
 				expectedArguments.Append (device);
 			}
 			expectedArguments.Append ($" --wait-for-exit:true");
-			Assert.AreEqual (expectedArguments.ToString (), mlaunchRunArguments);
+			Assert.That (mlaunchRunArguments, Does.Match (expectedArguments.ToString ()), "arguments");
 
 			var scriptContents = File.ReadAllText (outputPath).Trim ('\n');
 			var expectedScriptContents = mlaunchPath + " " + expectedArguments.ToString ();
-			Assert.AreEqual (expectedScriptContents, scriptContents, "Script contents");
+			Assert.That (scriptContents, Does.Match (expectedScriptContents), "Script contents");
 		}
 	}
 }


### PR DESCRIPTION
This _might_ be enough to make .NET 9 kind of work with Xcode 26.

Backport of #23499.