### PR TITLE
[RGen] Add two new validators one for arrays one for properties.

### DIFF
--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Resources.Designer.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Resources.Designer.cs
@@ -839,5 +839,86 @@ namespace Microsoft.Macios.Bindings.Analyzer {
                 return ResourceManager.GetString("RBI0028Title", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to There is a mismatch between the arguments of a method/property and the number of &apos;:&apos; in a selector..
+        /// </summary>
+        internal static string RBI0029Description {
+            get {
+                return ResourceManager.GetString("RBI0029Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to There is a mismatch between the arguments of &apos;{0}&apos; (found {1}) and the selector &apos;{2}&apos; (found {3}).
+        /// </summary>
+        internal static string RBI0029MessageFormat {
+            get {
+                return ResourceManager.GetString("RBI0029MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Selector argument mismatch.
+        /// </summary>
+        internal static string RBI0029Title {
+            get {
+                return ResourceManager.GetString("RBI0029Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Field properties must be declared static..
+        /// </summary>
+        internal static string RBI0030Description {
+            get {
+                return ResourceManager.GetString("RBI0030Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Field properties must be declared static.
+        /// </summary>
+        internal static string RBI0030MessageFormat {
+            get {
+                return ResourceManager.GetString("RBI0030MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Wrong field declaration.
+        /// </summary>
+        internal static string RBI0030Title {
+            get {
+                return ResourceManager.GetString("RBI0030Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Exported properties must be declared partial..
+        /// </summary>
+        internal static string RBI0031Description {
+            get {
+                return ResourceManager.GetString("RBI0031Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Exported properties must be declared partial.
+        /// </summary>
+        internal static string RBI0031MessageFormat {
+            get {
+                return ResourceManager.GetString("RBI0031MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Wrong property declaration.
+        /// </summary>
+        internal static string RBI0031Title {
+            get {
+                return ResourceManager.GetString("RBI0031Title", resourceCulture);
+            }
+        }
     }
 }

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Resources.resx
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Resources.resx
@@ -393,4 +393,41 @@
         <value>Ignored fflag</value>
     </data>
     
+    <!-- RBI0029 -->
+    
+    <data name="RBI0029Description" xml:space="preserve">
+        <value>There is a mismatch between the arguments of a method/property and the number of ':' in a selector.</value>
+    </data>
+    <data name="RBI0029MessageFormat" xml:space="preserve">
+        <value>There is a mismatch between the arguments of '{0}' (found {1}) and the selector '{2}' (found {3})</value>
+        <comment>The {0} is the name of the method or property, {1} is the argument count. {2} is the selector and {3} is its argument count</comment>
+    </data>
+    <data name="RBI0029Title" xml:space="preserve">
+        <value>Selector argument mismatch</value>
+    </data>
+    
+    <!-- RBI0030 -->
+    
+    <data name="RBI0030Description" xml:space="preserve">
+        <value>Field properties must be declared static.</value>
+    </data>
+    <data name="RBI0030MessageFormat" xml:space="preserve">
+        <value>Field properties must be declared static</value>
+    </data>
+    <data name="RBI0030Title" xml:space="preserve">
+        <value>Wrong field declaration</value>
+    </data>
+    
+    <!-- RBI0031 -->
+    
+    <data name="RBI0031Description" xml:space="preserve">
+        <value>Exported properties must be declared partial.</value>
+    </data>
+    <data name="RBI0031MessageFormat" xml:space="preserve">
+        <value>Exported properties must be declared partial</value>
+    </data>
+    <data name="RBI0031Title" xml:space="preserve">
+        <value>Wrong property declaration</value>
+    </data>
+    
 </root>

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/RgenDiagnostics.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/RgenDiagnostics.cs
@@ -436,4 +436,49 @@ public static class RgenDiagnostics {
 		description: new LocalizableResourceString (nameof (Resources.RBI0028Description), Resources.ResourceManager,
 			typeof (Resources))
 	);
+	
+	/// <summary>
+	/// Diagnostic descriptor for when there is a mismatch between the number of arguments in a selector and the expected argument count.
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0029 = new (
+		"RBI0029",
+		new LocalizableResourceString (nameof (Resources.RBI0029Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0029MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
+		"Usage",
+		DiagnosticSeverity.Warning,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof (Resources.RBI0029Description), Resources.ResourceManager,
+			typeof (Resources))
+	);
+	
+	/// <summary>
+	/// Diagnostic descriptor for when a field property has not been marked as static.
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0030 = new (
+		"RBI0030",
+		new LocalizableResourceString (nameof (Resources.RBI0030Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0030MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
+		"Usage",
+		DiagnosticSeverity.Warning,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof (Resources.RBI0030Description), Resources.ResourceManager,
+			typeof (Resources))
+	);
+	
+	/// <summary>
+	/// Diagnostic descriptor for when a property has not been marked as partial.
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0031 = new (
+		"RBI0031",
+		new LocalizableResourceString (nameof (Resources.RBI0031Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0031MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
+		"Usage",
+		DiagnosticSeverity.Warning,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof (Resources.RBI0031Description), Resources.ResourceManager,
+			typeof (Resources))
+	);
 }

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/RgenDiagnostics.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/RgenDiagnostics.cs
@@ -436,7 +436,7 @@ public static class RgenDiagnostics {
 		description: new LocalizableResourceString (nameof (Resources.RBI0028Description), Resources.ResourceManager,
 			typeof (Resources))
 	);
-	
+
 	/// <summary>
 	/// Diagnostic descriptor for when there is a mismatch between the number of arguments in a selector and the expected argument count.
 	/// </summary>
@@ -451,7 +451,7 @@ public static class RgenDiagnostics {
 		description: new LocalizableResourceString (nameof (Resources.RBI0029Description), Resources.ResourceManager,
 			typeof (Resources))
 	);
-	
+
 	/// <summary>
 	/// Diagnostic descriptor for when a field property has not been marked as static.
 	/// </summary>
@@ -466,7 +466,7 @@ public static class RgenDiagnostics {
 		description: new LocalizableResourceString (nameof (Resources.RBI0030Description), Resources.ResourceManager,
 			typeof (Resources))
 	);
-	
+
 	/// <summary>
 	/// Diagnostic descriptor for when a property has not been marked as partial.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validator.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validator.cs
@@ -195,22 +195,7 @@ partial class Validator<T> : IValidator {
 		Validator<TField> nestedValidator)
 	{
 		var fieldName = GetPropertyName (selector);
-
 		nestedValidators [fieldName] = nestedValidator;
-
-		AddStrategy (selector, nestedValidator.Descriptors, NestedValidation);
-
-		bool NestedValidation (TField? data, RootContext context, out ImmutableArray<Diagnostic> diagnostic, Location? location = null)
-		{
-			diagnostic = [];
-			if (data is null)
-				return true; // null nested = valid
-
-			var nestedErrors = nestedValidator.ValidateAll (data, context);
-			// flatten the diagnostics
-			diagnostic = [.. nestedErrors.SelectMany (x => x.Value)];
-			return nestedErrors.Count == 0;
-		}
 	}
 
 	/// <summary>

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/ArrayValidator.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/ArrayValidator.cs
@@ -42,7 +42,7 @@ class ArrayValidator<T> : Validator<ImmutableArray<T>> {
 	/// The validator used internally to validate each of the items in the array.
 	/// </summary>
 	readonly Validator<T> validator;
-	
+
 	/// <summary>
 	/// Initializes a new instance of the <see cref="ArrayValidator{T}"/> class.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/ArrayValidator.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/ArrayValidator.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.Macios.Generator.Context;
+
+namespace Microsoft.Macios.Bindings.Analyzer.Validators;
+
+/// <summary>
+/// Validator for arrays of items, which validates each item in the array using an inner validator.
+/// </summary>
+/// <typeparam name="T">The type of items in the array to validate.</typeparam>
+class ArrayValidator<T> : Validator<ImmutableArray<T>> {
+	/// <summary>
+	/// Validates that all items in the array are valid using the inner validator.
+	/// </summary>
+	/// <param name="property">The array of items to validate.</param>
+	/// <param name="context">The root context for validation.</param>
+	/// <param name="diagnostics">When this method returns, contains an array of diagnostics if any items are invalid; otherwise, an empty array.</param>
+	/// <param name="location">The code location to be used for the diagnostics.</param>
+	/// <returns><c>true</c> if all items in the array are valid; otherwise, <c>false</c>.</returns>
+	bool AllItemsAreValid (ImmutableArray<T> property, RootContext context,
+		out ImmutableArray<Diagnostic> diagnostics, Location? location = null)
+	{
+		diagnostics = ImmutableArray<Diagnostic>.Empty;
+		var builder = ImmutableArray.CreateBuilder<Diagnostic> ();
+		// loop over all the variables, validate them and collect the diagnostics
+		foreach (var prop in property) {
+			var errors = validator.ValidateAll (prop, context);
+			if (errors.Count > 0) {
+				// flatten and add all the errors in the builder
+				builder.AddRange (errors.SelectMany (x => x.Value));
+			}
+		}
+		diagnostics = builder.ToImmutable ();
+		return diagnostics.Length == 0;
+	}
+
+	/// <summary>
+	/// The validator used internally to validate each of the items in the array.
+	/// </summary>
+	readonly Validator<T> validator;
+	
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ArrayValidator{T}"/> class.
+	/// </summary>
+	/// <param name="innerValidator">The validator to use for validating each item in the array.</param>
+	public ArrayValidator (Validator<T> innerValidator)
+	{
+		validator = innerValidator;
+		// add a global strategy that will validate each of the properties in the array
+		AddGlobalStrategy (validator.Descriptors, AllItemsAreValid);
+	}
+}

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/FieldValidator.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/FieldValidator.cs
@@ -48,7 +48,7 @@ class FieldValidator : Validator<Property> {
 			diagnostics: out diagnostics,
 			location: location
 		);
-	
+
 	/// <summary>
 	/// Validates that field property flags are appropriate for field properties.
 	/// Many property flags are ignored when used on fields, and this method validates that only valid flags are used.
@@ -108,7 +108,7 @@ class FieldValidator : Validator<Property> {
 		diagnostics = builder.ToImmutable ();
 		return diagnostics.Length == 0;
 	}
-	
+
 	/// <summary>
 	/// Initializes a new instance of the <see cref="FieldValidator"/> class.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/FieldValidator.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/FieldValidator.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.Macios.Generator.Context;
 using Microsoft.Macios.Generator.DataModel;
 using static Microsoft.Macios.Generator.RgenDiagnostics;
+using static Microsoft.Macios.Bindings.Analyzer.Validators.PropertyStrategies;
 
 namespace Microsoft.Macios.Bindings.Analyzer.Validators;
 using PropertyFlag = ObjCBindings.Property;
@@ -47,31 +48,7 @@ class FieldValidator : Validator<Property> {
 			diagnostics: out diagnostics,
 			location: location
 		);
-
-	/// <summary>
-	/// Validates that a field property has the partial modifier.
-	/// </summary>
-	/// <param name="property">The property to validate.</param>
-	/// <param name="context">The root context for validation.</param>
-	/// <param name="diagnostics">When this method returns, contains an array of diagnostics if the property is invalid; otherwise, an empty array.</param>
-	/// <param name="location">The code location to be used for the diagnostics.</param>
-	/// <returns><c>true</c> if the property has the partial modifier; otherwise, <c>false</c>.</returns>
-	internal static bool IsPartial (Property property, RootContext context, out ImmutableArray<Diagnostic> diagnostics,
-		Location? location = null)
-		=> ModifiersStrategies.IsPartial (property.Modifiers, RBI0004, out diagnostics, location, property.Name);
-
-	/// <summary>
-	/// Validates that a field property has the static modifier.
-	/// </summary>
-	/// <param name="property">The property to validate.</param>
-	/// <param name="context">The root context for validation.</param>
-	/// <param name="diagnostics">When this method returns, contains an array of diagnostics if the property is invalid; otherwise, an empty array.</param>
-	/// <param name="location">The code location to be used for the diagnostics.</param>
-	/// <returns><c>true</c> if the property has the static modifier; otherwise, <c>false</c>.</returns>
-	internal static bool IsStatic (Property property, RootContext context, out ImmutableArray<Diagnostic> diagnostics,
-		Location? location = null)
-		=> ModifiersStrategies.IsStatic (property.Modifiers, RBI0004, out diagnostics, location, property.Name);
-
+	
 	/// <summary>
 	/// Validates that field property flags are appropriate for field properties.
 	/// Many property flags are ignored when used on fields, and this method validates that only valid flags are used.
@@ -131,63 +108,7 @@ class FieldValidator : Validator<Property> {
 		diagnostics = builder.ToImmutable ();
 		return diagnostics.Length == 0;
 	}
-
-	/// <summary>
-	/// Validates that the field property and its accessors are available on the current platform.
-	/// This method checks platform availability for the property itself, its getter (if present), and its setter (if present).
-	/// </summary>
-	/// <param name="property">The property to validate.</param>
-	/// <param name="context">The root context for validation.</param>
-	/// <param name="diagnostics">When this method returns, contains an array of diagnostics if the property or its accessors are not available on the current platform; otherwise, an empty array.</param>
-	/// <param name="location">The code location to be used for the diagnostics.</param>
-	/// <returns><c>true</c> if the property and all its accessors are available on the current platform; otherwise, <c>false</c>.</returns>
-	internal static bool IsValidPlatform (Property property, RootContext context,
-		out ImmutableArray<Diagnostic> diagnostics, Location? location = null)
-	{
-		diagnostics = ImmutableArray<Diagnostic>.Empty;
-		if (!property.IsField) {
-			// this is a bug, return the diagnostic for it
-			diagnostics = [Diagnostic.Create (
-				RBI0000, // An unexpected error occurred while processing '{0}'. Please fill a bug report at https://github.com/dotnet/macios/issues/new.
-				location: location,
-				messageArgs: property.Name
-			)];
-			return false;
-		}
-
-		// there are several locations in which we need to check if the field is valid for the platform
-		// 1. the property itself
-		// 2. the getter if present
-		// 3. the setter if present
-		if (!SupportedPlatformStrategies.IsValidPlatform (property.SymbolAvailability,
-				context, out diagnostics, property.Name, property.Location)) {
-			return false;
-		}
-
-		var builder = ImmutableArray.CreateBuilder<Diagnostic> ();
-		// if we have a getter or a setter, we want to validate them as well but we will return those merged in the
-		// diagnostics rather than returning false if one of them is invalid
-		var getter = property.GetAccessor (AccessorKind.Getter);
-		if (!getter.IsNullOrDefault) {
-			if (!SupportedPlatformStrategies.IsValidPlatform (getter.SymbolAvailability, context,
-					out var getterDiagnostics,
-					$"{property.Name}.get", getter.Location)) {
-				builder.AddRange (getterDiagnostics);
-			}
-		}
-
-		var setter = property.GetAccessor (AccessorKind.Setter);
-		if (!setter.IsNullOrDefault) {
-			if (!SupportedPlatformStrategies.IsValidPlatform (setter.SymbolAvailability, context,
-					out var setterDiagnostics,
-					$"{property.Name}.set", setter.Location)) {
-				builder.AddRange (setterDiagnostics);
-			}
-		}
-		diagnostics = builder.ToImmutable ();
-		return diagnostics.Length == 0;
-	}
-
+	
 	/// <summary>
 	/// Initializes a new instance of the <see cref="FieldValidator"/> class.
 	/// </summary>
@@ -198,9 +119,9 @@ class FieldValidator : Validator<Property> {
 		AddStrategy (p => p.Selector, RBI0019, SelectorHasNoWhitespace);
 
 		// fields have to be partial
-		AddGlobalStrategy (RBI0001, IsPartial);
+		AddGlobalStrategy (RBI0031, IsPartial);
 		// fields have to be static	
-		AddGlobalStrategy (RBI0004, IsStatic);
+		AddGlobalStrategy (RBI0030, IsStatic);
 
 		// ensure that the flags are valid
 		AddGlobalStrategy ([RBI0000, RBI0028], FlagsAreValid);

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/PropertyStrategies.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/PropertyStrategies.cs
@@ -10,7 +10,7 @@ using static Microsoft.Macios.Generator.RgenDiagnostics;
 namespace Microsoft.Macios.Bindings.Analyzer.Validators;
 
 static class PropertyStrategies {
-	
+
 	/// <summary>
 	/// Validates that the field property and its accessors are available on the current platform.
 	/// This method checks platform availability for the property itself, its getter (if present), and its setter (if present).
@@ -57,7 +57,7 @@ static class PropertyStrategies {
 		diagnostics = builder.ToImmutable ();
 		return diagnostics.Length == 0;
 	}
-	
+
 	/// <summary>
 	/// Validates that a field property has the partial modifier.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/PropertyStrategies.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/PropertyStrategies.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.Macios.Generator.Context;
+using Microsoft.Macios.Generator.DataModel;
+using static Microsoft.Macios.Generator.RgenDiagnostics;
+
+namespace Microsoft.Macios.Bindings.Analyzer.Validators;
+
+static class PropertyStrategies {
+	
+	/// <summary>
+	/// Validates that the field property and its accessors are available on the current platform.
+	/// This method checks platform availability for the property itself, its getter (if present), and its setter (if present).
+	/// </summary>
+	/// <param name="property">The property to validate.</param>
+	/// <param name="context">The root context for validation.</param>
+	/// <param name="diagnostics">When this method returns, contains an array of diagnostics if the property or its accessors are not available on the current platform; otherwise, an empty array.</param>
+	/// <param name="location">The code location to be used for the diagnostics.</param>
+	/// <returns><c>true</c> if the property and all its accessors are available on the current platform; otherwise, <c>false</c>.</returns>
+	internal static bool IsValidPlatform (Property property, RootContext context,
+		out ImmutableArray<Diagnostic> diagnostics, Location? location = null)
+	{
+		diagnostics = ImmutableArray<Diagnostic>.Empty;
+
+		// there are several locations in which we need to check if the field is valid for the platform
+		// 1. the property itself
+		// 2. the getter if present
+		// 3. the setter if present
+		if (!SupportedPlatformStrategies.IsValidPlatform (property.SymbolAvailability,
+				context, out diagnostics, property.Name, property.Location)) {
+			return false;
+		}
+
+		var builder = ImmutableArray.CreateBuilder<Diagnostic> ();
+		// if we have a getter or a setter, we want to validate them as well but we will return those merged in the
+		// diagnostics rather than returning false if one of them is invalid
+		var getter = property.GetAccessor (AccessorKind.Getter);
+		if (!getter.IsNullOrDefault) {
+			if (!SupportedPlatformStrategies.IsValidPlatform (getter.SymbolAvailability, context,
+					out var getterDiagnostics,
+					$"{property.Name}.get", getter.Location)) {
+				builder.AddRange (getterDiagnostics);
+			}
+		}
+
+		var setter = property.GetAccessor (AccessorKind.Setter);
+		if (!setter.IsNullOrDefault) {
+			if (!SupportedPlatformStrategies.IsValidPlatform (setter.SymbolAvailability, context,
+					out var setterDiagnostics,
+					$"{property.Name}.set", setter.Location)) {
+				builder.AddRange (setterDiagnostics);
+			}
+		}
+		diagnostics = builder.ToImmutable ();
+		return diagnostics.Length == 0;
+	}
+	
+	/// <summary>
+	/// Validates that a field property has the partial modifier.
+	/// </summary>
+	/// <param name="property">The property to validate.</param>
+	/// <param name="context">The root context for validation.</param>
+	/// <param name="diagnostics">When this method returns, contains an array of diagnostics if the property is invalid; otherwise, an empty array.</param>
+	/// <param name="location">The code location to be used for the diagnostics.</param>
+	/// <returns><c>true</c> if the property has the partial modifier; otherwise, <c>false</c>.</returns>
+	internal static bool IsPartial (Property property, RootContext context, out ImmutableArray<Diagnostic> diagnostics,
+		Location? location = null)
+		=> ModifiersStrategies.IsPartial (property.Modifiers, RBI0031, out diagnostics, location, property.Name);
+
+	/// <summary>
+	/// Validates that a field property has the static modifier.
+	/// </summary>
+	/// <param name="property">The property to validate.</param>
+	/// <param name="context">The root context for validation.</param>
+	/// <param name="diagnostics">When this method returns, contains an array of diagnostics if the property is invalid; otherwise, an empty array.</param>
+	/// <param name="location">The code location to be used for the diagnostics.</param>
+	/// <returns><c>true</c> if the property has the static modifier; otherwise, <c>false</c>.</returns>
+	internal static bool IsStatic (Property property, RootContext context, out ImmutableArray<Diagnostic> diagnostics,
+		Location? location = null)
+		=> ModifiersStrategies.IsStatic (property.Modifiers, RBI0030, out diagnostics, location, property.Name);
+
+}

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/PropertyValidator.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/PropertyValidator.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.Macios.Generator.Context;
+using Microsoft.Macios.Generator.DataModel;
+using static Microsoft.Macios.Generator.RgenDiagnostics;
+using static Microsoft.Macios.Bindings.Analyzer.Validators.PropertyStrategies;
+
+namespace Microsoft.Macios.Bindings.Analyzer.Validators;
+
+/// <summary>
+/// Validator for property bindings.
+/// </summary>
+class PropertyValidator : Validator<Property> {
+	readonly ExportPropertyAttributeValidator exportPropertyValidator = new();
+
+	/// <summary>
+	/// Validates that a property accessor has valid export attributes when present.
+	/// This method checks that exported accessors have non-null selectors, no whitespace in selectors,
+	/// and that the selector argument count matches the expected count (0 for getters, 1 for setters).
+	/// </summary>
+	/// <param name="data">A tuple containing the property name and accessor to validate.</param>
+	/// <param name="context">The root context for validation.</param>
+	/// <param name="diagnostics">When this method returns, contains an array of diagnostics if the accessor is invalid; otherwise, an empty array.</param>
+	/// <param name="location">The code location to be used for the diagnostics.</param>
+	/// <returns><c>true</c> if the accessor is valid or has no export attributes; otherwise, <c>false</c>.</returns>
+	internal static bool AccessorIsValid ((string PropertyName, Accessor Accessor) data, RootContext context,
+		out ImmutableArray<Diagnostic> diagnostics,
+		Location? location = null)
+	{
+		diagnostics = ImmutableArray<Diagnostic>.Empty;
+		if (data.Accessor.IsNullOrDefault) {
+			// nothing to check, it is valid
+			return true;
+		}
+		
+		// if the accessor is present AND only if the export property data is not null, we need to validate it
+		if (data.Accessor.ExportPropertyData.IsNullOrDefault) {
+			// no need to check, it was not exported
+			return true;
+		}
+		
+		// validate the export property data, in this case we are just going to validate the selector:
+		
+		// 1. Is not null
+		if (!StringStrategies.IsNotNullOrEmpty (
+			selector: data.Accessor.ExportPropertyData.Selector,
+			descriptor: RBI0018, // A export property must have a selector defined
+			diagnostics: out diagnostics,
+			location: location))
+		{
+			return false;
+		}
+
+		// 2. Is not white spaces
+		if (!StringStrategies.HasNoWhitespace (
+			    stringValue: data.Accessor.ExportPropertyData.Selector,
+			    descriptor: RBI0019, // A export property selector must not contain any whitespace.
+			    diagnostics: out diagnostics,
+			    location: location)) {
+			return false;
+		}
+		
+		// 3. selector argument count
+		return StringStrategies.MatchingSelectorArgCount (
+			data.PropertyName, 
+			data.Accessor.ExportPropertyData.Selector, 
+			data.Accessor.Kind == AccessorKind.Getter ? 0 : 1,
+			out diagnostics);
+	}
+	
+	/// <summary>
+	/// Initializes a new instance of the <see cref="PropertyValidator"/> class.
+	/// </summary>
+	public PropertyValidator () : base (p => p.Location)
+	{
+		// validate the export property data of the current property
+		AddNestedValidator (p => p.ExportPropertyData, exportPropertyValidator);
+		
+		// properties must be partial 
+		AddGlobalStrategy (RBI0031, IsPartial);
+		
+		// check platform validity for the property and its accessors
+		AddGlobalStrategy ([RBI0000, RBI0027], IsValidPlatform);
+		
+		// ensure that if the accessors have an export attribute, that the values are correct
+		AddStrategy<(string PropertyName, Accessor accessor)> (
+			selector: p => new (p.Name, p.GetAccessor (AccessorKind.Getter)), 
+			descriptor: [RBI0018, RBI0019, RBI0029], 
+			validation: AccessorIsValid, 
+			propertyName: "getter");
+		
+		AddStrategy<(string PropertyName, Accessor accessor)> (
+			selector: p => new (p.Name, p.GetAccessor (AccessorKind.Setter)), 
+			descriptor:  [RBI0018, RBI0019, RBI0029], 
+			validation: AccessorIsValid, 
+			propertyName: "setter");
+	} 
+}

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/PropertyValidator.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/PropertyValidator.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Macios.Bindings.Analyzer.Validators;
 /// Validator for property bindings.
 /// </summary>
 class PropertyValidator : Validator<Property> {
-	readonly ExportPropertyAttributeValidator exportPropertyValidator = new();
+	readonly ExportPropertyAttributeValidator exportPropertyValidator = new ();
 
 	/// <summary>
 	/// Validates that a property accessor has valid export attributes when present.
@@ -35,42 +35,41 @@ class PropertyValidator : Validator<Property> {
 			// nothing to check, it is valid
 			return true;
 		}
-		
+
 		// if the accessor is present AND only if the export property data is not null, we need to validate it
 		if (data.Accessor.ExportPropertyData.IsNullOrDefault) {
 			// no need to check, it was not exported
 			return true;
 		}
-		
+
 		// validate the export property data, in this case we are just going to validate the selector:
-		
+
 		// 1. Is not null
 		if (!StringStrategies.IsNotNullOrEmpty (
 			selector: data.Accessor.ExportPropertyData.Selector,
 			descriptor: RBI0018, // A export property must have a selector defined
 			diagnostics: out diagnostics,
-			location: location))
-		{
+			location: location)) {
 			return false;
 		}
 
 		// 2. Is not white spaces
 		if (!StringStrategies.HasNoWhitespace (
-			    stringValue: data.Accessor.ExportPropertyData.Selector,
-			    descriptor: RBI0019, // A export property selector must not contain any whitespace.
-			    diagnostics: out diagnostics,
-			    location: location)) {
+				stringValue: data.Accessor.ExportPropertyData.Selector,
+				descriptor: RBI0019, // A export property selector must not contain any whitespace.
+				diagnostics: out diagnostics,
+				location: location)) {
 			return false;
 		}
-		
+
 		// 3. selector argument count
 		return StringStrategies.MatchingSelectorArgCount (
-			data.PropertyName, 
-			data.Accessor.ExportPropertyData.Selector, 
+			data.PropertyName,
+			data.Accessor.ExportPropertyData.Selector,
 			data.Accessor.Kind == AccessorKind.Getter ? 0 : 1,
 			out diagnostics);
 	}
-	
+
 	/// <summary>
 	/// Initializes a new instance of the <see cref="PropertyValidator"/> class.
 	/// </summary>
@@ -78,24 +77,24 @@ class PropertyValidator : Validator<Property> {
 	{
 		// validate the export property data of the current property
 		AddNestedValidator (p => p.ExportPropertyData, exportPropertyValidator);
-		
+
 		// properties must be partial 
 		AddGlobalStrategy (RBI0031, IsPartial);
-		
+
 		// check platform validity for the property and its accessors
 		AddGlobalStrategy ([RBI0000, RBI0027], IsValidPlatform);
-		
+
 		// ensure that if the accessors have an export attribute, that the values are correct
 		AddStrategy<(string PropertyName, Accessor accessor)> (
-			selector: p => new (p.Name, p.GetAccessor (AccessorKind.Getter)), 
-			descriptor: [RBI0018, RBI0019, RBI0029], 
-			validation: AccessorIsValid, 
+			selector: p => new (p.Name, p.GetAccessor (AccessorKind.Getter)),
+			descriptor: [RBI0018, RBI0019, RBI0029],
+			validation: AccessorIsValid,
 			propertyName: "getter");
-		
+
 		AddStrategy<(string PropertyName, Accessor accessor)> (
-			selector: p => new (p.Name, p.GetAccessor (AccessorKind.Setter)), 
-			descriptor:  [RBI0018, RBI0019, RBI0029], 
-			validation: AccessorIsValid, 
+			selector: p => new (p.Name, p.GetAccessor (AccessorKind.Setter)),
+			descriptor: [RBI0018, RBI0019, RBI0029],
+			validation: AccessorIsValid,
 			propertyName: "setter");
-	} 
+	}
 }

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/StringStrategies.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/StringStrategies.cs
@@ -90,4 +90,34 @@ public static class StringStrategies {
 			location: location,
 			messageArgs: messageArgs
 		);
+
+	/// <summary>
+	/// Validates that the number of colons in a selector matches the expected argument count.
+	/// </summary>
+	/// <param name="symbol">The symbol name for diagnostic purposes.</param>
+	/// <param name="selector">The selector to validate.</param>
+	/// <param name="argCount">The expected number of arguments.</param>
+	/// <param name="diagnostics">When this method returns, contains an array of diagnostics if the argument count does not match; otherwise, an empty array.</param>
+	/// <param name="location">The code location to be used for the diagnostics.</param>
+	/// <returns><c>true</c> if the selector argument count matches the expected count; otherwise, <c>false</c>.</returns>
+	internal static bool MatchingSelectorArgCount (string symbol, string? selector, int argCount,
+		out ImmutableArray<Diagnostic> diagnostics,
+		Location? location = null)
+	{
+		diagnostics = ImmutableArray<Diagnostic>.Empty;
+		if (selector is null)
+			return true;
+		// the number of ':' in the selector should be equal to the number of arguments
+		var count = selector.Count (c => c == ':');
+		if (count == argCount)
+			return true;
+		diagnostics = [
+			Diagnostic.Create (
+				descriptor: RBI0029, // There is a mismatch between the arguments of '{0}' (found {1}) and the selector '{2}' (found {3})
+				location: location,
+				symbol, argCount, selector, count)
+		];
+		return false;
+	}
+	
 }

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/StringStrategies.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/StringStrategies.cs
@@ -21,7 +21,7 @@ public static class StringStrategies {
 		Location? location = null)
 	{
 		diagnostics = ImmutableArray<Diagnostic>.Empty;
-		if (!string.IsNullOrEmpty(selector))
+		if (!string.IsNullOrEmpty (selector))
 			return true;
 		diagnostics = [
 			Diagnostic.Create (
@@ -119,5 +119,5 @@ public static class StringStrategies {
 		];
 		return false;
 	}
-	
+
 }

--- a/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/Validators/ArrayValidatorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/Validators/ArrayValidatorTests.cs
@@ -1,0 +1,237 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma warning disable APL0003
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Macios.Bindings.Analyzer.Validators;
+using Microsoft.Macios.Generator.Attributes;
+using Microsoft.Macios.Generator.Availability;
+using Microsoft.Macios.Generator.Context;
+using Microsoft.Macios.Generator.DataModel;
+using Xunit;
+using static Microsoft.Macios.Generator.Tests.TestDataFactory;
+
+namespace Microsoft.Macios.Bindings.Analyzer.Tests.Validators;
+
+public class ArrayValidatorTests {
+
+	readonly RootContext context;
+
+	public ArrayValidatorTests ()
+	{
+		// Create a dummy compilation to get a semantic model and RootContext
+		var syntaxTree = CSharpSyntaxTree.ParseText ("namespace Test { }");
+		var compilation = CSharpCompilation.Create (
+			"TestAssembly",
+			[syntaxTree],
+			references: [],
+			options: new CSharpCompilationOptions (OutputKind.DynamicallyLinkedLibrary)
+		);
+		var semanticModel = compilation.GetSemanticModel (syntaxTree);
+		context = new RootContext (semanticModel);
+	}
+
+	Property CreateFieldProperty (string name = "TestProperty",
+		bool isStatic = true,
+		bool isPartial = true,
+		ObjCBindings.Property flags = ObjCBindings.Property.Default,
+		string? selector = "testSelector")
+	{
+		var modifiers = ImmutableArray.CreateBuilder<SyntaxToken> ();
+		modifiers.Add (SyntaxFactory.Token (SyntaxKind.PublicKeyword));
+		if (isStatic)
+			modifiers.Add (SyntaxFactory.Token (SyntaxKind.StaticKeyword));
+		if (isPartial)
+			modifiers.Add (SyntaxFactory.Token (SyntaxKind.PartialKeyword));
+
+		var exportFieldData = new FieldInfo<ObjCBindings.Property> (
+			new FieldData<ObjCBindings.Property> (selector!, flags), "Test");
+
+		var availability = new SymbolAvailability.Builder ();
+		availability.Add (new SupportedOSPlatformData ("ios"));
+		availability.Add (new SupportedOSPlatformData ("tvos"));
+		availability.Add (new SupportedOSPlatformData ("macos"));
+		availability.Add (new SupportedOSPlatformData ("maccatalyst"));
+
+		return new Property (
+			name: name,
+			returnType: ReturnTypeForString (),
+			symbolAvailability: availability.ToImmutable (),
+			attributes: [],
+			modifiers: modifiers.ToImmutable (),
+			accessors: []
+		) {
+			ExportFieldData = exportFieldData,
+		};
+	}
+
+	[Theory]
+	[InlineData (new [] { true }, new [] { true }, 0)] // One valid field
+	[InlineData (new [] { false }, new [] { true }, 1)] // One invalid field (not static)
+	[InlineData (new [] { true }, new [] { false }, 1)] // One invalid field (not partial)
+	[InlineData (new [] { false }, new [] { false }, 2)] // One invalid field (neither static nor partial)
+	[InlineData (new [] { true, true }, new [] { true, true }, 0)] // Two valid fields
+	[InlineData (new [] { false, true }, new [] { true, true }, 1)] // One invalid, one valid
+	[InlineData (new [] { false, false }, new [] { true, true }, 2)] // Two invalid (not static)
+	[InlineData (new [] { true, true }, new [] { false, false }, 2)] // Two invalid (not partial)
+	[InlineData (new [] { false, false }, new [] { false, false }, 4)] // Two invalid (neither static nor partial)
+	public void ValidateArrayFieldModifiersTests (bool[] isStaticArray, bool[] isPartialArray, int expectedDiagnosticsCount)
+	{
+		var validator = new ArrayValidator<Property> (new FieldValidator ());
+		var properties = ImmutableArray.CreateBuilder<Property> ();
+		
+		for (int i = 0; i < isStaticArray.Length; i++) {
+			properties.Add (CreateFieldProperty (
+				name: $"TestProperty{i}",
+				isStatic: isStaticArray[i],
+				isPartial: isPartialArray[i]
+			));
+		}
+
+		var result = validator.ValidateAll (properties.ToImmutable (), context);
+
+		var totalDiagnostics = result.Values.Sum (x => x.Count);
+		Assert.Equal (expectedDiagnosticsCount, totalDiagnostics);
+	}
+
+	[Theory]
+	[InlineData (new [] { ObjCBindings.Property.Default }, 0)]
+	[InlineData (new [] { ObjCBindings.Property.IsThreadStatic }, 1)]
+	[InlineData (new [] { ObjCBindings.Property.Default, ObjCBindings.Property.Default }, 0)]
+	[InlineData (new [] { ObjCBindings.Property.IsThreadStatic, ObjCBindings.Property.Default }, 1)]
+	[InlineData (new [] { ObjCBindings.Property.IsThreadStatic, ObjCBindings.Property.MarshalNativeExceptions }, 2)]
+	[InlineData (new [] { ObjCBindings.Property.CustomMarshalDirective, ObjCBindings.Property.DisableZeroCopy, ObjCBindings.Property.IsThreadSafe }, 3)]
+	public void ValidateArrayIgnoredFlagsTests (ObjCBindings.Property[] flagsArray, int expectedDiagnosticsCount)
+	{
+		var validator = new ArrayValidator<Property> (new FieldValidator ());
+		var properties = ImmutableArray.CreateBuilder<Property> ();
+		
+		for (int i = 0; i < flagsArray.Length; i++) {
+			properties.Add (CreateFieldProperty (
+				name: $"TestProperty{i}",
+				flags: flagsArray[i]
+			));
+		}
+
+		var result = validator.ValidateAll (properties.ToImmutable (), context);
+
+		var diagnostics = new List<Diagnostic> ();
+		foreach (var (_, value) in result) {
+			diagnostics.AddRange (value);
+		}
+
+		if (expectedDiagnosticsCount > 0) {
+			Assert.Equal (expectedDiagnosticsCount, diagnostics.Count);
+			Assert.All (diagnostics, d => Assert.Equal ("RBI0028", d.Id));
+		} else {
+			Assert.Empty (diagnostics);
+		}
+	}
+
+	[Theory]
+	[InlineData (new [] { "validSelector" }, 0)]
+	[InlineData (new [] { "" }, 1)]
+	[InlineData (new string?[] { null }, 1)]
+	[InlineData (new [] { "validSelector", "anotherValid" }, 0)]
+	[InlineData (new [] { "validSelector", null }, 1)]
+	[InlineData (new string?[] { null, null }, 2)]
+	public void ArraySelectorIsNotNullTests (string?[] selectors, int expectedDiagnosticsCount)
+	{
+		var validator = new ArrayValidator<Property> (new FieldValidator ());
+		var properties = ImmutableArray.CreateBuilder<Property> ();
+		
+		for (int i = 0; i < selectors.Length; i++) {
+			properties.Add (CreateFieldProperty (
+				name: $"TestProperty{i}",
+				selector: selectors[i]
+			));
+		}
+
+		var result = validator.ValidateAll (properties.ToImmutable (), context);
+
+		var diagnostics = result.Values.SelectMany (x => x).ToList ();
+		var selectorDiagnostics = diagnostics.Where (d => d.Id == "RBI0018").ToList ();
+
+		Assert.Equal (expectedDiagnosticsCount, selectorDiagnostics.Count);
+	}
+
+	[Theory]
+	[InlineData (new [] { "validSelector" }, 0)]
+	[InlineData (new [] { "invalid selector" }, 1)]
+	[InlineData (new [] { "validSelector", "anotherValid" }, 0)]
+	[InlineData (new [] { "validSelector", "invalid selector" }, 1)]
+	[InlineData (new [] { "invalid selector", "another invalid" }, 2)]
+	[InlineData (new [] { "selector\twith\ttab", "selector\nwith\nnewline", " leadingSpace" }, 3)]
+	public void ArraySelectorHasNoWhitespaceTests (string[] selectors, int expectedDiagnosticsCount)
+	{
+		var validator = new ArrayValidator<Property> (new FieldValidator ());
+		var properties = ImmutableArray.CreateBuilder<Property> ();
+		
+		for (int i = 0; i < selectors.Length; i++) {
+			properties.Add (CreateFieldProperty (
+				name: $"TestProperty{i}",
+				selector: selectors[i]
+			));
+		}
+
+		var result = validator.ValidateAll (properties.ToImmutable (), context);
+
+		var diagnostics = result.Values.SelectMany (x => x).ToList ();
+		var whitespaceDiagnostics = diagnostics.Where (d => d.Id == "RBI0019").ToList ();
+
+		Assert.Equal (expectedDiagnosticsCount, whitespaceDiagnostics.Count);
+	}
+
+	[Fact]
+	public void ValidateEmptyArrayTests ()
+	{
+		var validator = new ArrayValidator<Property> (new FieldValidator ());
+		var properties = ImmutableArray<Property>.Empty;
+
+		var result = validator.ValidateAll (properties, context);
+
+		Assert.Empty (result);
+	}
+
+	[Fact]
+	public void ValidateArrayOfValidFieldsTests ()
+	{
+		var validator = new ArrayValidator<Property> (new FieldValidator ());
+		var properties = ImmutableArray.Create (
+			CreateFieldProperty (name: "Property1"),
+			CreateFieldProperty (name: "Property2"),
+			CreateFieldProperty (name: "Property3")
+		);
+
+		var result = validator.ValidateAll (properties, context);
+
+		Assert.Empty (result);
+	}
+
+	[Theory]
+	[InlineData (1)]
+	[InlineData (3)]
+	[InlineData (5)]
+	public void ValidateArrayWithMixedValidityTests (int arraySize)
+	{
+		var validator = new ArrayValidator<Property> (new FieldValidator ());
+		var properties = ImmutableArray.CreateBuilder<Property> ();
+		
+		for (int i = 0; i < arraySize; i++) {
+			// Make every other property invalid (not static)
+			properties.Add (CreateFieldProperty (
+				name: $"TestProperty{i}",
+				isStatic: i % 2 == 0
+			));
+		}
+
+		var result = validator.ValidateAll (properties.ToImmutable (), context);
+
+		var totalDiagnostics = result.Values.Sum (x => x.Count);
+		var expectedInvalidCount = arraySize / 2; // Every other property is invalid
+		Assert.Equal (expectedInvalidCount, totalDiagnostics);
+	}
+}

--- a/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/Validators/ArrayValidatorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/Validators/ArrayValidatorTests.cs
@@ -78,16 +78,16 @@ public class ArrayValidatorTests {
 	[InlineData (new [] { false, false }, new [] { true, true }, 2)] // Two invalid (not static)
 	[InlineData (new [] { true, true }, new [] { false, false }, 2)] // Two invalid (not partial)
 	[InlineData (new [] { false, false }, new [] { false, false }, 4)] // Two invalid (neither static nor partial)
-	public void ValidateArrayFieldModifiersTests (bool[] isStaticArray, bool[] isPartialArray, int expectedDiagnosticsCount)
+	public void ValidateArrayFieldModifiersTests (bool [] isStaticArray, bool [] isPartialArray, int expectedDiagnosticsCount)
 	{
 		var validator = new ArrayValidator<Property> (new FieldValidator ());
 		var properties = ImmutableArray.CreateBuilder<Property> ();
-		
+
 		for (int i = 0; i < isStaticArray.Length; i++) {
 			properties.Add (CreateFieldProperty (
 				name: $"TestProperty{i}",
-				isStatic: isStaticArray[i],
-				isPartial: isPartialArray[i]
+				isStatic: isStaticArray [i],
+				isPartial: isPartialArray [i]
 			));
 		}
 
@@ -104,15 +104,15 @@ public class ArrayValidatorTests {
 	[InlineData (new [] { ObjCBindings.Property.IsThreadStatic, ObjCBindings.Property.Default }, 1)]
 	[InlineData (new [] { ObjCBindings.Property.IsThreadStatic, ObjCBindings.Property.MarshalNativeExceptions }, 2)]
 	[InlineData (new [] { ObjCBindings.Property.CustomMarshalDirective, ObjCBindings.Property.DisableZeroCopy, ObjCBindings.Property.IsThreadSafe }, 3)]
-	public void ValidateArrayIgnoredFlagsTests (ObjCBindings.Property[] flagsArray, int expectedDiagnosticsCount)
+	public void ValidateArrayIgnoredFlagsTests (ObjCBindings.Property [] flagsArray, int expectedDiagnosticsCount)
 	{
 		var validator = new ArrayValidator<Property> (new FieldValidator ());
 		var properties = ImmutableArray.CreateBuilder<Property> ();
-		
+
 		for (int i = 0; i < flagsArray.Length; i++) {
 			properties.Add (CreateFieldProperty (
 				name: $"TestProperty{i}",
-				flags: flagsArray[i]
+				flags: flagsArray [i]
 			));
 		}
 
@@ -134,19 +134,19 @@ public class ArrayValidatorTests {
 	[Theory]
 	[InlineData (new [] { "validSelector" }, 0)]
 	[InlineData (new [] { "" }, 1)]
-	[InlineData (new string?[] { null }, 1)]
+	[InlineData (new string? [] { null }, 1)]
 	[InlineData (new [] { "validSelector", "anotherValid" }, 0)]
 	[InlineData (new [] { "validSelector", null }, 1)]
-	[InlineData (new string?[] { null, null }, 2)]
-	public void ArraySelectorIsNotNullTests (string?[] selectors, int expectedDiagnosticsCount)
+	[InlineData (new string? [] { null, null }, 2)]
+	public void ArraySelectorIsNotNullTests (string? [] selectors, int expectedDiagnosticsCount)
 	{
 		var validator = new ArrayValidator<Property> (new FieldValidator ());
 		var properties = ImmutableArray.CreateBuilder<Property> ();
-		
+
 		for (int i = 0; i < selectors.Length; i++) {
 			properties.Add (CreateFieldProperty (
 				name: $"TestProperty{i}",
-				selector: selectors[i]
+				selector: selectors [i]
 			));
 		}
 
@@ -165,15 +165,15 @@ public class ArrayValidatorTests {
 	[InlineData (new [] { "validSelector", "invalid selector" }, 1)]
 	[InlineData (new [] { "invalid selector", "another invalid" }, 2)]
 	[InlineData (new [] { "selector\twith\ttab", "selector\nwith\nnewline", " leadingSpace" }, 3)]
-	public void ArraySelectorHasNoWhitespaceTests (string[] selectors, int expectedDiagnosticsCount)
+	public void ArraySelectorHasNoWhitespaceTests (string [] selectors, int expectedDiagnosticsCount)
 	{
 		var validator = new ArrayValidator<Property> (new FieldValidator ());
 		var properties = ImmutableArray.CreateBuilder<Property> ();
-		
+
 		for (int i = 0; i < selectors.Length; i++) {
 			properties.Add (CreateFieldProperty (
 				name: $"TestProperty{i}",
-				selector: selectors[i]
+				selector: selectors [i]
 			));
 		}
 
@@ -219,7 +219,7 @@ public class ArrayValidatorTests {
 	{
 		var validator = new ArrayValidator<Property> (new FieldValidator ());
 		var properties = ImmutableArray.CreateBuilder<Property> ();
-		
+
 		for (int i = 0; i < arraySize; i++) {
 			// Make every other property invalid (not static)
 			properties.Add (CreateFieldProperty (

--- a/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/Validators/PropertyValidatorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/Validators/PropertyValidatorTests.cs
@@ -50,12 +50,12 @@ public class PropertyValidatorTests {
 			modifiers.Add (SyntaxFactory.Token (SyntaxKind.PartialKeyword));
 
 		var accessors = ImmutableArray.CreateBuilder<Accessor> ();
-		
+
 		if (hasGetter) {
 			getterSelector ??= "sampleGetter";
 			var getterExportData = new ExportData<ObjCBindings.Property> (getterSelector,
 				argumentSemantic, ObjCBindings.Property.Default);
-			
+
 			accessors.Add (new Accessor (
 				accessorKind: AccessorKind.Getter,
 				symbolAvailability: new SymbolAvailability.Builder ().ToImmutable (),
@@ -69,7 +69,7 @@ public class PropertyValidatorTests {
 			setterSelector ??= "sampleSetter:";
 			var setterExportData = new ExportData<ObjCBindings.Property> (setterSelector,
 				argumentSemantic, ObjCBindings.Property.Default);
-			
+
 			accessors.Add (new Accessor (
 				accessorKind: AccessorKind.Setter,
 				symbolAvailability: new SymbolAvailability.Builder ().ToImmutable (),
@@ -93,7 +93,7 @@ public class PropertyValidatorTests {
 			modifiers: modifiers.ToImmutable (),
 			accessors: accessors.ToImmutable ()
 		) {
-			ExportPropertyData = new ExportData<ObjCBindings.Property> (propertySelector, 
+			ExportPropertyData = new ExportData<ObjCBindings.Property> (propertySelector,
 				argumentSemantic, propertyFlags)
 		};
 	}

--- a/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/Validators/PropertyValidatorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/Validators/PropertyValidatorTests.cs
@@ -1,0 +1,273 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma warning disable APL0003
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Macios.Bindings.Analyzer.Validators;
+using Microsoft.Macios.Generator.Attributes;
+using Microsoft.Macios.Generator.Availability;
+using Microsoft.Macios.Generator.Context;
+using Microsoft.Macios.Generator.DataModel;
+using ObjCRuntime;
+using Xunit;
+using static Microsoft.Macios.Generator.Tests.TestDataFactory;
+
+namespace Microsoft.Macios.Bindings.Analyzer.Tests.Validators;
+
+public class PropertyValidatorTests {
+
+	readonly RootContext context;
+
+	public PropertyValidatorTests ()
+	{
+		// Create a dummy compilation to get a semantic model and RootContext
+		var syntaxTree = CSharpSyntaxTree.ParseText ("namespace Test { }");
+		var compilation = CSharpCompilation.Create (
+			"TestAssembly",
+			[syntaxTree],
+			references: [],
+			options: new CSharpCompilationOptions (OutputKind.DynamicallyLinkedLibrary)
+		);
+		var semanticModel = compilation.GetSemanticModel (syntaxTree);
+		context = new RootContext (semanticModel);
+	}
+
+	Property CreateProperty (string name = "TestProperty",
+		bool isPartial = true,
+		string? propertySelector = "testProperty",
+		ObjCBindings.Property propertyFlags = ObjCBindings.Property.Default,
+		ArgumentSemantic argumentSemantic = ArgumentSemantic.None,
+		string? getterSelector = null,
+		string? setterSelector = null,
+		bool hasGetter = true,
+		bool hasSetter = true)
+	{
+		var modifiers = ImmutableArray.CreateBuilder<SyntaxToken> ();
+		modifiers.Add (SyntaxFactory.Token (SyntaxKind.PublicKeyword));
+		if (isPartial)
+			modifiers.Add (SyntaxFactory.Token (SyntaxKind.PartialKeyword));
+
+		var accessors = ImmutableArray.CreateBuilder<Accessor> ();
+		
+		if (hasGetter) {
+			getterSelector ??= "sampleGetter";
+			var getterExportData = new ExportData<ObjCBindings.Property> (getterSelector,
+				argumentSemantic, ObjCBindings.Property.Default);
+			
+			accessors.Add (new Accessor (
+				accessorKind: AccessorKind.Getter,
+				symbolAvailability: new SymbolAvailability.Builder ().ToImmutable (),
+				exportPropertyData: getterExportData,
+				attributes: [],
+				modifiers: []
+			));
+		}
+
+		if (hasSetter) {
+			setterSelector ??= "sampleSetter:";
+			var setterExportData = new ExportData<ObjCBindings.Property> (setterSelector,
+				argumentSemantic, ObjCBindings.Property.Default);
+			
+			accessors.Add (new Accessor (
+				accessorKind: AccessorKind.Setter,
+				symbolAvailability: new SymbolAvailability.Builder ().ToImmutable (),
+				exportPropertyData: setterExportData,
+				attributes: [],
+				modifiers: []
+			));
+		}
+
+		var availability = new SymbolAvailability.Builder ();
+		availability.Add (new SupportedOSPlatformData ("ios"));
+		availability.Add (new SupportedOSPlatformData ("tvos"));
+		availability.Add (new SupportedOSPlatformData ("macos"));
+		availability.Add (new SupportedOSPlatformData ("maccatalyst"));
+
+		return new Property (
+			name: name,
+			returnType: ReturnTypeForString (),
+			symbolAvailability: availability.ToImmutable (),
+			attributes: [],
+			modifiers: modifiers.ToImmutable (),
+			accessors: accessors.ToImmutable ()
+		) {
+			ExportPropertyData = new ExportData<ObjCBindings.Property> (propertySelector, 
+				argumentSemantic, propertyFlags)
+		};
+	}
+
+	[Theory]
+	[InlineData (true, 0)] // Valid property: partial
+	[InlineData (false, 1)] // Invalid: not partial
+	public void ValidatePropertyModifiersTests (bool isPartial, int expectedDiagnosticsCount)
+	{
+		var validator = new PropertyValidator ();
+		var property = CreateProperty (isPartial: isPartial);
+
+		var result = validator.ValidateAll (property, context);
+
+		var totalDiagnostics = result.Values.Sum (x => x.Count);
+		Assert.Equal (expectedDiagnosticsCount, totalDiagnostics);
+	}
+
+	[Theory]
+	[InlineData ("validSelector", true, 0)]
+	[InlineData ("", false, 1)]
+	[InlineData (null, false, 1)]
+	[InlineData ("another_valid_selector", true, 0)]
+	[InlineData ("valid123", true, 0)]
+	public void PropertySelectorIsNotNullTests (string? selector, bool expectedResult, int expectedDiagnosticsCount)
+	{
+		var validator = new PropertyValidator ();
+		var property = CreateProperty (propertySelector: selector);
+
+		var result = validator.ValidateAll (property, context);
+		Assert.Equal (expectedResult, result.Count == 0);
+
+		var diagnostics = result.Values.SelectMany (x => x).ToList ();
+		var selectorDiagnostics = diagnostics.Where (d => d.Id == "RBI0018").ToList ();
+
+		Assert.Equal (expectedDiagnosticsCount, selectorDiagnostics.Count);
+	}
+
+	[Theory]
+	[InlineData ("validSelector", true, 0)]
+	[InlineData ("invalid selector", false, 1)]
+	[InlineData ("selector\twith\ttab", false, 1)]
+	[InlineData ("selector\nwith\nnewline", false, 1)]
+	[InlineData ("selector with space", false, 1)]
+	[InlineData ("valid_selector", true, 0)]
+	[InlineData ("validSelector123", true, 0)]
+	[InlineData (" leadingSpace", false, 1)]
+	[InlineData ("trailingSpace ", false, 1)]
+	public void PropertySelectorHasNoWhitespaceTests (string selector, bool expectedResult, int expectedDiagnosticsCount)
+	{
+		var validator = new PropertyValidator ();
+		var property = CreateProperty (propertySelector: selector);
+
+		var result = validator.ValidateAll (property, context);
+		Assert.Equal (expectedResult, result.Count == 0);
+
+		var diagnostics = result.Values.SelectMany (x => x).ToList ();
+		var whitespaceDiagnostics = diagnostics.Where (d => d.Id == "RBI0019").ToList ();
+
+		Assert.Equal (expectedDiagnosticsCount, whitespaceDiagnostics.Count);
+	}
+
+	[Theory]
+	[InlineData ("validGetter", null, 0)] // Valid getter, no setter export
+	[InlineData (null, "validSetter:", 0)] // No getter export, valid setter
+	[InlineData ("validGetter", "validSetter:", 0)] // Both valid
+	[InlineData ("", "validSetter:", 1)] // Invalid getter (empty)
+	[InlineData ("validGetter", "", 1)] // Invalid setter (empty)
+	[InlineData ("", "", 2)] // Both invalid
+	public void AccessorSelectorValidationTests (string? getterSelector, string? setterSelector, int expectedDiagnosticsCount)
+	{
+		var validator = new PropertyValidator ();
+		var property = CreateProperty (
+			getterSelector: getterSelector,
+			setterSelector: setterSelector
+		);
+
+		var result = validator.ValidateAll (property, context);
+
+		var diagnostics = result.Values.SelectMany (x => x).ToList ();
+		var selectorDiagnostics = diagnostics.Where (d => d.Id == "RBI0018").ToList ();
+
+		Assert.Equal (expectedDiagnosticsCount, selectorDiagnostics.Count);
+	}
+
+	[Theory]
+	[InlineData ("validGetter", "validSetter:", 0)] // Valid selectors
+	[InlineData ("invalid getter", "validSetter:", 1)] // Invalid getter (whitespace)
+	[InlineData ("validGetter", "invalid setter:", 1)] // Invalid setter (whitespace)
+	[InlineData ("invalid getter", "invalid setter:", 2)] // Both invalid
+	[InlineData ("getter\twith\ttab", "setter\nwith\nnewline:", 2)] // Both have different whitespace
+	public void AccessorSelectorWhitespaceTests (string getterSelector, string setterSelector, int expectedDiagnosticsCount)
+	{
+		var validator = new PropertyValidator ();
+		var property = CreateProperty (
+			getterSelector: getterSelector,
+			setterSelector: setterSelector
+		);
+
+		var result = validator.ValidateAll (property, context);
+
+		var diagnostics = result.Values.SelectMany (x => x).ToList ();
+		var whitespaceDiagnostics = diagnostics.Where (d => d.Id == "RBI0019").ToList ();
+
+		Assert.Equal (expectedDiagnosticsCount, whitespaceDiagnostics.Count);
+	}
+
+	[Theory]
+	[InlineData ("getPropertyValue", "setPropertyValue:", 0)] // Correct arg count: 0 for getter, 1 for setter
+	[InlineData ("getPropertyValue:", "setPropertyValue", 2)] // Wrong arg count: 1 for getter, 0 for setter
+	[InlineData ("getPropertyValue:withParam:", "setPropertyValue:", 1)] // Wrong getter arg count
+	[InlineData ("getPropertyValue", "setPropertyValue:withExtraParam:", 1)] // Wrong setter arg count
+	public void AccessorSelectorArgCountTests (string getterSelector, string setterSelector, int expectedDiagnosticsCount)
+	{
+		var validator = new PropertyValidator ();
+		var property = CreateProperty (
+			getterSelector: getterSelector,
+			setterSelector: setterSelector
+		);
+
+		var result = validator.ValidateAll (property, context);
+
+		var diagnostics = result.Values.SelectMany (x => x).ToList ();
+		var argCountDiagnostics = diagnostics.Where (d => d.Id == "RBI0029").ToList ();
+
+		Assert.Equal (expectedDiagnosticsCount, argCountDiagnostics.Count);
+	}
+
+	[Fact]
+	public void ValidateValidPropertyTests ()
+	{
+		var validator = new PropertyValidator ();
+		var property = CreateProperty (); // Default: partial, valid selectors
+
+		var result = validator.ValidateAll (property, context);
+
+		Assert.Empty (result);
+	}
+
+	[Theory]
+	[InlineData (true, true, 0)] // Has getter and setter, both valid
+	[InlineData (true, false, 0)] // Only getter, valid
+	[InlineData (false, true, 0)] // Only setter, valid
+	[InlineData (false, false, 0)] // No accessors, valid
+	public void PropertyAccessorPresenceTests (bool hasGetter, bool hasSetter, int expectedDiagnosticsCount)
+	{
+		var validator = new PropertyValidator ();
+		var property = CreateProperty (
+			hasGetter: hasGetter,
+			hasSetter: hasSetter
+		);
+
+		var result = validator.ValidateAll (property, context);
+
+		var totalDiagnostics = result.Values.Sum (x => x.Count);
+		Assert.Equal (expectedDiagnosticsCount, totalDiagnostics);
+	}
+
+	[Theory]
+	[InlineData (false, "validGetter", null, 1)] // Not partial but has valid accessors
+	[InlineData (false, "", "validSetter:", 2)] // Not partial and invalid getter
+	[InlineData (false, "invalid getter", "invalid setter:", 3)] // Not partial and multiple issues
+	public void CombinedValidationTests (bool isPartial, string? getterSelector, string? setterSelector, int expectedDiagnosticsCount)
+	{
+		var validator = new PropertyValidator ();
+		var property = CreateProperty (
+			isPartial: isPartial,
+			getterSelector: getterSelector,
+			setterSelector: setterSelector
+		);
+
+		var result = validator.ValidateAll (property, context);
+
+		var totalDiagnostics = result.Values.Sum (x => x.Count);
+		Assert.Equal (expectedDiagnosticsCount, totalDiagnostics);
+	}
+}


### PR DESCRIPTION
Changes in this commit:

1. Added a generic array validator that will validate an array using an inner validator.
2. Added a property validator that validates the following from a property:
   - Export<Property> attribute is valid.
   - Must be declared partial.
   - Supported platforms shoul be correct for the accessors.
   - Validate each of the accessor selectors if they have been added.

Extra changes:

1. While test the property validator I found out that we were duplicating errors in nested valiators. There is no need to add a new strategy when adding a nested validator.
2. Updated some of the error messages in the FieldValidator since we got one of the descriptors wrong.
3. Added a new string strategy to ensure that the number of ':' is a selector matches the number of arguments in a method (this includes getters and setters in properties).