### PR TITLE
[RGen] Handle sealed property and methods correctly.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.cs
@@ -49,7 +49,7 @@ readonly partial struct Method : IEquatable<Method> {
 	/// The name of the 'this' parameter for an extension method, or "this" for an instance method.
 	/// </summary>
 	public string This => IsExtension ? Parameters [0].Name : "this";
-
+	
 	/// <summary>
 	/// Method return type.
 	/// </summary>
@@ -71,6 +71,13 @@ readonly partial struct Method : IEquatable<Method> {
 	/// Returns if the method is static.
 	/// </summary>
 	public bool IsStatic => isStatic;
+	
+	readonly bool isSealed;
+
+	/// <summary>
+	/// True if the method was marked as sealed.
+	/// </summary>
+	public bool IsSealed => isSealed;
 
 	readonly ImmutableArray<SyntaxToken> modifiers = [];
 	/// <summary>
@@ -81,6 +88,7 @@ readonly partial struct Method : IEquatable<Method> {
 		init {
 			modifiers = value;
 			isStatic = modifiers.Any (x => x.IsKind (SyntaxKind.StaticKeyword));
+			isSealed = modifiers.Any (x => x.IsKind (SyntaxKind.SealedKeyword));
 		}
 	}
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
@@ -73,6 +73,13 @@ readonly partial struct Property : IEquatable<Property> {
 	/// </summary>
 	public bool IsStatic => isStatic;
 
+	readonly bool isSealed;
+	
+	/// <summary>
+	/// True if the method was marked as sealed.
+	/// </summary>
+	public bool IsSealed => isSealed;
+
 	/// <summary>
 	/// The platform availability of the property.
 	/// </summary>
@@ -94,6 +101,7 @@ readonly partial struct Property : IEquatable<Property> {
 		init {
 			modifiers = value;
 			isStatic = modifiers.Any (x => x.IsKind (SyntaxKind.StaticKeyword));
+			isSealed = modifiers.Any (x => x.IsKind (SyntaxKind.SealedKeyword));
 		}
 	}
 

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitterExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitterExtensions.cs
@@ -101,7 +101,7 @@ static class ClassEmitterExtensions {
 		}
 
 		// if we are dealing with a protocol or an extension method, we need to call send directly
-		if (context.Changes.BindingType == BindingType.Protocol || method.IsExtension) {
+		if (context.Changes.BindingType == BindingType.Protocol || method.IsExtension || method.IsSealed) {
 			methodBlock.WriteRaw (
 $@"{ExpressionStatement (invocations.Send)}
 {ExpressionStatement (KeepAlive (method.This))}
@@ -148,7 +148,7 @@ $@"if (IsDirectBinding) {{
 		}
 
 		// if we are dealing with a protocol or an extension method, we need to call send directly
-		if (context.Changes.BindingType == BindingType.Protocol || method.IsExtension) {
+		if (context.Changes.BindingType == BindingType.Protocol || method.IsExtension || method.IsSealed) {
 			methodBlock.WriteRaw (
 $@"{tempDeclaration}
 {ExpressionStatement (invocations.Send)}
@@ -395,7 +395,7 @@ return {backingField};
 				// the return value
 				var (tempVar, tempDeclaration) = GetReturnValueAuxVariable (property.ReturnType);
 				// if the binding is a protocol, we need to call send directly
-				if (context.Changes.BindingType == BindingType.Protocol) {
+				if (context.Changes.BindingType == BindingType.Protocol || property.IsSealed) {
 					getterBlock.WriteLine ($"{tempDeclaration}");
 					getterBlock.WriteLine ($"{ExpressionStatement (invocations.Getter.Send)}");
 					getterBlock.WriteLine ($"{ExpressionStatement (KeepAlive ("this"))}");
@@ -447,7 +447,7 @@ if (IsDirectBinding) {{
 
 				// perform the invocation
 				// if the binding is a protocol, we need to call send directly
-				if (context.Changes.BindingType == BindingType.Protocol) {
+				if (context.Changes.BindingType == BindingType.Protocol || property.IsSealed) {
 					setterBlock.WriteLine ($"{ExpressionStatement (invocations.Setter.Value.Send)}");
 					setterBlock.WriteLine ($"{ExpressionStatement (KeepAlive ("this"))}");
 				} else {

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedMethodsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ExpectedMethodsTests.cs
@@ -70,6 +70,10 @@ public partial class MethodTests
 	static readonly global::ObjCRuntime.NativeHandle selBookmarkDataWithContentsOfURL_Subdomain_Error_XHandle = global::ObjCRuntime.Selector.GetHandle ("bookmarkDataWithContentsOfURL:subdomain:error:");
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selReplaceObjectAtIndex_WithObject_X = "replaceObjectAtIndex:withObject:";
+	static readonly global::ObjCRuntime.NativeHandle selReplaceObjectAtIndex_WithObject_XHandle = global::ObjCRuntime.Selector.GetHandle ("replaceObjectAtIndex:withObject:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	static readonly global::ObjCRuntime.NativeHandle class_ptr = global::ObjCRuntime.Class.GetHandle ("MethodTests");
 
 	/// <summary>The Objective-C class handle for this class.</summary>
@@ -444,6 +448,17 @@ public partial class MethodTests
 				_tcs.SetResult (new (_cbattributedString, _cbattributes));
 		});
 		return _tcs.Task;
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	internal sealed partial void ReplaceObject (global::System.IntPtr index, global::System.IntPtr withObject)
+	{
+		global::ObjCRuntime.Messaging.void_objc_msgSend_IntPtr_IntPtr (this.Handle, global::ObjCRuntime.Selector.GetHandle ("replaceObjectAtIndex:withObject:"), index, withObject);
+		global::System.GC.KeepAlive (this);
 	}
 
 	[SupportedOSPlatform ("macos")]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
@@ -128,4 +128,11 @@ public partial class MethodTests {
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[Export<Method> ("bookmarkDataWithContentsOfURL:subdomain:error:")]
 	public static unsafe partial NSData GetBookmarkData (NSUrl bookmarkFileUrl, string subdomain, out NSError? error);
+	
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[Export<Method> ("replaceObjectAtIndex:withObject:")] 
+	internal sealed partial void ReplaceObject (nint index, IntPtr withObject); 
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/PropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/PropertyTests.cs
@@ -62,12 +62,19 @@ public partial class PropertyTests {
 	public virtual partial string Name { get; set; }
 
 	// nullable string
-	[Export<Property> ("name")]
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
+	[Export<Property> ("name")]
 	public virtual partial string? OtherName { get; set; }
+	
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[Export<Property> ("sealedProperty")]
+	public sealed partial string SelaedProperty { get; set; }
 
 	// array of strings
 	[Export<Property> ("surnames")]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
@@ -65,6 +65,14 @@ public partial class PropertyTests
 	static readonly global::ObjCRuntime.NativeHandle selSetName_XHandle = global::ObjCRuntime.Selector.GetHandle ("setName:");
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSealedPropertyX = "sealedProperty";
+	static readonly global::ObjCRuntime.NativeHandle selSealedPropertyXHandle = global::ObjCRuntime.Selector.GetHandle ("sealedProperty");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetSealedProperty_X = "setSealedProperty:";
+	static readonly global::ObjCRuntime.NativeHandle selSetSealedProperty_XHandle = global::ObjCRuntime.Selector.GetHandle ("setSealedProperty:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	const string selSurnamesX = "surnames";
 	static readonly global::ObjCRuntime.NativeHandle selSurnamesXHandle = global::ObjCRuntime.Selector.GetHandle ("surnames");
 
@@ -901,6 +909,40 @@ public partial class PropertyTests
 			global::System.GC.KeepAlive (nsa_value);
 			MarkDirty ();
 			__mt_Results_var = value;
+		}
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public sealed partial string SelaedProperty
+	{
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("ios")]
+		[SupportedOSPlatform ("tvos")]
+		[SupportedOSPlatform ("maccatalyst13.1")]
+		get
+		{
+			string ret;
+			ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("sealedProperty")), false)!;
+			global::System.GC.KeepAlive (this);
+			return ret;
+		}
+
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("ios")]
+		[SupportedOSPlatform ("tvos")]
+		[SupportedOSPlatform ("maccatalyst13.1")]
+		set
+		{
+			if (value is null)
+				global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value));
+			var nsvalue = global::CoreFoundation.CFString.CreateNative (value);
+			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setSealedProperty:"), nsvalue);
+			global::System.GC.KeepAlive (this);
+			global::CoreFoundation.CFString.ReleaseNative (nsvalue);
 		}
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
@@ -65,6 +65,14 @@ public partial class PropertyTests
 	static readonly global::ObjCRuntime.NativeHandle selSetName_XHandle = global::ObjCRuntime.Selector.GetHandle ("setName:");
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSealedPropertyX = "sealedProperty";
+	static readonly global::ObjCRuntime.NativeHandle selSealedPropertyXHandle = global::ObjCRuntime.Selector.GetHandle ("sealedProperty");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetSealedProperty_X = "setSealedProperty:";
+	static readonly global::ObjCRuntime.NativeHandle selSetSealedProperty_XHandle = global::ObjCRuntime.Selector.GetHandle ("setSealedProperty:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	const string selSurnamesX = "surnames";
 	static readonly global::ObjCRuntime.NativeHandle selSurnamesXHandle = global::ObjCRuntime.Selector.GetHandle ("surnames");
 
@@ -901,6 +909,40 @@ public partial class PropertyTests
 			global::System.GC.KeepAlive (nsa_value);
 			MarkDirty ();
 			__mt_Results_var = value;
+		}
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public sealed partial string SelaedProperty
+	{
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("ios")]
+		[SupportedOSPlatform ("tvos")]
+		[SupportedOSPlatform ("maccatalyst13.1")]
+		get
+		{
+			string ret;
+			ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("sealedProperty")), false)!;
+			global::System.GC.KeepAlive (this);
+			return ret;
+		}
+
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("ios")]
+		[SupportedOSPlatform ("tvos")]
+		[SupportedOSPlatform ("maccatalyst13.1")]
+		set
+		{
+			if (value is null)
+				global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value));
+			var nsvalue = global::CoreFoundation.CFString.CreateNative (value);
+			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setSealedProperty:"), nsvalue);
+			global::System.GC.KeepAlive (this);
+			global::CoreFoundation.CFString.ReleaseNative (nsvalue);
 		}
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedMethodsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedMethodsTests.cs
@@ -66,6 +66,10 @@ public partial class MethodTests
 	static readonly global::ObjCRuntime.NativeHandle selBookmarkDataWithContentsOfURL_Subdomain_Error_XHandle = global::ObjCRuntime.Selector.GetHandle ("bookmarkDataWithContentsOfURL:subdomain:error:");
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selReplaceObjectAtIndex_WithObject_X = "replaceObjectAtIndex:withObject:";
+	static readonly global::ObjCRuntime.NativeHandle selReplaceObjectAtIndex_WithObject_XHandle = global::ObjCRuntime.Selector.GetHandle ("replaceObjectAtIndex:withObject:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	static readonly global::ObjCRuntime.NativeHandle class_ptr = global::ObjCRuntime.Class.GetHandle ("MethodTests");
 
 	/// <summary>The Objective-C class handle for this class.</summary>
@@ -360,6 +364,17 @@ public partial class MethodTests
 		global::CoreFoundation.CFString.ReleaseNative (nssubdomain);
 		error = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSError> (error__handle__);
 		return ret;
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	internal sealed partial void ReplaceObject (global::System.IntPtr index, global::System.IntPtr withObject)
+	{
+		global::ObjCRuntime.Messaging.void_objc_msgSend_IntPtr_IntPtr (this.Handle, global::ObjCRuntime.Selector.GetHandle ("replaceObjectAtIndex:withObject:"), index, withObject);
+		global::System.GC.KeepAlive (this);
 	}
 
 	[SupportedOSPlatform ("macos")]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
@@ -65,6 +65,14 @@ public partial class PropertyTests
 	static readonly global::ObjCRuntime.NativeHandle selSetName_XHandle = global::ObjCRuntime.Selector.GetHandle ("setName:");
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSealedPropertyX = "sealedProperty";
+	static readonly global::ObjCRuntime.NativeHandle selSealedPropertyXHandle = global::ObjCRuntime.Selector.GetHandle ("sealedProperty");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetSealedProperty_X = "setSealedProperty:";
+	static readonly global::ObjCRuntime.NativeHandle selSetSealedProperty_XHandle = global::ObjCRuntime.Selector.GetHandle ("setSealedProperty:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	const string selSurnamesX = "surnames";
 	static readonly global::ObjCRuntime.NativeHandle selSurnamesXHandle = global::ObjCRuntime.Selector.GetHandle ("surnames");
 
@@ -901,6 +909,40 @@ public partial class PropertyTests
 			global::System.GC.KeepAlive (nsa_value);
 			MarkDirty ();
 			__mt_Results_var = value;
+		}
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public sealed partial string SelaedProperty
+	{
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("ios")]
+		[SupportedOSPlatform ("tvos")]
+		[SupportedOSPlatform ("maccatalyst13.1")]
+		get
+		{
+			string ret;
+			ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("sealedProperty")), false)!;
+			global::System.GC.KeepAlive (this);
+			return ret;
+		}
+
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("ios")]
+		[SupportedOSPlatform ("tvos")]
+		[SupportedOSPlatform ("maccatalyst13.1")]
+		set
+		{
+			if (value is null)
+				global::ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (value));
+			var nsvalue = global::CoreFoundation.CFString.CreateNative (value);
+			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setSealedProperty:"), nsvalue);
+			global::System.GC.KeepAlive (this);
+			global::CoreFoundation.CFString.ReleaseNative (nsvalue);
 		}
 	}
 


### PR DESCRIPTION
From the [review](https://github.com/dotnet/macios/pull/23656#pullrequestreview-3141249358) we noticed that sealed property and methods do not need the IsDirecBinding check. We update the struct to let use know if the method is sealed and generate the call accordingly. We just need to update some if conditions.

Tests have been updated to handle this case.