### PR TITLE
[release/10.0.1xx-rc.1] [system-dependencies] Explicitly install the simulator version we're built for.

### DIFF
--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -304,10 +304,13 @@ function install_mono () {
 
 function xcodebuild_download_selected_platforms ()
 {
-	log "Executing '$XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild -downloadPlatform iOS' $1"
-	"$XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild" -downloadPlatform iOS
-	log "Executing '$XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild -downloadPlatform tvOS' $1"
-	"$XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild" -downloadPlatform tvOS
+	IOS_NUGET_OS_VERSION=$(grep '^IOS_NUGET_OS_VERSION=' Make.version | sed 's/.*=//')
+	log "Executing '$XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild -downloadPlatform iOS -buildVersion $IOS_NUGET_OS_VERSION' $1"
+	"$XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild" -downloadPlatform iOS -buildVersion $IOS_NUGET_OS_VERSION
+
+	TVOS_NUGET_OS_VERSION=$(grep '^TVOS_NUGET_OS_VERSION=' Make.version | sed 's/.*=//')
+	log "Executing '$XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild -downloadPlatform tvOS -buildVersion $TVOS_NUGET_OS_VERSION' $1"
+	"$XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild" -downloadPlatform tvOS -buildVersion $TVOS_NUGET_OS_VERSION
 }
 
 function download_xcode_platforms ()

--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -304,11 +304,11 @@ function install_mono () {
 
 function xcodebuild_download_selected_platforms ()
 {
-	IOS_NUGET_OS_VERSION=$(grep '^IOS_NUGET_OS_VERSION=' Make.version | sed 's/.*=//')
+	IOS_NUGET_OS_VERSION=$(grep '^IOS_NUGET_OS_VERSION=' Make.versions | sed 's/.*=//')
 	log "Executing '$XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild -downloadPlatform iOS -buildVersion $IOS_NUGET_OS_VERSION' $1"
 	"$XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild" -downloadPlatform iOS -buildVersion $IOS_NUGET_OS_VERSION
 
-	TVOS_NUGET_OS_VERSION=$(grep '^TVOS_NUGET_OS_VERSION=' Make.version | sed 's/.*=//')
+	TVOS_NUGET_OS_VERSION=$(grep '^TVOS_NUGET_OS_VERSION=' Make.versions | sed 's/.*=//')
 	log "Executing '$XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild -downloadPlatform tvOS -buildVersion $TVOS_NUGET_OS_VERSION' $1"
 	"$XCODE_DEVELOPER_ROOT/usr/bin/xcodebuild" -downloadPlatform tvOS -buildVersion $TVOS_NUGET_OS_VERSION
 }


### PR DESCRIPTION
Example scenario:

1. Apple releases iOS 18.5 + corresponding Xcode, we update our build and
   versions accordingly.
2. Apple releases iOS 18.6, without a corresponding Xcode, but with a new iOS
   18.6 simulator which is installed whenever you ask Xcode to install the iOS
   simulator. This causes problems, because now xharness will ask for an iOS
   18.5 simulator, which may no be installed, because our install scripts
   inadvertedly installs the iOS 18.6 simulator.

The fix is to make our install script explicitly install the simulator version
we expect to be installed.

Backport of #23670.