### PR TITLE
[ci] Enable PME when signing NuGet packages

### DIFF
--- a/.azuredevops/policies/branchClassification.yml
+++ b/.azuredevops/policies/branchClassification.yml
@@ -1,0 +1,19 @@
+name: branch_classification
+resource: repository
+disabled: false
+where:
+configuration:
+  branchClassificationSettings:
+    defaultClassification: nonproduction
+    ruleset:
+      - name: prod-branches
+        branchNames:
+          - main
+          - release-test/*
+          - release/*
+          - net7.0
+          - net8.0
+          - net9.0
+          - net10.0
+          - xcode*
+        classification: production

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -50,10 +50,9 @@ stages:
 
   jobs:
   # Check - "xamarin-macios (Prepare Release Sign NuGets)"
-  - template: sign-artifacts/jobs/v2.yml@yaml-templates
+  - template: sign-artifacts/jobs/v4.yml@yaml-templates
     parameters:
       timeoutInMinutes: 120
-      use1ESTemplate: true
       uploadBinlogs: true
       uploadPrefix: ${{ parameters.uploadPrefix }}
       enabledCredScan: false


### PR DESCRIPTION
- Use the new sign-artifacts v4 that is already configured to enable PME for real signing. We use this to sign our NuGet pacakges.
- Adds production declaration our release branches as their names do not match 1ES classification. 