### PR TITLE
[tests] Adjust NWPathTest.LinkQuality to accept a wider range of network connectivity.

### DIFF
--- a/tests/monotouch-test/Network/NWPathTest.cs
+++ b/tests/monotouch-test/Network/NWPathTest.cs
@@ -172,7 +172,7 @@ namespace MonoTouchFixtures.Network {
 		public void LinkQuality ()
 		{
 			TestRuntime.AssertXcodeVersion (26, 0);
-			Assert.That (path.LinkQuality, Is.EqualTo (NWLinkQuality.Good).Or.EqualTo (NWLinkQuality.Unknown), "LinkQuality");
+			Assert.That (path.LinkQuality, Is.EqualTo (NWLinkQuality.Good).Or.EqualTo (NWLinkQuality.Moderate).Or.EqualTo (NWLinkQuality.Minimal).Or.EqualTo (NWLinkQuality.Unknown), "LinkQuality");
 		}
 	}
 }


### PR DESCRIPTION
This prevents random failures when running tests.