### PR TITLE
[tests] Fix a few formatting issues.

### DIFF
--- a/tests/monotouch-test/AppKit/NSDraggingItem.cs
+++ b/tests/monotouch-test/AppKit/NSDraggingItem.cs
@@ -19,8 +19,7 @@ namespace Xamarin.Mac.Tests {
 #pragma warning restore 0219
 		}
 
-		class MyPasteboard : NSObject, INSPasteboardWriting
-		{
+		class MyPasteboard : NSObject, INSPasteboardWriting {
 			NSObject INSPasteboardWriting.GetPasteboardPropertyListForType (string type)
 			{
 				return new NSObject ();

--- a/tests/monotouch-test/AppKit/NSPasteboard.cs
+++ b/tests/monotouch-test/AppKit/NSPasteboard.cs
@@ -517,12 +517,10 @@ namespace Xamarin.Mac.Tests {
 			b.ReleaseGlobally ();
 		}
 
-		class MyPasteboard2 : NSObject, INSPasteboardReading
-		{
+		class MyPasteboard2 : NSObject, INSPasteboardReading {
 		}
 
-		class MyPasteboard : NSObject, INSPasteboardWriting
-		{
+		class MyPasteboard : NSObject, INSPasteboardWriting {
 			NSObject INSPasteboardWriting.GetPasteboardPropertyListForType (string type)
 			{
 				return new NSObject ();

--- a/tests/monotouch-test/AppKit/NSTextFinder.cs
+++ b/tests/monotouch-test/AppKit/NSTextFinder.cs
@@ -22,8 +22,7 @@ namespace Xamarin.Mac.Tests {
 			f.Client = client;
 		}
 
-		class FinderClient : NSObject, INSTextFinderClient
-		{
+		class FinderClient : NSObject, INSTextFinderClient {
 			public bool AllowsMultipleSelection { get { return true; } }
 
 			public bool Editable { get { return true; } }

--- a/tests/monotouch-test/ScriptingBridge/SBApplicationTest.cs
+++ b/tests/monotouch-test/ScriptingBridge/SBApplicationTest.cs
@@ -37,8 +37,7 @@ namespace Xamarin.Mac.Tests {
 			using (var app1 = SBApplication.GetApplication (knownBundle))
 			using (var app2 = SBApplication.GetApplication<MySBApp> (knownBundle))
 			using (var app3 = SBApplication.GetApplication (unknownBundle))
-			using (var app4 = SBApplication.GetApplication<MySBApp> (unknownBundle))
-			{
+			using (var app4 = SBApplication.GetApplication<MySBApp> (unknownBundle)) {
 				Assert.IsNotNull (app1, "SBApplication from known bundle is null");
 				Assert.IsNotNull (app2, "MySBApp from known bundle is null");
 				Assert.IsNull (app3, "SBApplication from unknown bundle is non-null");
@@ -51,8 +50,7 @@ namespace Xamarin.Mac.Tests {
 		{
 			using (NSUrl knownUrl = new NSUrl ("http://www.xamarin.com"))
 			using (var app1 = SBApplication.GetApplication (knownUrl))
-			using (var app2 = SBApplication.GetApplication<MySBApp> (knownUrl))
-			{
+			using (var app2 = SBApplication.GetApplication<MySBApp> (knownUrl)) {
 				Assert.IsNotNull (app1, "SBApplication from known URL is null");
 				Assert.IsNotNull (app2, "MySBApp from known URL is null");
 			}
@@ -66,8 +64,7 @@ namespace Xamarin.Mac.Tests {
 			using (var app1 = SBApplication.GetApplication (knownPid))
 			using (var app2 = SBApplication.GetApplication<MySBApp> (knownPid))
 			using (var app3 = SBApplication.GetApplication (unknownPid))
-			using (var app4 = SBApplication.GetApplication<MySBApp> (unknownPid))
-			{
+			using (var app4 = SBApplication.GetApplication<MySBApp> (unknownPid)) {
 				Assert.IsNotNull (app1, "SBApplication from known pid is null");
 				Assert.IsNotNull (app2, "MySBApp from known pid is null");
 				Assert.IsNotNull (app3, "SBApplication from unknown pid is null");


### PR DESCRIPTION
Fix a few formatting issues that the autoformat script only fix when the
macios working directory is fully built (because the offending code is behind
conditional compilation symbols, which are only defined in a fully built
working copy).