### PR TITLE
[mk] Pass -fdiagnostics-absolute-paths to clang.

### DIFF
--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -23,7 +23,20 @@ macos_DEFINES=-DMONOMAC
 # We can probably remove this flag once we require developers to use Xcode 14.
 # Ref: https://github.com/dotnet/macios/issues/16223
 OBJC_CFLAGS=-ObjC++ -std=c++14 -fno-exceptions -fno-objc-msgsend-selector-stubs -fobjc-abi-version=2 -fobjc-legacy-dispatch
-CFLAGS= -Wall -fms-extensions -Werror -Wconversion -Wdeprecated -Wuninitialized -fstack-protector-strong -Wformat -Wformat-security -Werror=format-security -g -I.
+CFLAGS=\
+	-Wall \
+	-fms-extensions \
+	-Werror \
+	-Wconversion \
+	-Wdeprecated \
+	-Wuninitialized \
+	-fstack-protector-strong \
+	-Wformat \
+	-Wformat-security \
+	-Werror=format-security \
+	-fdiagnostics-absolute-paths \
+	-g \
+	-I.
 SWIFTFLAGS=-g -emit-library
 
 SWIFT_TOOLCHAIN_iossimulator=iphonesimulator


### PR DESCRIPTION
This way clang will show the full paths to files when emitting errors and
warnings, which makes it much easier to c&p the path to open it in an editor.