### PR TITLE
[Foundation] Make it possible to customize the X509ChainPolicy when validating certificates in NSUrlSessionHandler. Fixes #23764.

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -594,8 +594,13 @@ namespace Foundation {
 		/// </remarks>
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		public bool CheckCertificateRevocationList {
+			// This implementation was mostly copied from https://github.com/dotnet/runtime/blob/0e3562e97c6db531f26a2ffe3e8084cf67ba8a93/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs#L326-L335
 			get => CertificateChainPolicy!.RevocationMode == X509RevocationMode.Online;
-			set => CertificateChainPolicy!.RevocationMode = value ? X509RevocationMode.Online : X509RevocationMode.NoCheck;
+			set {
+				EnsureModifiability ();
+
+				CertificateChainPolicy!.RevocationMode = value ? X509RevocationMode.Online : X509RevocationMode.NoCheck;
+			}
 		}
 
 		/// <summary>Gets or sets the custom chain policy to use when validating certificate chains.</summary>

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -615,6 +615,13 @@ namespace Foundation {
 					policy = new X509ChainPolicy () {
 						RevocationMode = X509RevocationMode.Online,
 						RevocationFlag = X509RevocationFlag.ExcludeRoot,
+						// Ignore unknown revocation status, because Apple has a bug where revocation checks fail if the certificate(s)
+						// in question don't support revocation checking via OCSP.
+						// References:
+						// * https://learn.microsoft.com/en-us/dotnet/core/compatibility/networking/10.0/ssl-certificate-revocation-check-default
+						// * https://github.com/dotnet/macios/issues/23764#issuecomment-3264999234
+						// * https://github.com/dotnet/runtime/issues/117195
+						VerificationFlags = X509VerificationFlags.IgnoreEndRevocationUnknown,
 					};
 				}
 				return policy;

--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -131,6 +131,7 @@ namespace Foundation {
 		NSObject? notificationToken;  // needed to make sure we do not hang if not using a background session
 		readonly object notificationTokenLock = new object (); // need to make sure that threads do no step on each other with a dispose and a remove  inflight data
 #endif
+		X509ChainPolicy? policy;
 
 		static NSUrlSessionConfiguration CreateConfig ()
 		{
@@ -586,15 +587,35 @@ namespace Foundation {
 			set { }
 		}
 
-		// We're ignoring this property, just like Xamarin.Android does:
-		// https://github.com/xamarin/xamarin-android/blob/09e8cb5c07ea6c39383185a3f90e53186749b802/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs#L158
-		[UnsupportedOSPlatform ("ios")]
-		[UnsupportedOSPlatform ("maccatalyst")]
-		[UnsupportedOSPlatform ("tvos")]
-		[UnsupportedOSPlatform ("macos")]
+		/// <summary>Gets or sets a value that indicates whether the certificate is checked against the certificate authority revocation list.</summary>
+		/// <remarks>
+		///   <para>This is the same as setting CertificateChainPolicy.RevocationMode = X509RevocationMode.Online (if enabling the check) or X509RevocationMode.NoCheck (if disabling the check).</para>
+		///   <para>This only has an effect if a custom server certificate validation callback is being used ('ServerCertificateCustomValidationCallback' is set).</para>
+		/// </remarks>
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public bool CheckCertificateRevocationList { get; set; } = false;
+		public bool CheckCertificateRevocationList {
+			get => CertificateChainPolicy!.RevocationMode == X509RevocationMode.Online;
+			set => CertificateChainPolicy!.RevocationMode = value ? X509RevocationMode.Online : X509RevocationMode.NoCheck;
+		}
 
+		/// <summary>Gets or sets the custom chain policy to use when validating certificate chains.</summary>
+		/// <remarks>
+		///   <para>The getter will never return a <see langword="null" /> policy, it will return a policy configured with the default behavior.</para>
+		///   <para>To select the default policy, call the setter with <see langword="null" /> value.</para>
+		///   <para>This only has an effect if a custom server certificate validation callback is being used ('ServerCertificateCustomValidationCallback' is set).</para>
+		/// </remarks>
+		public X509ChainPolicy? CertificateChainPolicy {
+			get {
+				if (policy is null) {
+					policy = new X509ChainPolicy () {
+						RevocationMode = X509RevocationMode.Online,
+						RevocationFlag = X509RevocationFlag.ExcludeRoot,
+					};
+				}
+				return policy;
+			}
+			set => policy = value;
+		}
 
 		X509CertificateCollection? _clientCertificates;
 
@@ -703,7 +724,7 @@ namespace Foundation {
 				if (value is null) {
 					_serverCertificateCustomValidationCallbackHelper = null;
 				} else {
-					_serverCertificateCustomValidationCallbackHelper = new ServerCertificateCustomValidationCallbackHelper (value);
+					_serverCertificateCustomValidationCallbackHelper = new ServerCertificateCustomValidationCallbackHelper (value, CertificateChainPolicy!);
 				}
 			}
 		}
@@ -720,11 +741,13 @@ namespace Foundation {
 		}
 
 		sealed class ServerCertificateCustomValidationCallbackHelper {
+			X509ChainPolicy policy;
 			public Func<HttpRequestMessage, X509Certificate2?, X509Chain?, SslPolicyErrors, bool> Callback { get; private set; }
 
-			public ServerCertificateCustomValidationCallbackHelper (Func<HttpRequestMessage, X509Certificate2?, X509Chain?, SslPolicyErrors, bool> callback)
+			public ServerCertificateCustomValidationCallbackHelper (Func<HttpRequestMessage, X509Certificate2?, X509Chain?, SslPolicyErrors, bool> callback, X509ChainPolicy policy)
 			{
 				Callback = callback;
+				this.policy = policy;
 			}
 
 			public bool Invoke (HttpRequestMessage request, SecTrust secTrust)
@@ -759,10 +782,9 @@ namespace Foundation {
 
 			X509Chain CreateChain (X509Certificate2 [] certificates)
 			{
-				// inspired by https://github.com/dotnet/runtime/blob/99d21b9276ebe8f7bea7fb3ba74dca9fca625fe2/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignerInfo.cs#L691-L696
+				// See https://github.com/dotnet/macios/issues/23764 for more information.
 				var chain = new X509Chain ();
-				chain.ChainPolicy.RevocationMode = X509RevocationMode.Online;
-				chain.ChainPolicy.RevocationFlag = X509RevocationFlag.ExcludeRoot;
+				chain.ChainPolicy = policy.Clone ();
 				chain.ChainPolicy.ExtraStore.AddRange (certificates);
 				return chain;
 			}

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -903,16 +903,16 @@ namespace MonoTests.System.Net.Http {
 
 		// https://github.com/dotnet/macios/issues/23764
 		[TestCase ("https://sha256.badssl.com/")]
-		public void SslCertificatesWithoutOCSPEndPointsNSUrlSessionHandler_DisallowByDefault (string url)
+		public void SslCertificatesWithoutOCSPEndPointsNSUrlSessionHandler_AllowByDefault (string url)
 		{
-			SslCertificatesWithoutOCSPEndPointsNSUrlSessionHandler (url, null, SslPolicyErrors.RemoteCertificateChainErrors);
+			SslCertificatesWithoutOCSPEndPointsNSUrlSessionHandler (url, null, SslPolicyErrors.None);
 		}
 
 		// https://github.com/dotnet/macios/issues/23764
 		[TestCase ("https://sha256.badssl.com/")]
-		public void SslCertificatesWithoutOCSPEndPointsNSUrlSessionHandler_Allow (string url)
+		public void SslCertificatesWithoutOCSPEndPointsNSUrlSessionHandler_Disallow (string url)
 		{
-			SslCertificatesWithoutOCSPEndPointsNSUrlSessionHandler (url, X509VerificationFlags.IgnoreEndRevocationUnknown, SslPolicyErrors.None);
+			SslCertificatesWithoutOCSPEndPointsNSUrlSessionHandler (url, (X509VerificationFlags) 0, SslPolicyErrors.RemoteCertificateChainErrors);
 		}
 
 		void SslCertificatesWithoutOCSPEndPointsNSUrlSessionHandler (string url, X509VerificationFlags? verificationFlags, SslPolicyErrors expectedError)

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -900,5 +900,59 @@ namespace MonoTests.System.Net.Http {
 				Assert.IsNull (ex, "Exception");
 			}
 		}
+
+		// https://github.com/dotnet/macios/issues/23764
+		[TestCase ("https://sha256.badssl.com/")]
+		public void SslCertificatesWithoutOCSPEndPointsNSUrlSessionHandler_DisallowByDefault (string url)
+		{
+			SslCertificatesWithoutOCSPEndPointsNSUrlSessionHandler (url, null, SslPolicyErrors.RemoteCertificateChainErrors);
+		}
+
+		// https://github.com/dotnet/macios/issues/23764
+		[TestCase ("https://sha256.badssl.com/")]
+		public void SslCertificatesWithoutOCSPEndPointsNSUrlSessionHandler_Allow (string url)
+		{
+			SslCertificatesWithoutOCSPEndPointsNSUrlSessionHandler (url, X509VerificationFlags.IgnoreEndRevocationUnknown, SslPolicyErrors.None);
+		}
+
+		void SslCertificatesWithoutOCSPEndPointsNSUrlSessionHandler (string url, X509VerificationFlags? verificationFlags, SslPolicyErrors expectedError)
+		{
+			bool callbackWasExecuted = false;
+			HttpResponseMessage result = null;
+			X509Certificate2 serverCertificate = null;
+			SslPolicyErrors sslPolicyErrors = SslPolicyErrors.None;
+
+			var handler = new NSUrlSessionHandler {
+				ServerCertificateCustomValidationCallback = (request, certificate, chain, errors) => {
+					callbackWasExecuted = true;
+					serverCertificate = certificate;
+					sslPolicyErrors = errors;
+					return true;
+				},
+			};
+			if (verificationFlags.HasValue)
+				handler.CertificateChainPolicy.VerificationFlags = verificationFlags.Value;
+
+			Assert.IsTrue (handler.CheckCertificateRevocationList, "CheckCertificateRevocationList");
+
+			var done = TestRuntime.TryRunAsync (TimeSpan.FromSeconds (30), async () => {
+				var client = new HttpClient (handler);
+				// Disable keep-alive and cache to force reconnection for each request
+				client.DefaultRequestHeaders.ConnectionClose = true;
+				client.DefaultRequestHeaders.CacheControl = new CacheControlHeaderValue { NoCache = true, NoStore = true };
+				result = await client.GetAsync (url);
+			}, out var ex);
+
+			if (!done) { // timeouts happen in the bots due to dns issues, connection issues etc., we do not want to fail
+				Assert.Inconclusive ("Request timedout.");
+			} else {
+				Assert.True (callbackWasExecuted, "Validation Callback called");
+				Assert.AreEqual (expectedError, sslPolicyErrors, "Callback was called with unexpected SslPolicyErrors");
+				Assert.IsNotNull (serverCertificate, "Server certificate is null");
+				Assert.IsNull (ex, "Exception wasn't expected.");
+				Assert.IsNotNull (result, "Result was null");
+				Assert.IsTrue (result.IsSuccessStatusCode, $"Status code was not success: {result.StatusCode}");
+			}
+		}
 	}
 }


### PR DESCRIPTION
* Add a `CertificateChainPolicy` property to `NSUrlSessionHandler` to make it
  possible for developers to customize the the policy that is used when
  validating certificate chains when using a custom server certificate
  validation.
* Also implement `NSUrlSessionHandler.CheckCertificateRevocationList` using
  the new `CertificateChainPolicy` property.

Fixes https://github.com/dotnet/macios/issues/23764.