### PR TITLE
[RGen] Add analyzer rules for async methods in a class.

### DIFF
--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Resources.Designer.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Resources.Designer.cs
@@ -1001,5 +1001,140 @@ namespace Microsoft.Macios.Bindings.Analyzer {
                 return ResourceManager.GetString("RBI0034Title", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A method marked as an async method should have void as its return type..
+        /// </summary>
+        internal static string RBI0035Description {
+            get {
+                return ResourceManager.GetString("RBI0035Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The method &apos;{0}&apos; was marked as async but its return type is not void.
+        /// </summary>
+        internal static string RBI0035MessageFormat {
+            get {
+                return ResourceManager.GetString("RBI0035MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Async method not returning void.
+        /// </summary>
+        internal static string RBI0035Title {
+            get {
+                return ResourceManager.GetString("RBI0035Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A method marked as an async method should have at least one parameter that is a delegate..
+        /// </summary>
+        internal static string RBI0036Description {
+            get {
+                return ResourceManager.GetString("RBI0036Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The method &apos;{0}&apos; was marked as async but has 0 parameters when at least a single delegate parameter is required.
+        /// </summary>
+        internal static string RBI0036MessageFormat {
+            get {
+                return ResourceManager.GetString("RBI0036MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No parameters in async method.
+        /// </summary>
+        internal static string RBI0036Title {
+            get {
+                return ResourceManager.GetString("RBI0036Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A method marked as an async method should have its last parameter be a delegate..
+        /// </summary>
+        internal static string RBI0037Description {
+            get {
+                return ResourceManager.GetString("RBI0037Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The method &apos;{0}&apos; was marked as async but its last parameter is not a delegate.
+        /// </summary>
+        internal static string RBI0037MessageFormat {
+            get {
+                return ResourceManager.GetString("RBI0037MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Last parameter is not a delegate.
+        /// </summary>
+        internal static string RBI0037Title {
+            get {
+                return ResourceManager.GetString("RBI0037Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A method that could be async was not marked as async..
+        /// </summary>
+        internal static string RBI0038Description {
+            get {
+                return ResourceManager.GetString("RBI0038Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The method &apos;{0}&apos; was not marked as async but it can be.
+        /// </summary>
+        internal static string RBI0038MessageFormat {
+            get {
+                return ResourceManager.GetString("RBI0038MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Possible async method missing async flag.
+        /// </summary>
+        internal static string RBI0038Title {
+            get {
+                return ResourceManager.GetString("RBI0038Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Two methods marked as async will result in the same async name..
+        /// </summary>
+        internal static string RBI0039Description {
+            get {
+                return ResourceManager.GetString("RBI0039Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The async name &apos;{0}&apos; used by &apos;{1}&apos; is already used by &apos;{2}&apos;.
+        /// </summary>
+        internal static string RBI0039MessageFormat {
+            get {
+                return ResourceManager.GetString("RBI0039MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Duplicated async name.
+        /// </summary>
+        internal static string RBI0039Title {
+            get {
+                return ResourceManager.GetString("RBI0039Title", resourceCulture);
+            }
+        }
     }
 }

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Resources.resx
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Resources.resx
@@ -469,4 +469,69 @@
         <value>Duplicate selector</value>
     </data>
     
+    <!-- RBI0035 -->
+    
+    <data name="RBI0035Description" xml:space="preserve">
+        <value>A method marked as an async method should have void as its return type.</value>
+    </data>
+    <data name="RBI0035MessageFormat" xml:space="preserve">
+        <value>The method '{0}' was marked as async but its return type is not void</value>
+        <comment>{0} is the name of the method.</comment>
+    </data>
+    <data name="RBI0035Title" xml:space="preserve">
+        <value>Async method not returning void</value>
+    </data>
+    
+    <!-- RBI0036 -->
+    
+    <data name="RBI0036Description" xml:space="preserve">
+        <value>A method marked as an async method should have at least one parameter that is a delegate.</value>
+    </data>
+    <data name="RBI0036MessageFormat" xml:space="preserve">
+        <value>The method '{0}' was marked as async but has 0 parameters when at least a single delegate parameter is required</value>
+        <comment>{0} is the name of the method.</comment>
+    </data>
+    <data name="RBI0036Title" xml:space="preserve">
+        <value>No parameters in async method</value>
+    </data>
+    
+    <!-- RBI0037 -->
+    
+    <data name="RBI0037Description" xml:space="preserve">
+        <value>A method marked as an async method should have its last parameter be a delegate.</value>
+    </data>
+    <data name="RBI0037MessageFormat" xml:space="preserve">
+        <value>The method '{0}' was marked as async but its last parameter is not a delegate</value>
+        <comment>{0} is the name of the method.</comment>
+    </data>
+    <data name="RBI0037Title" xml:space="preserve">
+        <value>Last parameter is not a delegate</value>
+    </data>
+    
+    <!-- RBI0038 -->
+    
+    <data name="RBI0038Description" xml:space="preserve">
+        <value>A method that could be async was not marked as async.</value>
+    </data>
+    <data name="RBI0038MessageFormat" xml:space="preserve">
+        <value>The method '{0}' was not marked as async but it can be</value>
+        <comment>{0} is the name of the method.</comment>
+    </data>
+    <data name="RBI0038Title" xml:space="preserve">
+        <value>Possible async method missing async flag</value>
+    </data>
+    
+    <!-- RBI0039 -->
+    
+    <data name="RBI0039Description" xml:space="preserve">
+        <value>Two methods marked as async will result in the same async name.</value>
+    </data>
+    <data name="RBI0039MessageFormat" xml:space="preserve">
+        <value>The async name '{0}' used by '{1}' is already used by '{2}'</value>
+        <comment>{0} is the name of the async method, {1} is the name of the sync method and {2} is the name of the first ocurrance.</comment>
+    </data>
+    <data name="RBI0039Title" xml:space="preserve">
+        <value>Duplicated async name</value>
+    </data>
+    
 </root>

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/RgenDiagnostics.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/RgenDiagnostics.cs
@@ -526,7 +526,7 @@ public static class RgenDiagnostics {
 		description: new LocalizableResourceString (nameof (Resources.RBI0034Description), Resources.ResourceManager,
 			typeof (Resources))
 	);
-	
+
 	/// <summary>
 	/// Diagnostic descriptor for when a marked async method has not void return. 
 	/// </summary>
@@ -541,7 +541,7 @@ public static class RgenDiagnostics {
 		description: new LocalizableResourceString (nameof (Resources.RBI0035Description), Resources.ResourceManager,
 			typeof (Resources))
 	);
-	
+
 	/// <summary>
 	/// Diagnostic descriptor for when a marked async method has no parameters. 
 	/// </summary>
@@ -556,7 +556,7 @@ public static class RgenDiagnostics {
 		description: new LocalizableResourceString (nameof (Resources.RBI0036Description), Resources.ResourceManager,
 			typeof (Resources))
 	);
-	
+
 	/// <summary>
 	/// Diagnostic descriptor for when a marked async method has no delegate as the last parameter. 
 	/// </summary>
@@ -571,7 +571,7 @@ public static class RgenDiagnostics {
 		description: new LocalizableResourceString (nameof (Resources.RBI0037Description), Resources.ResourceManager,
 			typeof (Resources))
 	);
-	
+
 	/// <summary>
 	/// Diagnostic descriptor for when a method that could be async was not marked. 
 	/// </summary>
@@ -586,7 +586,7 @@ public static class RgenDiagnostics {
 		description: new LocalizableResourceString (nameof (Resources.RBI0038Description), Resources.ResourceManager,
 			typeof (Resources))
 	);
-	
+
 	/// <summary>
 	/// Diagnostic descriptor for when two methods with the same parameters have the same async name. 
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/RgenDiagnostics.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/RgenDiagnostics.cs
@@ -526,4 +526,79 @@ public static class RgenDiagnostics {
 		description: new LocalizableResourceString (nameof (Resources.RBI0034Description), Resources.ResourceManager,
 			typeof (Resources))
 	);
+	
+	/// <summary>
+	/// Diagnostic descriptor for when a marked async method has not void return. 
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0035 = new (
+		"RBI0035",
+		new LocalizableResourceString (nameof (Resources.RBI0035Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0035MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
+		"Usage",
+		DiagnosticSeverity.Error,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof (Resources.RBI0035Description), Resources.ResourceManager,
+			typeof (Resources))
+	);
+	
+	/// <summary>
+	/// Diagnostic descriptor for when a marked async method has no parameters. 
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0036 = new (
+		"RBI0036",
+		new LocalizableResourceString (nameof (Resources.RBI0036Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0036MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
+		"Usage",
+		DiagnosticSeverity.Error,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof (Resources.RBI0036Description), Resources.ResourceManager,
+			typeof (Resources))
+	);
+	
+	/// <summary>
+	/// Diagnostic descriptor for when a marked async method has no delegate as the last parameter. 
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0037 = new (
+		"RBI0037",
+		new LocalizableResourceString (nameof (Resources.RBI0037Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0037MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
+		"Usage",
+		DiagnosticSeverity.Error,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof (Resources.RBI0037Description), Resources.ResourceManager,
+			typeof (Resources))
+	);
+	
+	/// <summary>
+	/// Diagnostic descriptor for when a method that could be async was not marked. 
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0038 = new (
+		"RBI0038",
+		new LocalizableResourceString (nameof (Resources.RBI0038Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0038MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
+		"Usage",
+		DiagnosticSeverity.Warning,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof (Resources.RBI0038Description), Resources.ResourceManager,
+			typeof (Resources))
+	);
+	
+	/// <summary>
+	/// Diagnostic descriptor for when two methods with the same parameters have the same async name. 
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0039 = new (
+		"RBI0039",
+		new LocalizableResourceString (nameof (Resources.RBI0039Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0039MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
+		"Usage",
+		DiagnosticSeverity.Error,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof (Resources.RBI0039Description), Resources.ResourceManager,
+			typeof (Resources))
+	);
 }

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/ClassValidator.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/ClassValidator.cs
@@ -17,11 +17,11 @@ namespace Microsoft.Macios.Bindings.Analyzer.Validators;
 /// Compares tuples of (method name, ordered parameter types) to detect duplicate async method names.
 /// Being declared with the 'file' modifier keeps the helper local to this source file.
 /// </summary>
-file class AsyncNameComparer : IEqualityComparer<(string, TypeInfo[])> {
+file class AsyncNameComparer : IEqualityComparer<(string, TypeInfo [])> {
 	/// <summary>
 	/// Determines equality by requiring the same method name and identical ordered parameter type sequence.
 	/// </summary>
-	public bool Equals ((string, TypeInfo[]) x, (string, TypeInfo[]) y)
+	public bool Equals ((string, TypeInfo []) x, (string, TypeInfo []) y)
 	{
 		// has to be the same name and with the same parameter type in the same order to be considered equal
 		return x.Item1 == y.Item1 && x.Item2.SequenceEqual (y.Item2);
@@ -30,7 +30,7 @@ file class AsyncNameComparer : IEqualityComparer<(string, TypeInfo[])> {
 	/// <summary>
 	/// Computes a hash code combining the method name and ordered parameter types.
 	/// </summary>
-	public int GetHashCode ((string, TypeInfo[]) obj)
+	public int GetHashCode ((string, TypeInfo []) obj)
 	{
 		int hash = obj.Item1.GetHashCode ();
 		foreach (var t in obj.Item2)
@@ -211,7 +211,7 @@ sealed class ClassValidator : BindingValidator {
 		diagnostics = ImmutableArray<Diagnostic>.Empty;
 		var builder = ImmutableArray.CreateBuilder<Diagnostic> ();
 		// create a dictionary with a custom comparer that checks the method name and the parameter types
-		var asyncMethodNames = new Dictionary<(string Name, TypeInfo[] Arguments), List<(string SymbolName, Location? Location)>> (
+		var asyncMethodNames = new Dictionary<(string Name, TypeInfo [] Arguments), List<(string SymbolName, Location? Location)>> (
 			new AsyncNameComparer ());
 
 		foreach (var currentMethod in binding.Methods) {
@@ -238,7 +238,7 @@ sealed class ClassValidator : BindingValidator {
 					continue;
 				}
 
-				if (!currentMethod.Parameters[^1].Type.IsDelegate){
+				if (!currentMethod.Parameters [^1].Type.IsDelegate) {
 					// error, we need the last parameter to be a delegate type for the method to be async, report a diagnostic	
 					builder.Add (Diagnostic.Create (
 						descriptor: RBI0037,
@@ -251,7 +251,7 @@ sealed class ClassValidator : BindingValidator {
 					// across the binding for async methods. The async method name + parameter count has to be unique.
 					var asyncMethod = currentMethod.ToAsync ();
 					var asyncMethodKey = (
-						asyncMethod.Name, 
+						asyncMethod.Name,
 						asyncMethod.Parameters.Select (x => x.Type).ToArray ());
 					if (asyncMethodNames.TryGetValue (asyncMethodKey, out var list)) {
 						list.Add ((currentMethod.Name, currentMethod.Location));
@@ -275,7 +275,7 @@ sealed class ClassValidator : BindingValidator {
 				}
 			}
 		}
-		
+
 		// we have gone through all the methods, now we need to check if there are any duplicate async method names
 		var duplicates = asyncMethodNames.Where (x => x.Value.Count > 1).ToImmutableArray ();
 		if (duplicates.Length > 0) {
@@ -294,11 +294,11 @@ sealed class ClassValidator : BindingValidator {
 				}
 			}
 		}
-		
+
 		diagnostics = builder.ToImmutable ();
 		return diagnostics.Length == 0;
 	}
-	
+
 	/// <summary>
 	/// Initializes a new instance of the <see cref="ClassValidator"/> class.
 	/// </summary>
@@ -312,7 +312,7 @@ sealed class ClassValidator : BindingValidator {
 
 		// validate that the selectors are not duplicated, this includes properties and methods
 		AddGlobalStrategy ([RBI0034], SelectorsAreUnique);
-		
+
 		// validate async methods. This is a global strategy because it needs to look at all the methods in the binding
 		// are validated together so that async methods do not have the same names
 		AddGlobalStrategy ([RBI0035, RBI0036, RBI0037, RBI0038, RBI0039], ValidAsyncMethods);

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/ClassValidator.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/ClassValidator.cs
@@ -5,13 +5,39 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.Macios.Generator;
 using Microsoft.Macios.Generator.Context;
 using Microsoft.Macios.Generator.DataModel;
 using static Microsoft.Macios.Generator.RgenDiagnostics;
+using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
 
 namespace Microsoft.Macios.Bindings.Analyzer.Validators;
+
+/// <summary>
+/// Helper equality comparer used only within this file to key the async methods dictionary.
+/// Compares tuples of (method name, ordered parameter types) to detect duplicate async method names.
+/// Being declared with the 'file' modifier keeps the helper local to this source file.
+/// </summary>
+file class AsyncNameComparer : IEqualityComparer<(string, TypeInfo[])> {
+	/// <summary>
+	/// Determines equality by requiring the same method name and identical ordered parameter type sequence.
+	/// </summary>
+	public bool Equals ((string, TypeInfo[]) x, (string, TypeInfo[]) y)
+	{
+		// has to be the same name and with the same parameter type in the same order to be considered equal
+		return x.Item1 == y.Item1 && x.Item2.SequenceEqual (y.Item2);
+	}
+
+	/// <summary>
+	/// Computes a hash code combining the method name and ordered parameter types.
+	/// </summary>
+	public int GetHashCode ((string, TypeInfo[]) obj)
+	{
+		int hash = obj.Item1.GetHashCode ();
+		foreach (var t in obj.Item2)
+			hash = hash * 31 + (t.GetHashCode ());
+		return hash;
+	}
+}
 
 /// <summary>
 /// Validator for class bindings.
@@ -164,6 +190,116 @@ sealed class ClassValidator : BindingValidator {
 	}
 
 	/// <summary>
+	/// Validates async methods in a binding. This includes checking for methods that should be async, methods marked as
+	/// async that are invalid, and ensuring that generated async method names are unique.
+	/// </summary>
+	/// <param name="binding">The binding to validate.</param>
+	/// <param name="context">The root context for validation.</param>
+	/// <param name="diagnostics">When this method returns, contains diagnostics for any async method issues; otherwise, an empty array.</param>
+	/// <param name="location">The code location to be used for the diagnostics.</param>
+	/// <returns><c>true</c> if all async methods are valid; otherwise, <c>false</c>.</returns>
+	bool ValidAsyncMethods (Binding binding, RootContext context,
+		out ImmutableArray<Diagnostic> diagnostics, Location? location = null)
+	{
+		// there are several things we need to validate with async methods:
+		// 1. If a method parameter is a callback delegate and the method is not marked as async, we have to report a
+		//    diagnostic as a warning.
+		// 2. I a method is marked as async yet it does not have a callback delegate parameter, we have to report a
+		//    diagnostic as an error.
+		// 3. Collect all the names of async methods and ensure that there are no duplicates across the binding.
+		//	  If there are duplicates, we have to report a diagnostic as an error.
+		diagnostics = ImmutableArray<Diagnostic>.Empty;
+		var builder = ImmutableArray.CreateBuilder<Diagnostic> ();
+		// create a dictionary with a custom comparer that checks the method name and the parameter types
+		var asyncMethodNames = new Dictionary<(string Name, TypeInfo[] Arguments), List<(string SymbolName, Location? Location)>> (
+			new AsyncNameComparer ());
+
+		foreach (var currentMethod in binding.Methods) {
+			if (currentMethod.IsAsync) {
+				if (!currentMethod.ReturnType.IsVoid) {
+					builder.Add (Diagnostic.Create (
+						descriptor: RBI0035, // The method '{0}' was marked as async but its return type is not void
+						location: currentMethod.Location,
+						messageArgs: [
+							currentMethod.Name,
+						]));
+					continue;
+				}
+				// if it was marked as async, we need to ensure that it has at least a parameter, if there are not
+				// params, the method can't be async
+				if (currentMethod.Parameters.Length == 0) {
+					// error, we need at least one parameter for the method to be async, report a diagnostic
+					builder.Add (Diagnostic.Create (
+						descriptor: RBI0036, // The method '{0}' was marked as async but has 0 parameters when at least a single delegate parameter is required
+						location: currentMethod.Location,
+						messageArgs: [
+							currentMethod.Name,
+						]));
+					continue;
+				}
+
+				if (!currentMethod.Parameters[^1].Type.IsDelegate){
+					// error, we need the last parameter to be a delegate type for the method to be async, report a diagnostic	
+					builder.Add (Diagnostic.Create (
+						descriptor: RBI0037,
+						location: currentMethod.Location,
+						messageArgs: [
+							currentMethod.Name,
+						]));
+				} else {
+					// parameters are valid, but we want to get the async method name to ensure that the name is unique
+					// across the binding for async methods. The async method name + parameter count has to be unique.
+					var asyncMethod = currentMethod.ToAsync ();
+					var asyncMethodKey = (
+						asyncMethod.Name, 
+						asyncMethod.Parameters.Select (x => x.Type).ToArray ());
+					if (asyncMethodNames.TryGetValue (asyncMethodKey, out var list)) {
+						list.Add ((currentMethod.Name, currentMethod.Location));
+					} else {
+						// add a new list with the current property
+						asyncMethodNames.Add (asyncMethodKey, [(currentMethod.Name, currentMethod.Location)]);
+					}
+				}
+			} else {
+				// this is not an async method, but we need to check if it has a callback delegate parameter,
+				// if it does, we need to report a warning, not an error because maybe the user does not want to use
+				// the async feature
+				if (currentMethod.ReturnType.IsVoid && currentMethod.Parameters [^1].Type.IsDelegate) {
+					// report a warning
+					builder.Add (Diagnostic.Create (
+						descriptor: RBI0038, // The method '{0}' was not marked as async but it can be
+						location: currentMethod.Location,
+						messageArgs: [
+							currentMethod.Name,
+						]));
+				}
+			}
+		}
+		
+		// we have gone through all the methods, now we need to check if there are any duplicate async method names
+		var duplicates = asyncMethodNames.Where (x => x.Value.Count > 1).ToImmutableArray ();
+		if (duplicates.Length > 0) {
+			foreach (var duplicate in duplicates) {
+				var firstSymbol = duplicate.Value.First ();
+				for (var index = 1; index < duplicate.Value.Count; index++) {
+					var dupSymbol = duplicate.Value [index]; // used for the msg and the location
+					builder.Add (Diagnostic.Create (
+						descriptor: RBI0039,
+						location: dupSymbol.Location,
+						messageArgs: [
+							duplicate.Key.Name,
+							dupSymbol.SymbolName,
+							firstSymbol.SymbolName
+						]));
+				}
+			}
+		}
+		
+		diagnostics = builder.ToImmutable ();
+		return diagnostics.Length == 0;
+	}
+	
+	/// <summary>
 	/// Initializes a new instance of the <see cref="ClassValidator"/> class.
 	/// </summary>
 	public ClassValidator ()
@@ -176,6 +312,10 @@ sealed class ClassValidator : BindingValidator {
 
 		// validate that the selectors are not duplicated, this includes properties and methods
 		AddGlobalStrategy ([RBI0034], SelectorsAreUnique);
+		
+		// validate async methods. This is a global strategy because it needs to look at all the methods in the binding
+		// are validated together so that async methods do not have the same names
+		AddGlobalStrategy ([RBI0035, RBI0036, RBI0037, RBI0038, RBI0039], ValidAsyncMethods);
 
 		// validate that strong delegates are not duplicated, this is only for weak properties
 		AddStrategy (

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
@@ -87,6 +87,22 @@ readonly partial struct Method {
 	public bool IsAsync => ExportMethodData.Flags.HasFlag (ObjCBindings.Method.Async);
 
 	/// <summary>
+	/// True if an async version of the method can be generated. This is true if <see cref="IsAsync"/> is true and
+	/// the method signature is compatible (returns void, and the last parameter is a completion handler delegate).
+	/// </summary>
+	public bool GenerateAsync {
+		get {
+			if (!IsAsync)
+				return false;
+			// ensure that we have the minimum requirements for the async method to be generated correctly
+			// 1. Method has to return void
+			// 2. Method has to have parameters
+			// 3. Last parameter has to be a completion handler
+			return ReturnType.IsVoid && Parameters.Length > 0 && Parameters [^1].Type.IsDelegate;
+		}
+	}
+
+	/// <summary>
 	/// True if the method is variadic.
 	/// </summary>
 	public bool IsVariadic => ExportMethodData.Flags.HasFlag (ObjCBindings.Method.IsVariadic);

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Methods.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Methods.cs
@@ -36,7 +36,7 @@ static partial class BindingSyntaxFactory {
 
 		// get the argument list of the delegate type, if the last on is an NSError, we need a if statement to check for null
 		// else, the body is just the set result for the tcs
-		if (delegateType.Delegate.Parameters [^1].Type.Name.Contains ("NSError")) {
+		if (delegateType.Delegate.Parameters.Length > 0 && delegateType.Delegate.Parameters [^1].Type.Name.Contains ("NSError")) {
 			// we are dealing with a callback that has an NSError parameter, we need to check if it is null and set the exception
 			// else set the result
 			var nsErrorParamName = GetTaskCallbackParameterName (delegateType.Delegate.Parameters [^1].Name);

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitterExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitterExtensions.cs
@@ -223,7 +223,8 @@ if (IsDirectBinding) {{
 			}
 		}
 
-		if (!method.IsAsync)
+		if (!method.GenerateAsync)
+			// we cannot generate an async method
 			return;
 
 		// if the method is an async method, generate its async version

--- a/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/ClassAnalyzerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/ClassAnalyzerTests.cs
@@ -18,7 +18,6 @@ public class ClassAnalyzerTests : BaseGeneratorWithAnalyzerTestClass {
 		public IEnumerator<object []> GetEnumerator ()
 		{
 			// not partial class
-			/*
 			yield return [
 @"
 #pragma warning disable APL0003
@@ -45,7 +44,6 @@ public class TestClass{
 				DiagnosticSeverity.Error,
 				"The binding type 'TestNamespace.TestClass' must be declared partial"
 			];
-			*/
 
 			// duplicate selector, 2 properties
 			yield return [
@@ -622,6 +620,204 @@ public partial class TestClass{
 				DiagnosticSeverity.Error,
 				"There is a mismatch between the arguments of 'AttributedStringByInflectingString' (found 0) and the selector 'isAttributedStringByInflectingString:' (found 1)"
 			];
+			
+			// async methods
+			
+			// async method not void
+			yield return [
+@"
+#pragma warning disable APL0003
+
+using System;
+using System.Runtime.Versioning;
+using AVFoundation;
+using CoreGraphics;
+using Foundation;
+using ObjCBindings;
+using ObjCRuntime;
+using nfloat = System.Runtime.InteropServices.NFloat;
+
+namespace TestNamespace;
+
+[SupportedOSPlatform (""macos"")]
+[SupportedOSPlatform (""ios"")]
+[SupportedOSPlatform (""tvos"")]
+[SupportedOSPlatform (""maccatalyst13.1"")]
+[BindingType<Class>]
+public partial class TestClass{
+
+	[SupportedOSPlatform (""ios"")]
+	[SupportedOSPlatform (""tvos"")]
+	[SupportedOSPlatform (""macos"")]
+	[SupportedOSPlatform (""maccatalyst13.1"")]
+	[Export<Method> (""count"", 
+		Flags = ObjCBindings.Method.Async)]
+	public virtual partial nuint GetCount ();
+
+}",
+				"RBI0035",
+				DiagnosticSeverity.Error,
+				"The method 'GetCount' was marked as async but its return type is not void"
+			];
+			
+			// void but no args
+			yield return [
+				@"
+#pragma warning disable APL0003
+
+using System;
+using System.Runtime.Versioning;
+using AVFoundation;
+using CoreGraphics;
+using Foundation;
+using ObjCBindings;
+using ObjCRuntime;
+using nfloat = System.Runtime.InteropServices.NFloat;
+
+namespace TestNamespace;
+
+[SupportedOSPlatform (""macos"")]
+[SupportedOSPlatform (""ios"")]
+[SupportedOSPlatform (""tvos"")]
+[SupportedOSPlatform (""maccatalyst13.1"")]
+[BindingType<Class>]
+public partial class TestClass{
+
+	[SupportedOSPlatform (""ios"")]
+	[SupportedOSPlatform (""tvos"")]
+	[SupportedOSPlatform (""macos"")]
+	[SupportedOSPlatform (""maccatalyst13.1"")]
+	[Export<Method> (""count"", 
+		Flags = ObjCBindings.Method.Async)]
+	public virtual partial void GetCount ();
+
+}",
+				"RBI0036",
+				DiagnosticSeverity.Error,
+				"The method 'GetCount' was marked as async but has 0 parameters when at least a single delegate parameter is required"
+			];
+			
+			// void but with args but no delegate
+			yield return [
+				@"
+#pragma warning disable APL0003
+
+using System;
+using System.Runtime.Versioning;
+using AVFoundation;
+using CoreGraphics;
+using Foundation;
+using ObjCBindings;
+using ObjCRuntime;
+using nfloat = System.Runtime.InteropServices.NFloat;
+
+namespace TestNamespace;
+
+[SupportedOSPlatform (""macos"")]
+[SupportedOSPlatform (""ios"")]
+[SupportedOSPlatform (""tvos"")]
+[SupportedOSPlatform (""maccatalyst13.1"")]
+[BindingType<Class>]
+public partial class TestClass{
+
+	[SupportedOSPlatform (""ios"")]
+	[SupportedOSPlatform (""tvos"")]
+	[SupportedOSPlatform (""macos"")]
+	[SupportedOSPlatform (""maccatalyst13.1"")]
+	[Export<Method> (""count:"", 
+		Flags = ObjCBindings.Method.Async)]
+	public virtual partial void GetCount (int value);
+
+}",
+				"RBI0037",
+				DiagnosticSeverity.Error,
+				"The method 'GetCount' was marked as async but its last parameter is not a delegate",
+			];
+			
+			// void but with delegate but with a duplicated async name
+			yield return [
+				@"
+#pragma warning disable APL0003
+
+using System;
+using System.Runtime.Versioning;
+using AVFoundation;
+using CoreGraphics;
+using Foundation;
+using ObjCBindings;
+using ObjCRuntime;
+using nfloat = System.Runtime.InteropServices.NFloat;
+
+namespace TestNamespace;
+
+[SupportedOSPlatform (""macos"")]
+[SupportedOSPlatform (""ios"")]
+[SupportedOSPlatform (""tvos"")]
+[SupportedOSPlatform (""maccatalyst13.1"")]
+[BindingType<Class>]
+public partial class TestClass{
+
+	[SupportedOSPlatform (""ios"")]
+	[SupportedOSPlatform (""tvos"")]
+	[SupportedOSPlatform (""macos"")]
+	[SupportedOSPlatform (""maccatalyst13.1"")]
+	[Export<Method> (""count:"", 
+		Flags = ObjCBindings.Method.Async,
+		MethodName = ""GetCountAsync"")]
+	public virtual partial void GetCount (Action callback);
+
+	[SupportedOSPlatform (""ios"")]
+	[SupportedOSPlatform (""tvos"")]
+	[SupportedOSPlatform (""macos"")]
+	[SupportedOSPlatform (""maccatalyst13.1"")]
+	[Export<Method> (""count_second:"", 
+		Flags = ObjCBindings.Method.Async,
+		MethodName = ""GetCountAsync"")]
+	public virtual partial void GetCountSecond (Action callback);
+
+}",
+				"RBI0039",
+				DiagnosticSeverity.Error,
+				"The async name 'GetCountAsync' used by 'GetCountSecond' is already used by 'GetCount'",
+			];
+			
+			// can async method but flag is missing
+			yield return [
+				@"
+#pragma warning disable APL0003
+
+using System;
+using System.Runtime.Versioning;
+using AVFoundation;
+using CoreGraphics;
+using Foundation;
+using ObjCBindings;
+using ObjCRuntime;
+using nfloat = System.Runtime.InteropServices.NFloat;
+
+namespace TestNamespace;
+
+[SupportedOSPlatform (""macos"")]
+[SupportedOSPlatform (""ios"")]
+[SupportedOSPlatform (""tvos"")]
+[SupportedOSPlatform (""maccatalyst13.1"")]
+[BindingType<Class>]
+public partial class TestClass{
+
+	[SupportedOSPlatform (""ios"")]
+	[SupportedOSPlatform (""tvos"")]
+	[SupportedOSPlatform (""macos"")]
+	[SupportedOSPlatform (""maccatalyst13.1"")]
+	[Export<Method> (""count:"", 
+		Flags = ObjCBindings.Method.Default,
+		MethodName = ""GetCountAsync"")]
+	public virtual partial void GetCount (Action callback);
+
+}",
+				"RBI0038",
+				DiagnosticSeverity.Warning,
+				"The method 'GetCount' was not marked as async but it can be"
+			];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
@@ -802,6 +998,51 @@ public partial class TestClass{
 	public virtual partial nuint SecondGetCount ();
 }",
 				"RBI0034",
+			];
+			
+			// void but with delegate with a duplicated async name but with different args
+			yield return [
+				@"
+#pragma warning disable APL0003
+
+using System;
+using System.Runtime.Versioning;
+using AVFoundation;
+using CoreGraphics;
+using Foundation;
+using ObjCBindings;
+using ObjCRuntime;
+using nfloat = System.Runtime.InteropServices.NFloat;
+
+namespace TestNamespace;
+
+[SupportedOSPlatform (""macos"")]
+[SupportedOSPlatform (""ios"")]
+[SupportedOSPlatform (""tvos"")]
+[SupportedOSPlatform (""maccatalyst13.1"")]
+[BindingType<Class>]
+public partial class TestClass{
+
+	[SupportedOSPlatform (""ios"")]
+	[SupportedOSPlatform (""tvos"")]
+	[SupportedOSPlatform (""macos"")]
+	[SupportedOSPlatform (""maccatalyst13.1"")]
+	[Export<Method> (""count:"", 
+		Flags = ObjCBindings.Method.Async,
+		MethodName = ""GetCountAsync"")]
+	public virtual partial void GetCount (Action callback);
+
+	[SupportedOSPlatform (""ios"")]
+	[SupportedOSPlatform (""tvos"")]
+	[SupportedOSPlatform (""macos"")]
+	[SupportedOSPlatform (""maccatalyst13.1"")]
+	[Export<Method> (""count_second:"", 
+		Flags = ObjCBindings.Method.Async,
+		MethodName = ""GetCountAsync"")]
+	public virtual partial void GetCountSecond (int second, Action callback);
+
+}",
+				"RBI0039",
 			];
 		}
 

--- a/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/ClassAnalyzerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/ClassAnalyzerTests.cs
@@ -620,9 +620,9 @@ public partial class TestClass{
 				DiagnosticSeverity.Error,
 				"There is a mismatch between the arguments of 'AttributedStringByInflectingString' (found 0) and the selector 'isAttributedStringByInflectingString:' (found 1)"
 			];
-			
+
 			// async methods
-			
+
 			// async method not void
 			yield return [
 @"
@@ -659,7 +659,7 @@ public partial class TestClass{
 				DiagnosticSeverity.Error,
 				"The method 'GetCount' was marked as async but its return type is not void"
 			];
-			
+
 			// void but no args
 			yield return [
 				@"
@@ -696,7 +696,7 @@ public partial class TestClass{
 				DiagnosticSeverity.Error,
 				"The method 'GetCount' was marked as async but has 0 parameters when at least a single delegate parameter is required"
 			];
-			
+
 			// void but with args but no delegate
 			yield return [
 				@"
@@ -733,7 +733,7 @@ public partial class TestClass{
 				DiagnosticSeverity.Error,
 				"The method 'GetCount' was marked as async but its last parameter is not a delegate",
 			];
-			
+
 			// void but with delegate but with a duplicated async name
 			yield return [
 				@"
@@ -780,7 +780,7 @@ public partial class TestClass{
 				DiagnosticSeverity.Error,
 				"The async name 'GetCountAsync' used by 'GetCountSecond' is already used by 'GetCount'",
 			];
-			
+
 			// can async method but flag is missing
 			yield return [
 				@"
@@ -999,7 +999,7 @@ public partial class TestClass{
 }",
 				"RBI0034",
 			];
-			
+
 			// void but with delegate with a duplicated async name but with different args
 			yield return [
 				@"


### PR DESCRIPTION
Ensure that:

1. If a method can be async, that is marked as such (warning).
2. Make sure marked async methods return void (error).
3. Make sure marked async methods have a delegate (error).
4. Make sure that Async methods have diff async names if the parameters are the same (error).

The tests showed a number of bugs in the async generation when we use the async flag with no parameters. Those got fixed.