### PR TITLE
[devops] Use a variable for the Xcode channel to avoid duplication.

### DIFF
--- a/docs/ReleaseCheckList.md
+++ b/docs/ReleaseCheckList.md
@@ -20,11 +20,10 @@ Copy this list into a new issue and then check off as the release progresses.
     * XCODE_VERSION
     * XCODE_URL
     * XCODE_DEVELOPER_ROOT
-  * Update any `xcodeChannel` values in tools/devops. Change to `Beta` if using an Xcode beta or release candidate, and switch back to `Stable` with the final (stable) Xcode release.
+  * Update the `xcodeChannel` value in `tools/devops/automation/templates/variables/common.yml`. Change to `Beta` if using an Xcode beta or release candidate, and switch back to `Stable` with the final (stable) Xcode release.
     ```shell
-    $ cd tools/devops
-    $ git grep -nE -e 'xcodeChannel: (Stable|Beta)' -i
-      [...] # these are the matches that may need fixing.
+    $ git grep -A 1 -E 'xcodeChannel' -- tools/devops/automation/templates/variables/common.yml
+      [...] # the value that needs to be updated
     ```
   * Add the new OS versions to the `builds/Version-*.plist.in` files.
   * Build and fix any issues.

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -128,7 +128,7 @@ extends:
     stages:
       - template: templates/main-stage.yml
         parameters:
-          xcodeChannel: Beta
+          xcodeChannel: $(xcodeChannel)
           macOSName: ${{ parameters.macOSName }}
           isPR: false
           provisionatorChannel: ${{ parameters.provisionatorChannel }}

--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -121,7 +121,7 @@ extends:
     stages:
     - template: templates/main-stage.yml
       parameters:
-        xcodeChannel: Beta
+        xcodeChannel: $(xcodeChannel)
         macOSName: ${{ parameters.macOSName }}
         isPR: true
         provisionatorChannel: ${{ parameters.provisionatorChannel }}

--- a/tools/devops/automation/run-nightly-codeql.yml
+++ b/tools/devops/automation/run-nightly-codeql.yml
@@ -44,7 +44,7 @@ stages:
       demands:
       - Agent.OS -equals Darwin
       - macOS.Name -equals ${{ parameters.macOSName }}
-      - XcodeChannel -equals Beta
+      - XcodeChannel -equals $(xcodeChannel)
     workspace:
       clean: all
     steps:

--- a/tools/devops/automation/scripts/bash/validate-xcode-channel.sh
+++ b/tools/devops/automation/scripts/bash/validate-xcode-channel.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -e
+
+if test -z "${XCODE_CHANNEL:-}"; then
+	echo "The environment variable XCODE_CHANNEL must be specified."
+	exit 1
+fi
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
+
+FILE=$(pwd)/tmp.txt
+
+make print-variable-value-to-file FILE="$FILE" VARIABLE=XCODE_IS_PREVIEW
+XCODE_IS_PREVIEW=$(cat "$FILE")
+
+make print-variable-value-to-file FILE="$FILE" VARIABLE=XCODE_IS_STABLE
+XCODE_IS_STABLE=$(cat "$FILE")
+
+rm -f "$FILE"
+
+if [[ "$XCODE_IS_PREVIEW $XCODE_IS_STABLE" == "true false" ]]; then
+	if [[ "${XCODE_CHANNEL}" != "Beta" ]]; then
+		echo "XCODE_CHANNEL must be 'Beta' (not '$XCODE_CHANNEL') when XCODE_IS_PREVIEW=$XCODE_IS_PREVIEW (and XCODE_IS_STABLE=$XCODE_IS_STABLE)"
+		exit 1
+	fi
+elif [[ "$XCODE_IS_PREVIEW $XCODE_IS_STABLE" == "false true" ]]; then
+	if [[ "${XCODE_CHANNEL}" != "Stable" ]]; then
+		echo "XCODE_CHANNEL must be 'Stable' (not '$XCODE_CHANNEL') when XCODE_IS_STABLE=$XCODE_IS_STABLE (and XCODE_IS_PREVIEW=$XCODE_IS_PREVIEW)"
+		exit 1
+	fi
+else
+	echo "Unexpected values for XCODE_IS_STABLE ($XCODE_IS_STABLE) and XCODE_IS_PREVIEW ($XCODE_IS_PREVIEW): must be either 'true' or 'false', and not equal to eachother."
+	exit 1
+fi
+
+echo "The current Xcode channel ('$XCODE_CHANNEL') is correct."

--- a/tools/devops/automation/templates/common/configure.yml
+++ b/tools/devops/automation/templates/common/configure.yml
@@ -146,6 +146,12 @@ steps:
   name: configure_platforms
   displayName: 'Configure platforms'
 
+- bash: ./$(BUILD_REPOSITORY_TITLE)/tools/devops/automation/scripts/bash/validate-xcode-channel.sh
+  name: validateXcodeChannel
+  displayName: 'Validate Xcode channel'
+  env:
+    XCODE_CHANNEL: $(xcodeChannel)
+
 - pwsh: |
     Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/$Env:BUILD_REPOSITORY_TITLE/tools/devops/automation/scripts/MaciosCI.psd1
     $jsonPath = Join-Path -Path "$(Build.ArtifactStagingDirectory)" -ChildPath "configuration.json"

--- a/tools/devops/automation/templates/pipelines/api-diff-pipeline.yml
+++ b/tools/devops/automation/templates/pipelines/api-diff-pipeline.yml
@@ -54,7 +54,7 @@ variables:
 stages:
 - template: ../api-diff-stage.yml
   parameters:
-    xcodeChannel: Beta
+    xcodeChannel: $(xcodeChannel)
     macOSName: ${{ parameters.macOSName }}
     isPR: ${{ parameters.isPR }}
     provisionatorChannel: ${{ parameters.provisionatorChannel }}

--- a/tools/devops/automation/templates/pipelines/build-pipeline.yml
+++ b/tools/devops/automation/templates/pipelines/build-pipeline.yml
@@ -89,7 +89,7 @@ variables:
 stages:
 - template: ../main-stage.yml
   parameters:
-    xcodeChannel: Beta
+    xcodeChannel: $(xcodeChannel)
     macOSName: ${{ parameters.macOSName }}
     isPR: ${{ parameters.isPR }}
     provisionatorChannel: ${{ parameters.provisionatorChannel }}

--- a/tools/devops/automation/templates/pipelines/run-tests-pipeline.yml
+++ b/tools/devops/automation/templates/pipelines/run-tests-pipeline.yml
@@ -55,7 +55,7 @@ variables:
 stages:
   - template: ../tests-stage.yml
     parameters:
-      xcodeChannel: Beta
+      xcodeChannel: $(xcodeChannel)
       macOSName: ${{ parameters.macOSName }}
       isPR: ${{ parameters.isPR }}
       provisionatorChannel: ${{ parameters.provisionatorChannel }}

--- a/tools/devops/automation/templates/variables/common.yml
+++ b/tools/devops/automation/templates/variables/common.yml
@@ -69,3 +69,6 @@ variables:
 
 - name: DotNetPreviewSdkVersion
   value: 10.0
+
+- name: xcodeChannel
+  value: Beta


### PR DESCRIPTION
Also verify that we use the right Xcode channel depending on which version of Xcode we're targeting.