### PR TITLE
[RGen] Keep the track of the enum member position.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Binding.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Binding.Generator.cs
@@ -300,7 +300,7 @@ readonly partial struct Binding {
 		var bucket = ImmutableArray.CreateBuilder<EnumMember> ();
 		// loop over the fields and add those that contain a FieldAttribute
 		var enumValueDeclarations = enumDeclaration.Members.OfType<EnumMemberDeclarationSyntax> ();
-		foreach (var enumValueDeclaration in enumValueDeclarations) {
+		foreach (var (index, enumValueDeclaration) in enumValueDeclarations.Index ()) {
 			if (Skip (enumValueDeclaration, context.SemanticModel))
 				continue;
 			if (context.SemanticModel.GetDeclaredSymbol (enumValueDeclaration) is not IFieldSymbol enumValueSymbol) {
@@ -314,6 +314,7 @@ readonly partial struct Binding {
 				// could not calculate the library for the enum add it with bad data for the analyzer to pick it up
 				var enumMember = new EnumMember (
 					name: enumValueDeclaration.Identifier.ToFullString ().Trim (),
+					index: (uint) index,
 					libraryName: string.Empty,
 					libraryPath: null,
 					fieldData: enumValueSymbol.GetFieldData (),
@@ -326,6 +327,7 @@ readonly partial struct Binding {
 			} else {
 				var enumMember = new EnumMember (
 					name: enumValueDeclaration.Identifier.ToFullString ().Trim (),
+					index: (uint) index,
 					libraryName: libraryName,
 					libraryPath: libraryPath,
 					fieldData: enumValueSymbol.GetFieldData (),

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMember.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMember.Generator.cs
@@ -30,19 +30,21 @@ readonly partial struct EnumMember {
 	/// Create a new change that happened on a member.
 	/// </summary>
 	/// <param name="name">The name of the changed member.</param>
+	/// <param name="index">The position of the enum member starting at 0.</param>
 	/// <param name="libraryName">The library name of the smart enum.</param>
 	/// <param name="libraryPath">The library path to the library, null if it is a known frameworl.</param>
 	/// <param name="fieldData">The binding data attached to this enum value.</param>
 	/// <param name="symbolAvailability">The symbol availability of the member.</param>
 	/// <param name="attributes">The list of attribute changes in the member.</param>
 	public EnumMember (string name,
+		uint index,
 		string libraryName,
 		string? libraryPath,
 		FieldData<EnumValue>? fieldData,
 		SymbolAvailability symbolAvailability,
-		ImmutableArray<AttributeCodeChange> attributes)
+		ImmutableArray<AttributeCodeChange> attributes) : this (StructState.Initialized, name)
 	{
-		Name = name;
+		Index = index;
 		FieldInfo = fieldData is null ? null : new (fieldData.Value, libraryName, libraryPath);
 		SymbolAvailability = symbolAvailability;
 		Attributes = attributes;
@@ -52,11 +54,13 @@ readonly partial struct EnumMember {
 	/// Create a new change that happened on a member.
 	/// </summary>
 	/// <param name="name">The name of the changed member.</param>
+	/// <param name="index">The position of the enum member starting at 0.</param>
 	/// <param name="libraryName">The library name of the smart enum.</param>
 	/// <param name="libraryPath">The library path to the library, null if it is a known frameworl.</param>
-	public EnumMember (string name, string libraryName, string? libraryPath)
+	public EnumMember (string name, uint index, string libraryName, string? libraryPath)
 		: this (
 			name: name,
+			index: index,
 			libraryName: libraryName,
 			libraryPath: libraryPath,
 			fieldData: null,

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMember.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMember.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Macios.Generator.DataModel;
 /// </summary>
 [StructLayout (LayoutKind.Auto)]
 readonly partial struct EnumMember : IEquatable<EnumMember> {
-	
+
 	/// <summary>
 	/// The initialization state of the struct.
 	/// </summary>
@@ -32,12 +32,12 @@ readonly partial struct EnumMember : IEquatable<EnumMember> {
 	/// Gets a value indicating whether the instance is the default, uninitialized instance.
 	/// </summary>
 	public bool IsNullOrDefault => State == StructState.Default;
-	
+
 	/// <summary>
 	/// Get the name of the member.
 	/// </summary>
 	public string Name { get; }
-	
+
 	/// <summary>
 	/// Gets the index of the enum member.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMember.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMember.cs
@@ -17,10 +17,31 @@ namespace Microsoft.Macios.Generator.DataModel;
 /// </summary>
 [StructLayout (LayoutKind.Auto)]
 readonly partial struct EnumMember : IEquatable<EnumMember> {
+	
+	/// <summary>
+	/// The initialization state of the struct.
+	/// </summary>
+	StructState State { get; init; } = StructState.Default;
+
+	/// <summary>
+	/// Gets the default, uninitialized instance of <see cref="EnumMember"/>.
+	/// </summary>
+	public static EnumMember Default { get; } = new (StructState.Default, string.Empty);
+
+	/// <summary>
+	/// Gets a value indicating whether the instance is the default, uninitialized instance.
+	/// </summary>
+	public bool IsNullOrDefault => State == StructState.Default;
+	
 	/// <summary>
 	/// Get the name of the member.
 	/// </summary>
 	public string Name { get; }
+	
+	/// <summary>
+	/// Gets the index of the enum member.
+	/// </summary>
+	public uint Index { get; init; }
 
 	/// <summary>
 	/// The platform availability of the enum value.
@@ -36,6 +57,8 @@ readonly partial struct EnumMember : IEquatable<EnumMember> {
 	public bool Equals (EnumMember other)
 	{
 		if (Name != other.Name)
+			return false;
+		if (Index != other.Index)
 			return false;
 		if (SymbolAvailability != other.SymbolAvailability)
 			return false;
@@ -55,24 +78,47 @@ readonly partial struct EnumMember : IEquatable<EnumMember> {
 	/// <inheritdoc />
 	public override int GetHashCode ()
 	{
-		return HashCode.Combine (Name, SymbolAvailability, Attributes);
+		return HashCode.Combine (Name, Index, SymbolAvailability, FieldInfo, Attributes);
 	}
 
+	/// <summary>
+	/// Compares two <see cref="EnumMember"/> instances for equality.
+	/// </summary>
+	/// <param name="x">The first <see cref="EnumMember"/> to compare.</param>
+	/// <param name="y">The second <see cref="EnumMember"/> to compare.</param>
+	/// <returns><c>true</c> if the instances are equal; otherwise, <c>false</c>.</returns>
 	public static bool operator == (EnumMember x, EnumMember y)
 	{
 		return x.Equals (y);
 	}
 
+	/// <summary>
+	/// Compares two <see cref="EnumMember"/> instances for inequality.
+	/// </summary>
+	/// <param name="x">The first <see cref="EnumMember"/> to compare.</param>
+	/// <param name="y">The second <see cref="EnumMember"/> to compare.</param>
+	/// <returns><c>true</c> if the instances are not equal; otherwise, <c>false</c>.</returns>
 	public static bool operator != (EnumMember x, EnumMember y)
 	{
 		return !(x == y);
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="EnumMember"/> struct.
+	/// </summary>
+	/// <param name="state">The initialization state of the struct.</param>
+	/// <param name="name">The name of the enum member.</param>
+	public EnumMember (StructState state, string name)
+	{
+		State = state;
+		Name = name;
 	}
 
 	/// <inheritdoc />
 	public override string ToString ()
 	{
 		var sb = new StringBuilder (
-			$"{{ Name: '{Name}' SymbolAvailability: {SymbolAvailability} FieldInfo: {FieldInfo} Attributes: [");
+			$"{{ Name: '{Name}', Index: {Index}, SymbolAvailability: {SymbolAvailability} FieldInfo: {FieldInfo} Attributes: [");
 		sb.AppendJoin (", ", Attributes);
 		sb.Append ("] }");
 		return sb.ToString ();

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Binding.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Binding.Transformer.cs
@@ -106,7 +106,7 @@ readonly partial struct Binding {
 				}
 				enumMember = new EnumMember (
 					name: enumValueDeclaration.Identifier.ToFullString ().Trim (),
-          index: (uint) index,
+		  index: (uint) index,
 					libraryName: string.Empty,
 					libraryPath: null,
 					fieldData: enumValueSymbol.GetFieldData (),
@@ -121,7 +121,7 @@ readonly partial struct Binding {
 				bindingType = BindingType.SmartEnum;
 				enumMember = new EnumMember (
 					name: enumValueDeclaration.Identifier.ToFullString ().Trim (),
-          index: (uint) index,
+		  index: (uint) index,
 					libraryName: libraryName,
 					libraryPath: libraryPath,
 					fieldData: enumValueSymbol.GetFieldData (),

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Binding.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Binding.Transformer.cs
@@ -86,7 +86,7 @@ readonly partial struct Binding {
 		var bindingType = HasErrorDomainAttribute ? BindingType.SmartEnum : BindingType.Unknown;
 		var bucket = ImmutableArray.CreateBuilder<EnumMember> ();
 		var enumValueDeclarations = enumDeclaration.Members.OfType<EnumMemberDeclarationSyntax> ();
-		foreach (var enumValueDeclaration in enumValueDeclarations) {
+		foreach (var (index, enumValueDeclaration) in enumValueDeclarations.Index ()) {
 			if (context.SemanticModel.GetDeclaredSymbol (enumValueDeclaration) is not IFieldSymbol enumValueSymbol) {
 				continue;
 			}
@@ -100,6 +100,7 @@ readonly partial struct Binding {
 			bindingType = BindingType.SmartEnum;
 			var enumMember = new EnumMember (
 				name: enumValueDeclaration.Identifier.ToFullString ().Trim (),
+				index: (uint) index,
 				libraryName: libraryName,
 				libraryPath: libraryPath,
 				fieldData: enumValueSymbol.GetFieldData (),

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/EnumMember.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/EnumMember.Transformer.cs
@@ -33,12 +33,13 @@ readonly partial struct EnumMember {
 	}
 
 	public EnumMember (string name,
+		uint index,
 		string libraryName,
 		string? libraryPath,
 		FieldData? fieldData,
-		SymbolAvailability symbolAvailability)
+		SymbolAvailability symbolAvailability) : this (StructState.Initialized, name)
 	{
-		Name = name;
+		Index = index;
 		SymbolAvailability = symbolAvailability;
 		FieldInfo = new (fieldData, libraryName, libraryPath);
 	}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingComparerTests.cs
@@ -196,6 +196,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 			EnumMembers = [
 				new EnumMember (
 					name: "name",
+					index: 0,
 					libraryName: "Test",
 					libraryPath: "/path/to/library",
 					fieldData: new (),
@@ -218,6 +219,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 			EnumMembers = [
 				new EnumMember (
 					name: "name",
+					index: 0,
 					libraryName: "Test",
 					libraryPath: "/path/to/library",
 					fieldData: new (),
@@ -234,6 +236,7 @@ public class BindingComparerTests : BaseGeneratorTestClass {
 			EnumMembers = [
 				new EnumMember (
 					name: "name2",
+					index: 0,
 					libraryName: "Test",
 					libraryPath: "/path/to/library",
 					fieldData: new (),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingEqualityComparerTests.cs
@@ -115,6 +115,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 			EnumMembers = [
 				new EnumMember (
 					name: "name",
+					index: 0,
 					libraryName: "Test",
 					libraryPath: "/path/to/library",
 					fieldData: new (),
@@ -137,6 +138,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 			EnumMembers = [
 				new EnumMember (
 					name: "name",
+					index: 0,
 					libraryName: "Test",
 					libraryPath: "/path/to/library",
 					fieldData: new (),
@@ -153,6 +155,7 @@ public class BindingEqualityComparerTests : BaseGeneratorTestClass {
 			EnumMembers = [
 				new EnumMember (
 					name: "name2",
+					index: 0,
 					libraryName: "Test",
 					libraryPath: "/path/to/library",
 					fieldData: new (),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingTests.cs
@@ -275,6 +275,7 @@ public class TestClass {
 			EnumMembers = [
 				new (
 					name: "BuiltInMicrophone",
+					index: 0,
 					libraryName: "AVCaptureDeviceTypeBuiltInMicrophone",
 					libraryPath: null,
 					fieldData: new (presentSelector),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumMemberCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumMemberCodeChangesTests.cs
@@ -13,22 +13,43 @@ namespace Microsoft.Macios.Generator.Tests.DataModel;
 
 public class EnumMemberCodeChangesTests {
 	[Fact]
+	public void IsNullOrDefaultTest ()
+	{
+		var defaultMember = EnumMember.Default;
+		Assert.True (defaultMember.IsNullOrDefault);
+
+		var initializedMember = new EnumMember (
+			name: "name",
+			index: 0,
+			libraryName: "Test",
+			libraryPath: "/path/to/library",
+			fieldData: new (),
+			symbolAvailability: new (),
+			attributes: []);
+		Assert.False (initializedMember.IsNullOrDefault);
+	}
+
+	[Fact]
 	public void EqualsNoParams ()
 	{
 		var memberCodeChange1 = new EnumMember (
 			name: "name",
+			index: 0,
 			libraryName: "Test",
 			libraryPath: "/path/to/library",
 			fieldData: new (),
 			symbolAvailability: new (),
 			attributes: []);
+		Assert.False (memberCodeChange1.IsNullOrDefault);
 		var memberCodeChange2 = new EnumMember (
 			name: "name",
+			index: 0,
 			libraryName: "Test",
 			libraryPath: "/path/to/library",
 			fieldData: new (),
 			symbolAvailability: new (),
 			attributes: []);
+		Assert.False (memberCodeChange2.IsNullOrDefault);
 		Assert.True (memberCodeChange1.Equals (memberCodeChange2));
 		Assert.True (memberCodeChange1 == memberCodeChange2);
 		Assert.False (memberCodeChange1 != memberCodeChange2);
@@ -39,6 +60,7 @@ public class EnumMemberCodeChangesTests {
 	{
 		var memberCodeChange1 = new EnumMember (
 			name: "name",
+			index: 0,
 			libraryName: "Test",
 			libraryPath: "/path/to/library",
 			fieldData: new (),
@@ -47,8 +69,10 @@ public class EnumMemberCodeChangesTests {
 				new AttributeCodeChange ("name", ["arg1", "arg2"])
 			]
 		);
+		Assert.False (memberCodeChange1.IsNullOrDefault);
 		var memberCodeChange2 = new EnumMember (
 			name: "name",
+			index: 0,
 			libraryName: "Test",
 			libraryPath: "/path/to/library",
 			fieldData: new (),
@@ -57,6 +81,7 @@ public class EnumMemberCodeChangesTests {
 				new AttributeCodeChange ("name", ["arg1", "arg2"])
 			]
 		);
+		Assert.False (memberCodeChange2.IsNullOrDefault);
 		Assert.True (memberCodeChange1.Equals (memberCodeChange2));
 		Assert.True (memberCodeChange1 == memberCodeChange2);
 		Assert.False (memberCodeChange1 != memberCodeChange2);
@@ -67,19 +92,23 @@ public class EnumMemberCodeChangesTests {
 	{
 		var memberCodeChange1 = new EnumMember (
 			name: "name",
+			index: 0,
 			libraryName: "Test",
 			libraryPath: "/path/to/library",
 			fieldData: new (),
 			symbolAvailability: new (),
 			attributes: []);
+		Assert.False (memberCodeChange1.IsNullOrDefault);
 		var memberCodeChange2 = new EnumMember (
 			name: "name2",
+			index: 0,
 			libraryName: "Test",
 			libraryPath: "/path/to/library",
 			fieldData: new (),
 			symbolAvailability: new (),
 			attributes: []
 		);
+		Assert.False (memberCodeChange2.IsNullOrDefault);
 		Assert.False (memberCodeChange1.Equals (memberCodeChange2));
 		Assert.False (memberCodeChange1 == memberCodeChange2);
 		Assert.True (memberCodeChange1 != memberCodeChange2);
@@ -90,6 +119,7 @@ public class EnumMemberCodeChangesTests {
 	{
 		var memberCodeChange1 = new EnumMember (
 			name: "name",
+			index: 0,
 			libraryName: "Test",
 			libraryPath: "/path/to/library",
 			fieldData: new (),
@@ -98,8 +128,10 @@ public class EnumMemberCodeChangesTests {
 				new AttributeCodeChange ("name", ["arg1", "arg2"])
 			]
 		);
+		Assert.False (memberCodeChange1.IsNullOrDefault);
 		var memberCodeChange2 = new EnumMember (
 			name: "name",
+			index: 0,
 			libraryName: "Test",
 			libraryPath: "/path/to/library",
 			fieldData: new (),
@@ -108,6 +140,7 @@ public class EnumMemberCodeChangesTests {
 				new AttributeCodeChange ("name2", ["arg1", "arg2"])
 			]
 		);
+		Assert.False (memberCodeChange2.IsNullOrDefault);
 		Assert.False (memberCodeChange1.Equals (memberCodeChange2));
 		Assert.False (memberCodeChange1 == memberCodeChange2);
 		Assert.True (memberCodeChange1 != memberCodeChange2);
@@ -118,6 +151,7 @@ public class EnumMemberCodeChangesTests {
 	{
 		var memberCodeChange1 = new EnumMember (
 			name: "name",
+			index: 0,
 			libraryName: "Test",
 			libraryPath: "/path/to/library",
 			fieldData: new (),
@@ -126,8 +160,10 @@ public class EnumMemberCodeChangesTests {
 				new AttributeCodeChange ("name", ["arg1", "arg2"])
 			]
 		);
+		Assert.False (memberCodeChange1.IsNullOrDefault);
 		var memberCodeChange2 = new EnumMember (
 			name: "name",
+			index: 0,
 			libraryName: "Test",
 			libraryPath: "/path/to/library",
 			fieldData: new (),
@@ -136,6 +172,7 @@ public class EnumMemberCodeChangesTests {
 				new AttributeCodeChange ("name", ["arg1", "arg3"])
 			]
 		);
+		Assert.False (memberCodeChange2.IsNullOrDefault);
 		Assert.False (memberCodeChange1.Equals (memberCodeChange2));
 		Assert.False (memberCodeChange1 == memberCodeChange2);
 		Assert.True (memberCodeChange1 != memberCodeChange2);
@@ -146,6 +183,7 @@ public class EnumMemberCodeChangesTests {
 	{
 		var memberCodeChange1 = new EnumMember (
 			name: "name",
+			index: 0,
 			libraryName: "Test",
 			libraryPath: "/path/to/library",
 			fieldData: new (),
@@ -154,8 +192,10 @@ public class EnumMemberCodeChangesTests {
 				new AttributeCodeChange ("name", ["arg1", "arg2"])
 			]
 		);
+		Assert.False (memberCodeChange1.IsNullOrDefault);
 		var memberCodeChange2 = new EnumMember (
 			name: "name",
+			index: 0,
 			libraryName: "Test",
 			libraryPath: "/path/to/library",
 			fieldData: new (),
@@ -164,6 +204,7 @@ public class EnumMemberCodeChangesTests {
 				new AttributeCodeChange ("name", ["arg2", "arg1"])
 			]
 		);
+		Assert.False (memberCodeChange2.IsNullOrDefault);
 		Assert.False (memberCodeChange1.Equals (memberCodeChange2));
 		Assert.False (memberCodeChange1 == memberCodeChange2);
 		Assert.True (memberCodeChange1 != memberCodeChange2);
@@ -174,6 +215,7 @@ public class EnumMemberCodeChangesTests {
 	{
 		var memberCodeChange1 = new EnumMember (
 			name: "name",
+			index: 0,
 			libraryName: "Test",
 			libraryPath: "/path/to/library",
 			fieldData: new (),
@@ -183,8 +225,10 @@ public class EnumMemberCodeChangesTests {
 				new AttributeCodeChange ("name2", [])
 			]
 		);
+		Assert.False (memberCodeChange1.IsNullOrDefault);
 		var memberCodeChange2 = new EnumMember (
 			name: "name",
+			index: 0,
 			libraryName: "Test",
 			libraryPath: "/path/to/library",
 			fieldData: new (),
@@ -193,6 +237,7 @@ public class EnumMemberCodeChangesTests {
 				new AttributeCodeChange ("name", ["arg2", "arg1"])
 			]
 		);
+		Assert.False (memberCodeChange2.IsNullOrDefault);
 		Assert.False (memberCodeChange1.Equals (memberCodeChange2));
 		Assert.False (memberCodeChange1 == memberCodeChange2);
 		Assert.True (memberCodeChange1 != memberCodeChange2);
@@ -209,6 +254,7 @@ public class EnumMemberCodeChangesTests {
 
 		var memberCodeChange1 = new EnumMember (
 			name: "name",
+			index: 0,
 			libraryName: "Test",
 			libraryPath: "/path/to/library",
 			fieldData: new (),
@@ -218,8 +264,10 @@ public class EnumMemberCodeChangesTests {
 				new AttributeCodeChange ("name2", [])
 			]
 		);
+		Assert.False (memberCodeChange1.IsNullOrDefault);
 		var memberCodeChange2 = new EnumMember (
 			name: "name",
+			index: 0,
 			libraryName: "Test",
 			libraryPath: "/path/to/library",
 			fieldData: new (),
@@ -228,6 +276,34 @@ public class EnumMemberCodeChangesTests {
 				new AttributeCodeChange ("name", ["arg2", "arg1"])
 			]
 		);
+		Assert.False (memberCodeChange2.IsNullOrDefault);
+		Assert.False (memberCodeChange1.Equals (memberCodeChange2));
+		Assert.False (memberCodeChange1 == memberCodeChange2);
+		Assert.True (memberCodeChange1 != memberCodeChange2);
+	}
+
+	[Fact]
+	public void NotEqualsDifferentIndex ()
+	{
+		var memberCodeChange1 = new EnumMember (
+			name: "name",
+			index: 0,
+			libraryName: "Test",
+			libraryPath: "/path/to/library",
+			fieldData: new (),
+			symbolAvailability: new (),
+			attributes: []);
+		Assert.False (memberCodeChange1.IsNullOrDefault);
+		var memberCodeChange2 = new EnumMember (
+			name: "name",
+			index: 1,
+			libraryName: "Test",
+			libraryPath: "/path/to/library",
+			fieldData: new (),
+			symbolAvailability: new (),
+			attributes: []
+		);
+		Assert.False (memberCodeChange2.IsNullOrDefault);
 		Assert.False (memberCodeChange1.Equals (memberCodeChange2));
 		Assert.False (memberCodeChange1 == memberCodeChange2);
 		Assert.True (memberCodeChange1 != memberCodeChange2);
@@ -238,22 +314,23 @@ public class EnumMemberCodeChangesTests {
 	{
 		var memberCodeChange1 = new EnumMember (
 			name: "name",
+			index: 0,
 			libraryName: "Test",
 			libraryPath: "/path/to/library",
 			fieldData: new ("x", "libName", EnumValue.Default),
-			symbolAvailability: new (), attributes: [
-				new AttributeCodeChange ("name", ["arg1", "arg2"]),
-			]
-		);
+			symbolAvailability: new (),
+			attributes: []);
+		Assert.False (memberCodeChange1.IsNullOrDefault);
 		var memberCodeChange2 = new EnumMember (
 			name: "name",
+			index: 0,
 			libraryName: "Test",
 			libraryPath: "/path/to/library",
-			fieldData: new ("x", "yLibName", EnumValue.Default),
-			symbolAvailability: new (), attributes: [
-				new AttributeCodeChange ("name", ["arg2", "arg1"])
-			]
+			fieldData: new ("y", "libName", EnumValue.Default),
+			symbolAvailability: new (),
+			attributes: []
 		);
+		Assert.False (memberCodeChange2.IsNullOrDefault);
 		Assert.False (memberCodeChange1.Equals (memberCodeChange2));
 		Assert.False (memberCodeChange1 == memberCodeChange2);
 		Assert.True (memberCodeChange1 != memberCodeChange2);
@@ -264,14 +341,16 @@ public class EnumMemberCodeChangesTests {
 		{
 			var simpleEnum = new EnumMember (
 				name: "EnumValue",
+				index: 0,
 				libraryName: "Test",
 				libraryPath: "/path/to/library",
 				fieldData: null,
 				symbolAvailability: new (),
 				attributes: []);
-			yield return [simpleEnum, "{ Name: 'EnumValue' SymbolAvailability: [] FieldInfo:  Attributes: [] }"];
+			yield return [simpleEnum, "{ Name: 'EnumValue', Index: 0, SymbolAvailability: [] FieldInfo:  Attributes: [] }"];
 			var fieldDataEnum = new EnumMember (
 				name: "EnumValue",
+				index: 0,
 				libraryName: "Test",
 				libraryPath: "/path/to/library",
 				fieldData: new ("x", "libName", EnumValue.Default),
@@ -279,7 +358,7 @@ public class EnumMemberCodeChangesTests {
 				attributes: []);
 			yield return [
 				fieldDataEnum,
-				"{ Name: 'EnumValue' SymbolAvailability: [] FieldInfo: { State = Initialized, FieldData = { SymbolName: 'x', LibraryPath: 'libName', Type: 'null', NotificationCenter: 'null', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library } Attributes: [] }",
+				"{ Name: 'EnumValue', Index: 0, SymbolAvailability: [] FieldInfo: { State = Initialized, FieldData = { SymbolName: 'x', LibraryPath: 'libName', Type: 'null', NotificationCenter: 'null', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library } Attributes: [] }",
 			];
 
 			var builder = SymbolAvailability.CreateBuilder ();
@@ -287,6 +366,7 @@ public class EnumMemberCodeChangesTests {
 
 			var availabilityEnum = new EnumMember (
 				name: "EnumValue",
+				index: 0,
 				libraryName: "Test",
 				libraryPath: "/path/to/library",
 				fieldData: new ("x", "libName", EnumValue.Default),
@@ -294,11 +374,12 @@ public class EnumMemberCodeChangesTests {
 				attributes: []);
 			yield return [
 				availabilityEnum,
-				"{ Name: 'EnumValue' SymbolAvailability: [{ Platform: 'iOS', Supported: '0.0', Unsupported: [], Obsoleted: [] }] FieldInfo: { State = Initialized, FieldData = { SymbolName: 'x', LibraryPath: 'libName', Type: 'null', NotificationCenter: 'null', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library } Attributes: [] }",
+				"{ Name: 'EnumValue', Index: 0, SymbolAvailability: [{ Platform: 'iOS', Supported: '0.0', Unsupported: [], Obsoleted: [] }] FieldInfo: { State = Initialized, FieldData = { SymbolName: 'x', LibraryPath: 'libName', Type: 'null', NotificationCenter: 'null', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library } Attributes: [] }",
 			];
 
 			var attrsEnum = new EnumMember (
 				name: "EnumValue",
+				index: 0,
 				libraryName: "Test",
 				libraryPath: "/path/to/library",
 				fieldData: new ("x", "libName", EnumValue.Default),
@@ -309,7 +390,7 @@ public class EnumMemberCodeChangesTests {
 				]);
 			yield return [
 				attrsEnum,
-				"{ Name: 'EnumValue' SymbolAvailability: [{ Platform: 'iOS', Supported: '0.0', Unsupported: [], Obsoleted: [] }] FieldInfo: { State = Initialized, FieldData = { SymbolName: 'x', LibraryPath: 'libName', Type: 'null', NotificationCenter: 'null', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library } Attributes: [{ Name: Attribute1, Arguments: [] }, { Name: Attribute2, Arguments: [] }] }",
+				"{ Name: 'EnumValue', Index: 0, SymbolAvailability: [{ Platform: 'iOS', Supported: '0.0', Unsupported: [], Obsoleted: [] }] FieldInfo: { State = Initialized, FieldData = { SymbolName: 'x', LibraryPath: 'libName', Type: 'null', NotificationCenter: 'null', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library } Attributes: [{ Name: Attribute1, Arguments: [] }, { Name: Attribute2, Arguments: [] }] }",
 			];
 		}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumMembersEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumMembersEqualityComparerTests.cs
@@ -21,43 +21,43 @@ public class EnumMembersEqualityComparerTests {
 	[Fact]
 	public void NotEqualsDiffLength ()
 	{
-		ImmutableArray<EnumMember> x = [new ("name", string.Empty, string.Empty, new (), new (), []), new ("name1", string.Empty, string.Empty)];
-		ImmutableArray<EnumMember> y = [new ("name", string.Empty, string.Empty, new (), new (), [])];
+		ImmutableArray<EnumMember> x = [new ("name", 0, string.Empty, string.Empty, new (), new (), []), new ("name1", 0, string.Empty, string.Empty)];
+		ImmutableArray<EnumMember> y = [new ("name", 0, string.Empty, string.Empty, new (), new (), [])];
 		Assert.False (comparer.Equals (x, y));
 	}
 
 	[Fact]
 	public void NotEqualsDiffAttributes ()
 	{
-		ImmutableArray<EnumMember> x = [new ("name", string.Empty, string.Empty, new (), new (), []), new ("name1", string.Empty, string.Empty)];
-		ImmutableArray<EnumMember> y = [new ("name", string.Empty, string.Empty, new (), new (), [
+		ImmutableArray<EnumMember> x = [new ("name", 0, string.Empty, string.Empty, new (), new (), []), new ("name1", 0, string.Empty, string.Empty)];
+		ImmutableArray<EnumMember> y = [new ("name", 0, string.Empty, string.Empty, new (), new (), [
 			new ("AttrName")
 		]),
-			new ("name1", string.Empty, string.Empty)];
+			new ("name1", 0, string.Empty, string.Empty)];
 		Assert.False (comparer.Equals (x, y));
 	}
 
 	[Fact]
 	public void EqualsSameOrder ()
 	{
-		ImmutableArray<EnumMember> x = [new ("name", string.Empty, string.Empty, new (), new SymbolAvailability (), []), new ("name1", string.Empty, string.Empty)];
-		ImmutableArray<EnumMember> y = [new ("name", string.Empty, string.Empty, new (), new SymbolAvailability (), []), new ("name1", string.Empty, string.Empty)];
+		ImmutableArray<EnumMember> x = [new ("name", 0, string.Empty, string.Empty, new (), new SymbolAvailability (), []), new ("name1", 0, string.Empty, string.Empty)];
+		ImmutableArray<EnumMember> y = [new ("name", 0, string.Empty, string.Empty, new (), new SymbolAvailability (), []), new ("name1", 0, string.Empty, string.Empty)];
 		Assert.True (comparer.Equals (x, y));
 	}
 
 	[Fact]
 	public void EqualsDiffOrder ()
 	{
-		ImmutableArray<EnumMember> x = [new ("name1", string.Empty, string.Empty), new ("name", string.Empty, string.Empty)];
-		ImmutableArray<EnumMember> y = [new ("name", string.Empty, string.Empty), new ("name1", string.Empty, string.Empty)];
+		ImmutableArray<EnumMember> x = [new ("name1", 0, string.Empty, string.Empty), new ("name", 0, string.Empty, string.Empty)];
+		ImmutableArray<EnumMember> y = [new ("name", 0, string.Empty, string.Empty), new ("name1", 0, string.Empty, string.Empty)];
 		Assert.True (comparer.Equals (x, y));
 	}
 
 	[Fact]
 	public void NotEqualsDiffFieldData ()
 	{
-		ImmutableArray<EnumMember> x = [new ("name", "", "", new ("x", "xLib", EnumValue.Default), new SymbolAvailability (), []), new ("name1", "", "")];
-		ImmutableArray<EnumMember> y = [new ("name", "", "", new ("y", "xLib", EnumValue.Default), new SymbolAvailability (), []), new ("name1", "", "")];
+		ImmutableArray<EnumMember> x = [new ("name", 0, "", "", new ("x", "xLib", EnumValue.Default), new SymbolAvailability (), []), new ("name1", 0, "", "")];
+		ImmutableArray<EnumMember> y = [new ("name", 0, "", "", new ("y", "xLib", EnumValue.Default), new SymbolAvailability (), []), new ("name1", 0, "", "")];
 		Assert.False (comparer.Equals (x, y));
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/DataModel/SmartEnumTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/DataModel/SmartEnumTests.cs
@@ -61,18 +61,21 @@ public enum AVCaptureDeviceType {
 					EnumMembers = [
 						new EnumMember (
 							name: "BuiltInMicrophone",
+							index: 0,
 							libraryName: "AVFoundation",
 							libraryPath: null,
 							fieldData: new ("AVCaptureDeviceTypeBuiltInMicrophone"),
 							symbolAvailability: availabilityBuilder.ToImmutable ()),
 						new EnumMember (
 							name: "BuiltInWideAngleCamera",
+							index: 1,
 							libraryName: "AVFoundation",
 							libraryPath: null,
 							fieldData: new ("AVCaptureDeviceTypeBuiltInWideAngleCamera"),
 							symbolAvailability: availabilityBuilder.ToImmutable ()),
 						new EnumMember (
 							name: "BuiltInTelephotoCamera",
+							index: 2,
 							libraryName: "AVFoundation",
 							libraryPath: null,
 							fieldData: new ("AVCaptureDeviceTypeBuiltInTelephotoCamera"),
@@ -117,12 +120,14 @@ public enum AVCaptureDeviceType {
 					EnumMembers = [
 						new EnumMember (
 							name: "BuiltInMicrophone",
+							index: 0,
 							libraryName: "AVFoundation",
 							libraryPath: null,
 							fieldData: new ("AVCaptureDeviceTypeBuiltInMicrophone"),
 							symbolAvailability: availabilityBuilder.ToImmutable ()),
 						new EnumMember (
 							name: "BuiltInWideAngleCamera",
+							index: 1,
 							libraryName: "AVFoundation",
 							libraryPath: null,
 							fieldData: new ("AVCaptureDeviceTypeBuiltInWideAngleCamera"),


### PR DESCRIPTION
This is needed by the transformer so that we can ensure that the enums are placed in the correct location when transforming APIs that might have diff members per platform.