### PR TITLE
[RGen] Add a new type to track versions.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Availability/PlatformSupportVersion.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Availability/PlatformSupportVersion.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.Macios.Generator.Availability;
+
+/// <summary>
+/// Represents a platform support version, combining a version number and a support kind.
+/// </summary>
+public readonly record struct PlatformSupportVersion {
+	/// <summary>
+	/// Gets the version number.
+	/// </summary>
+	public Version Version { get; init; }
+	/// <summary>
+	/// Gets the kind of support (e.g., explicit, implicit).
+	/// </summary>
+	public SupportKind Kind { get; init; }
+
+	/// <summary>
+	/// Gets a default platform support version with an implicit kind.
+	/// </summary>
+	public static PlatformSupportVersion ImplicitDefault { get; } = new () {
+		Version = new (),
+		Kind = SupportKind.Implicit
+	};
+
+	/// <summary>
+	/// Gets a default platform support version with an explicit kind.
+	/// </summary>
+	public static PlatformSupportVersion ExplicitDefault { get; } = new () {
+		Version = new (), 
+		Kind = SupportKind.Explicit
+	};
+
+	/// <summary>
+	/// Returns the platform support version with the highest precedence.
+	/// </summary>
+	/// <param name="v1">The first platform support version to compare.</param>
+	/// <param name="v2">The second platform support version to compare.</param>
+	/// <returns>
+	/// The platform support version with the highest precedence. If the kinds are the same, it returns the one with the greater version.
+	/// If the kinds are different, it returns the one with the higher kind value.
+	/// </returns>
+	public static PlatformSupportVersion Max (PlatformSupportVersion v1, PlatformSupportVersion v2)
+	{
+		if (v1.Kind == v2.Kind) {
+			return v1.Version >= v2.Version ? v1 : v2;
+		}
+		return (int) v1.Kind > (int) v2.Kind ? v1 : v2;
+	}
+
+	/// <summary>
+	/// Returns the platform support version with the lowest version if the kinds are the same, otherwise returns the one with the highest precedence kind.
+	/// </summary>
+	/// <param name="v1">The first platform support version to compare.</param>
+	/// <param name="v2">The second platform support version to compare.</param>
+	/// <returns>
+	/// The platform support version with the lowest version if the kinds are the same.
+	/// If the kinds are different, it returns the one with the higher kind value.
+	/// </returns>
+	public static PlatformSupportVersion Min (PlatformSupportVersion v1, PlatformSupportVersion v2)
+	{
+		if (v1.Kind == v2.Kind) {
+			return v1.Version <= v2.Version ? v1 : v2;
+		}
+		return (int) v1.Kind > (int) v2.Kind ? v1 : v2;
+	}
+}

--- a/src/rgen/Microsoft.Macios.Generator/Availability/PlatformSupportVersion.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Availability/PlatformSupportVersion.cs
@@ -30,7 +30,7 @@ public readonly record struct PlatformSupportVersion {
 	/// Gets a default platform support version with an explicit kind.
 	/// </summary>
 	public static PlatformSupportVersion ExplicitDefault { get; } = new () {
-		Version = new (), 
+		Version = new (),
 		Kind = SupportKind.Explicit
 	};
 

--- a/src/rgen/Microsoft.Macios.Generator/Availability/SupportKind.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Availability/SupportKind.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Macios.Generator.Availability;
+
+public enum SupportKind {
+	Implicit,
+	Explicit
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Availability/PlatformSupportVersionTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Availability/PlatformSupportVersionTests.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Macios.Generator.Availability;
+using Xunit;
+
+namespace Microsoft.Macios.Generator.Tests.Availability;
+
+public class PlatformSupportVersionTests {
+	[Fact]
+	public void ImplicitDefaultTest ()
+	{
+		var implicitDefault = PlatformSupportVersion.ImplicitDefault;
+		Assert.Equal (new Version (0, 0), implicitDefault.Version);
+		Assert.Equal (SupportKind.Implicit, implicitDefault.Kind);
+	}
+
+	[Fact]
+	public void ExplicitDefaultTest ()
+	{
+		var explicitDefault = PlatformSupportVersion.ExplicitDefault;
+		Assert.Equal (new Version (0, 0), explicitDefault.Version);
+		Assert.Equal (SupportKind.Explicit, explicitDefault.Kind);
+	}
+
+	public static TheoryData<PlatformSupportVersion, PlatformSupportVersion, PlatformSupportVersion> MaxTestData =>
+		new () {
+			// Same kind, v1 > v2
+			{
+				new PlatformSupportVersion { Version = new Version (2, 0), Kind = SupportKind.Implicit },
+				new PlatformSupportVersion { Version = new Version (1, 0), Kind = SupportKind.Implicit },
+				new PlatformSupportVersion { Version = new Version (2, 0), Kind = SupportKind.Implicit }
+			},
+			// Same kind, v2 > v1
+			{
+				new PlatformSupportVersion { Version = new Version (1, 0), Kind = SupportKind.Implicit },
+				new PlatformSupportVersion { Version = new Version (2, 0), Kind = SupportKind.Implicit },
+				new PlatformSupportVersion { Version = new Version (2, 0), Kind = SupportKind.Implicit }
+			},
+			// Same kind, v1 == v2
+			{
+				new PlatformSupportVersion { Version = new Version (1, 0), Kind = SupportKind.Implicit },
+				new PlatformSupportVersion { Version = new Version (1, 0), Kind = SupportKind.Implicit },
+				new PlatformSupportVersion { Version = new Version (1, 0), Kind = SupportKind.Implicit }
+			},
+			// Different kind, v1.Kind > v2.Kind
+			{
+				new PlatformSupportVersion { Version = new Version (1, 0), Kind = SupportKind.Explicit },
+				new PlatformSupportVersion { Version = new Version (2, 0), Kind = SupportKind.Implicit },
+				new PlatformSupportVersion { Version = new Version (1, 0), Kind = SupportKind.Explicit }
+			},
+			// Different kind, v2.Kind > v1.Kind
+			{
+				new PlatformSupportVersion { Version = new Version (2, 0), Kind = SupportKind.Implicit },
+				new PlatformSupportVersion { Version = new Version (1, 0), Kind = SupportKind.Explicit },
+				new PlatformSupportVersion { Version = new Version (1, 0), Kind = SupportKind.Explicit }
+			},
+			// ExplicitDefault vs ImplicitDefault
+			{
+				PlatformSupportVersion.ExplicitDefault,
+				PlatformSupportVersion.ImplicitDefault,
+				PlatformSupportVersion.ExplicitDefault
+			},
+			// ExplicitDefault vs other Implicit
+			{
+				PlatformSupportVersion.ExplicitDefault,
+				new PlatformSupportVersion { Version = new Version (10, 0), Kind = SupportKind.Implicit },
+				PlatformSupportVersion.ExplicitDefault
+			},
+			// ImplicitDefault vs other Implicit
+			{
+				PlatformSupportVersion.ImplicitDefault,
+				new PlatformSupportVersion { Version = new Version (1, 0), Kind = SupportKind.Implicit },
+				new PlatformSupportVersion { Version = new Version (1, 0), Kind = SupportKind.Implicit }
+			},
+			// ExplicitDefault vs other Explicit
+			{
+				PlatformSupportVersion.ExplicitDefault,
+				new PlatformSupportVersion { Version = new Version (1, 0), Kind = SupportKind.Explicit },
+				new PlatformSupportVersion { Version = new Version (1, 0), Kind = SupportKind.Explicit }
+			},
+		};
+
+	[Theory]
+	[MemberData (nameof (MaxTestData))]
+	public void MaxTests (PlatformSupportVersion v1, PlatformSupportVersion v2, PlatformSupportVersion expected)
+	{
+		Assert.Equal (expected, PlatformSupportVersion.Max (v1, v2));
+		// Test commutativity
+		Assert.Equal (expected, PlatformSupportVersion.Max (v2, v1));
+	}
+
+	public static TheoryData<PlatformSupportVersion, PlatformSupportVersion, PlatformSupportVersion> MinTestData =>
+		new () {
+			// Same kind, v1 < v2
+			{
+				new PlatformSupportVersion { Version = new Version (1, 0), Kind = SupportKind.Implicit },
+				new PlatformSupportVersion { Version = new Version (2, 0), Kind = SupportKind.Implicit },
+				new PlatformSupportVersion { Version = new Version (1, 0), Kind = SupportKind.Implicit }
+			},
+			// Same kind, v2 < v1
+			{
+				new PlatformSupportVersion { Version = new Version (2, 0), Kind = SupportKind.Implicit },
+				new PlatformSupportVersion { Version = new Version (1, 0), Kind = SupportKind.Implicit },
+				new PlatformSupportVersion { Version = new Version (1, 0), Kind = SupportKind.Implicit }
+			},
+			// Same kind, v1 == v2
+			{
+				new PlatformSupportVersion { Version = new Version (1, 0), Kind = SupportKind.Implicit },
+				new PlatformSupportVersion { Version = new Version (1, 0), Kind = SupportKind.Implicit },
+				new PlatformSupportVersion { Version = new Version (1, 0), Kind = SupportKind.Implicit }
+			},
+			// Different kind, v1.Kind > v2.Kind
+			{
+				new PlatformSupportVersion { Version = new Version (2, 0), Kind = SupportKind.Explicit },
+				new PlatformSupportVersion { Version = new Version (1, 0), Kind = SupportKind.Implicit },
+				new PlatformSupportVersion { Version = new Version (2, 0), Kind = SupportKind.Explicit }
+			},
+			// Different kind, v2.Kind > v1.Kind
+			{
+				new PlatformSupportVersion { Version = new Version (1, 0), Kind = SupportKind.Implicit },
+				new PlatformSupportVersion { Version = new Version (2, 0), Kind = SupportKind.Explicit },
+				new PlatformSupportVersion { Version = new Version (2, 0), Kind = SupportKind.Explicit }
+			},
+			// ExplicitDefault vs ImplicitDefault
+			{
+				PlatformSupportVersion.ExplicitDefault,
+				PlatformSupportVersion.ImplicitDefault,
+				PlatformSupportVersion.ExplicitDefault
+			},
+			// ExplicitDefault vs other Implicit
+			{
+				PlatformSupportVersion.ExplicitDefault,
+				new PlatformSupportVersion { Version = new Version (10, 0), Kind = SupportKind.Implicit },
+				PlatformSupportVersion.ExplicitDefault
+			},
+			// ImplicitDefault vs other Implicit
+			{
+				PlatformSupportVersion.ImplicitDefault,
+				new PlatformSupportVersion { Version = new Version (1, 0), Kind = SupportKind.Implicit },
+				PlatformSupportVersion.ImplicitDefault
+			},
+			// ExplicitDefault vs other Explicit
+			{
+				PlatformSupportVersion.ExplicitDefault,
+				new PlatformSupportVersion { Version = new Version (1, 0), Kind = SupportKind.Explicit },
+				PlatformSupportVersion.ExplicitDefault
+			},
+		};
+
+	[Theory]
+	[MemberData (nameof (MinTestData))]
+	public void MinTests (PlatformSupportVersion v1, PlatformSupportVersion v2, PlatformSupportVersion expected)
+	{
+		Assert.Equal (expected, PlatformSupportVersion.Min (v1, v2));
+		// Test commutativity
+		Assert.Equal (expected, PlatformSupportVersion.Min (v2, v1));
+	}
+}


### PR DESCRIPTION
When adding a platform to a symbol it might be the case that the addition has an implication for another platform. For example, when we add support for iOS we are adding support for Catalyst. This new struct keeps track of the reason why a version was added and will allow to choose always the Explicit version when two versions are compared.

This will later can be used with the Builder class to add Implicit versions for a platform and be able to calculate which version to use.