### PR TITLE
[msbuild] Fix PartialAppManifests from library projects with incremental builds.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -429,6 +429,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<CollectBundleResourcesDependsOn Condition="'$(IsBindingProject)' != 'true'">
 			$(CollectBundleResourcesDependsOn);
 			_UnpackLibraryResources;
+			_LoadUnpackedPartialAppManifests;
 			_CompileImageAssets;
 			_CompileInterfaceDefinitions;
 			_CompileSceneKitAssets;
@@ -1274,6 +1275,9 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 			<!-- Collada output caches -->
 			<_ColladaCache>$(DeviceSpecificIntermediateOutputPath)collada\_BundleResourceWithLogicalName.items</_ColladaCache>
+
+			<!-- Partial app manifest output cache -->
+			<_UnpackedPartialAppManifestCache>$(DeviceSpecificIntermediateOutputPath)partialappmanifest\_PartialAppManifests.items</_UnpackedPartialAppManifestCache>
 
 			<!-- processed items -->
 			<_ProcessedBundleResourcesPath Condition="'$(_ProcessedBundleResourcesPath)' == ''">$(DeviceSpecificIntermediateOutputPath)\_ProcessedBundleResourcesPath.items</_ProcessedBundleResourcesPath>
@@ -2176,7 +2180,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<Output TaskParameter="InterfaceDefinitions" ItemName="InterfaceDefinition" />
 			<Output TaskParameter="ColladaAssets" ItemName="Collada" />
 			<Output TaskParameter="CoreMLModels" ItemName="CoreMLModel" />
-			<Output TaskParameter="PartialAppManifests" ItemName="PartialAppManifest" />
+			<Output TaskParameter="PartialAppManifests" ItemName="_UnpackedPartialAppManifest" />
 			<Output TaskParameter="SceneKitAssets" ItemName="SceneKitAsset" />
 		</UnpackLibraryResources>
 
@@ -2188,9 +2192,23 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
 		</Touch>
 
+		<!-- Cached the partial app manifests items for incremental build support -->
+		<WriteItemsToFile Items="@(_UnpackedPartialAppManifest)" ItemName="_UnpackedPartialAppManifest" File="$(_UnpackedPartialAppManifestCache)" Overwrite="true" IncludeMetadata="true" />
+
 		<ItemGroup>
+			<FileWrites Include="$(_UnpackedPartialAppManifestCache)" />
 			<FileWrites Include="@(_UnpackedBundleResourceWithLogicalName)" />
 		</ItemGroup>
+	</Target>
+
+	<!-- Load the unpacked partial app manifests - this will run even if '_UnpackLibraryResources' didn't (due to incremental builds),
+	     because we need to always add the partial app manifests to the PartialAppManifest item group, even in incremental builds -->
+	<Target Name="_LoadUnpackedPartialAppManifests"
+		DependsOnTargets="_UnpackLibraryResources"
+		Condition="Exists('$(_UnpackedPartialAppManifestCache)')">
+		<ReadItemsFromFile File="$(_UnpackedPartialAppManifestCache)">
+			<Output TaskParameter="Items" ItemName="PartialAppManifest" />
+		</ReadItemsFromFile>
 	</Target>
 
 	<Target Name="_ParseBundlerArguments">

--- a/tests/dotnet/UnitTests/PartialAppManifestTest.cs
+++ b/tests/dotnet/UnitTests/PartialAppManifestTest.cs
@@ -24,5 +24,35 @@ namespace Xamarin.Tests {
 			Assert.AreEqual ("3.14", infoPlist.GetString ("CFBundleShortVersionString").Value, "CFBundleShortVersionString");
 			Assert.AreEqual ("SomeValue", infoPlist.GetString ("Something").Value, "Something");
 		}
+
+		[Test]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64")]
+		public void AppWithLibraryWithResourcesReference (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			var project = "AppWithLibraryWithResourcesReference";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
+			Clean (project_path);
+
+			var library = "LibraryWithResources";
+			var library_project_path = GetProjectPath (library, platform: platform);
+			Clean (library_project_path);
+
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties ["BundleOriginalResources"] = "true";
+
+			DotNet.AssertBuild (project_path, properties);
+
+			var infoPlistPath = GetInfoPListPath (platform, appPath);
+			var infoPlist = PDictionary.FromFile (infoPlistPath)!;
+			Assert.AreEqual ("Here I am", infoPlist.GetString ("LibraryWithResources").Value, "LibraryWithResources 1");
+
+			// build again, nothing should change
+			DotNet.AssertBuild (project_path, properties);
+
+			infoPlist = PDictionary.FromFile (infoPlistPath)!;
+			Assert.AreEqual ("Here I am", infoPlist.GetString ("LibraryWithResources").Value, "LibraryWithResources 2");
+		}
 	}
 }


### PR DESCRIPTION
1. Any PartialAppManifest items library projects are embedded into the library
   as a resource.
2. Such resources are extracted from the library when referenced in an
   executable project, and the PartialAppManifest item group (for the
   executable project) is populated with these items.
3. The extraction target ("_UnpackLibraryResources") supports incremental
   builds: it's only executed if the library didn't change since the last
   build.
4. We still need to populate the PartialAppManifest item group even if the
   extraction target didn't execute.

So implement support for storing the list of extracted PartialAppManifest
items to disk, and then reloading that list even if the extraction target
wasn't executed.