### PR TITLE
[apidiff] Make the api compat check use assembly paths without version numbers.

### DIFF
--- a/tools/apidiff/Makefile
+++ b/tools/apidiff/Makefile
@@ -206,6 +206,19 @@ unzip:: $$(COMPARISON_DLL_$(1))
 endef
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call UnzipNuGet,$(platform))))
 
+# Here we copy the dll to compare to a location that doesn't contain any version numbers
+define UpdatedDll
+UPDATED_DIR_$(1)=temp/updated/$(1)
+UPDATED_DLL_$(1)=$$(UPDATED_DIR_$(1))/Microsoft.$(1).dll
+$$(UPDATED_DLL_$(1)): $(DOTNET_DESTDIR)/$($(1)_NUGET_REF_NAME)/ref/$(DOTNET_TFM)/Microsoft.$(1).dll
+	$$(Q) rm -Rf "$$(dir $$@)"
+	$$(Q) mkdir -p "$$(dir $$@)"
+	$$(Q) $(CP) $$< $$@
+
+updated:: $$(UPDATED_DLL_$(1))
+endef
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call UpdatedDll,$(platform))))
+
 define GenerateComparisonReferenceXml
 $(APIDIFF_DIR)/references/comparison/Microsoft.$(1).xml: $$(COMPARISON_DLL_$(1)) $(MONO_API_INFO)
 	$$(Q) mkdir -p $$(dir $$@)
@@ -248,9 +261,9 @@ $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call ComputeAssemblyVersions,$(p
 
 define VerifyNoBreakingChanges
 $$(OUTPUT_DIR)/diff/Microsoft.$(platform).txt: export DOTNET=$(DOTNET)
-$$(OUTPUT_DIR)/diff/Microsoft.$(platform).txt: $$(COMPARISON_DLL_$(1)) $(DOTNET_DESTDIR)/$($(1)_NUGET_REF_NAME)/ref/$(DOTNET_TFM)/Microsoft.$(1).dll suppression-files/$(1).xml Makefile assembly-versions-$(1) install-apicompat.stamp
+$$(OUTPUT_DIR)/diff/Microsoft.$(platform).txt: $$(COMPARISON_DLL_$(1)) $$(UPDATED_DLL_$(1)) suppression-files/$(1).xml Makefile assembly-versions-$(1) install-apicompat.stamp
 	$$(Q) mkdir -p $$(dir $$@)
-	$$(QF_GEN) ./apicompat.sh verify "$(1)" "$$(COMPARISON_DLL_$(1))" "$(DOTNET_DESTDIR)/$($(1)_NUGET_REF_NAME)/ref/$(DOTNET_TFM)/Microsoft.$(1).dll" "$$(abspath $$@)" "$$(OUTPUT_DIR)" "$$(OUTPUT_DIR)/tmp/left-assembly-version-$(1).txt" "$$(OUTPUT_DIR)/tmp/right-assembly-version-$(1).txt" "$(NUGET_PRERELEASE_IDENTIFIER)"
+	$$(QF_GEN) ./apicompat.sh verify "$(1)" "$$(COMPARISON_DLL_$(1))" "$$(UPDATED_DLL_$(1))" "$$(abspath $$@)" "$$(OUTPUT_DIR)" "$$(OUTPUT_DIR)/tmp/left-assembly-version-$(1).txt" "$$(OUTPUT_DIR)/tmp/right-assembly-version-$(1).txt" "$(NUGET_PRERELEASE_IDENTIFIER)"
 
 verify-no-breaking-changes:: $$(OUTPUT_DIR)/diff/Microsoft.$(platform).txt
 endef
@@ -258,8 +271,8 @@ $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call VerifyNoBreakingChanges,$(p
 
 define RegenerateSuppressionFiles
 regenerate-suppression-files-$(1): export DOTNET=$(DOTNET)
-regenerate-suppression-files-$(1): $$(COMPARISON_DLL_$(1)) $(DOTNET_DESTDIR)/$($(1)_NUGET_REF_NAME)/ref/$(DOTNET_TFM)/Microsoft.$(1).dll Makefile assembly-versions-$(1) install-apicompat.stamp
-	$$(QF_GEN) ./apicompat.sh regenerate "$(1)" "$$(COMPARISON_DLL_$(1))" "$(DOTNET_DESTDIR)/$($(1)_NUGET_REF_NAME)/ref/$(DOTNET_TFM)/Microsoft.$(1).dll" "" "$$(OUTPUT_DIR)" "$$(OUTPUT_DIR)/tmp/left-assembly-version-$(1).txt" "$$(OUTPUT_DIR)/tmp/right-assembly-version-$(1).txt" "$(NUGET_PRERELEASE_IDENTIFIER)"
+regenerate-suppression-files-$(1): $$(COMPARISON_DLL_$(1)) $$(UPDATED_DLL_$(1)) Makefile assembly-versions-$(1) install-apicompat.stamp
+	$$(QF_GEN) ./apicompat.sh regenerate "$(1)" "$$(COMPARISON_DLL_$(1))" "$$(UPDATED_DLL_$(1))" "" "$$(OUTPUT_DIR)" "$$(OUTPUT_DIR)/tmp/left-assembly-version-$(1).txt" "$$(OUTPUT_DIR)/tmp/right-assembly-version-$(1).txt" "$(NUGET_PRERELEASE_IDENTIFIER)"
 
 regenerate-suppression-files:: regenerate-suppression-files-$(1)
 endef

--- a/tools/apidiff/suppression-files/MacCatalyst.xml
+++ b/tools/apidiff/suppression-files/MacCatalyst.xml
@@ -5,24 +5,24 @@
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:ObjCBindings.BindingTypeAttribute`1.get_LibraryName</Target>
     <Left>temp/comparison/MacCatalyst/Microsoft.MacCatalyst.dll</Left>
-    <Right>../../_build/Microsoft.MacCatalyst.Ref.net9.0_26.0/ref/net9.0/Microsoft.MacCatalyst.dll</Right>
+    <Right>temp/updated/MacCatalyst/Microsoft.MacCatalyst.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:ObjCBindings.BindingTypeAttribute`1.set_LibraryName(System.String)</Target>
     <Left>temp/comparison/MacCatalyst/Microsoft.MacCatalyst.dll</Left>
-    <Right>../../_build/Microsoft.MacCatalyst.Ref.net9.0_26.0/ref/net9.0/Microsoft.MacCatalyst.dll</Right>
+    <Right>temp/updated/MacCatalyst/Microsoft.MacCatalyst.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:ObjCBindings.FieldAttribute`1.get_LibraryName</Target>
     <Left>temp/comparison/MacCatalyst/Microsoft.MacCatalyst.dll</Left>
-    <Right>../../_build/Microsoft.MacCatalyst.Ref.net9.0_26.0/ref/net9.0/Microsoft.MacCatalyst.dll</Right>
+    <Right>temp/updated/MacCatalyst/Microsoft.MacCatalyst.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:ObjCBindings.FieldAttribute`1.set_LibraryName(System.String)</Target>
     <Left>temp/comparison/MacCatalyst/Microsoft.MacCatalyst.dll</Left>
-    <Right>../../_build/Microsoft.MacCatalyst.Ref.net9.0_26.0/ref/net9.0/Microsoft.MacCatalyst.dll</Right>
+    <Right>temp/updated/MacCatalyst/Microsoft.MacCatalyst.dll</Right>
   </Suppression>
 </Suppressions>

--- a/tools/apidiff/suppression-files/iOS.xml
+++ b/tools/apidiff/suppression-files/iOS.xml
@@ -5,24 +5,24 @@
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:ObjCBindings.BindingTypeAttribute`1.get_LibraryName</Target>
     <Left>temp/comparison/iOS/Microsoft.iOS.dll</Left>
-    <Right>../../_build/Microsoft.iOS.Ref.net9.0_26.0/ref/net9.0/Microsoft.iOS.dll</Right>
+    <Right>temp/updated/iOS/Microsoft.iOS.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:ObjCBindings.BindingTypeAttribute`1.set_LibraryName(System.String)</Target>
     <Left>temp/comparison/iOS/Microsoft.iOS.dll</Left>
-    <Right>../../_build/Microsoft.iOS.Ref.net9.0_26.0/ref/net9.0/Microsoft.iOS.dll</Right>
+    <Right>temp/updated/iOS/Microsoft.iOS.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:ObjCBindings.FieldAttribute`1.get_LibraryName</Target>
     <Left>temp/comparison/iOS/Microsoft.iOS.dll</Left>
-    <Right>../../_build/Microsoft.iOS.Ref.net9.0_26.0/ref/net9.0/Microsoft.iOS.dll</Right>
+    <Right>temp/updated/iOS/Microsoft.iOS.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:ObjCBindings.FieldAttribute`1.set_LibraryName(System.String)</Target>
     <Left>temp/comparison/iOS/Microsoft.iOS.dll</Left>
-    <Right>../../_build/Microsoft.iOS.Ref.net9.0_26.0/ref/net9.0/Microsoft.iOS.dll</Right>
+    <Right>temp/updated/iOS/Microsoft.iOS.dll</Right>
   </Suppression>
 </Suppressions>

--- a/tools/apidiff/suppression-files/macOS.xml
+++ b/tools/apidiff/suppression-files/macOS.xml
@@ -5,24 +5,24 @@
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:ObjCBindings.BindingTypeAttribute`1.get_LibraryName</Target>
     <Left>temp/comparison/macOS/Microsoft.macOS.dll</Left>
-    <Right>../../_build/Microsoft.macOS.Ref.net9.0_26.0/ref/net9.0/Microsoft.macOS.dll</Right>
+    <Right>temp/updated/macOS/Microsoft.macOS.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:ObjCBindings.BindingTypeAttribute`1.set_LibraryName(System.String)</Target>
     <Left>temp/comparison/macOS/Microsoft.macOS.dll</Left>
-    <Right>../../_build/Microsoft.macOS.Ref.net9.0_26.0/ref/net9.0/Microsoft.macOS.dll</Right>
+    <Right>temp/updated/macOS/Microsoft.macOS.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:ObjCBindings.FieldAttribute`1.get_LibraryName</Target>
     <Left>temp/comparison/macOS/Microsoft.macOS.dll</Left>
-    <Right>../../_build/Microsoft.macOS.Ref.net9.0_26.0/ref/net9.0/Microsoft.macOS.dll</Right>
+    <Right>temp/updated/macOS/Microsoft.macOS.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:ObjCBindings.FieldAttribute`1.set_LibraryName(System.String)</Target>
     <Left>temp/comparison/macOS/Microsoft.macOS.dll</Left>
-    <Right>../../_build/Microsoft.macOS.Ref.net9.0_26.0/ref/net9.0/Microsoft.macOS.dll</Right>
+    <Right>temp/updated/macOS/Microsoft.macOS.dll</Right>
   </Suppression>
 </Suppressions>

--- a/tools/apidiff/suppression-files/tvOS.xml
+++ b/tools/apidiff/suppression-files/tvOS.xml
@@ -5,24 +5,24 @@
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:ObjCBindings.BindingTypeAttribute`1.get_LibraryName</Target>
     <Left>temp/comparison/tvOS/Microsoft.tvOS.dll</Left>
-    <Right>../../_build/Microsoft.tvOS.Ref.net9.0_26.0/ref/net9.0/Microsoft.tvOS.dll</Right>
+    <Right>temp/updated/tvOS/Microsoft.tvOS.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:ObjCBindings.BindingTypeAttribute`1.set_LibraryName(System.String)</Target>
     <Left>temp/comparison/tvOS/Microsoft.tvOS.dll</Left>
-    <Right>../../_build/Microsoft.tvOS.Ref.net9.0_26.0/ref/net9.0/Microsoft.tvOS.dll</Right>
+    <Right>temp/updated/tvOS/Microsoft.tvOS.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:ObjCBindings.FieldAttribute`1.get_LibraryName</Target>
     <Left>temp/comparison/tvOS/Microsoft.tvOS.dll</Left>
-    <Right>../../_build/Microsoft.tvOS.Ref.net9.0_26.0/ref/net9.0/Microsoft.tvOS.dll</Right>
+    <Right>temp/updated/tvOS/Microsoft.tvOS.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:ObjCBindings.FieldAttribute`1.set_LibraryName(System.String)</Target>
     <Left>temp/comparison/tvOS/Microsoft.tvOS.dll</Left>
-    <Right>../../_build/Microsoft.tvOS.Ref.net9.0_26.0/ref/net9.0/Microsoft.tvOS.dll</Right>
+    <Right>temp/updated/tvOS/Microsoft.tvOS.dll</Right>
   </Suppression>
 </Suppressions>


### PR DESCRIPTION
This way we don't have to update the suppression files for every new OS version we bind.