### PR TITLE
[LocalAuthentication] Fix nullability for LAContext.CanEvaluatePolicy. Fixes #12981.

### DIFF
--- a/src/localauthentication.cs
+++ b/src/localauthentication.cs
@@ -50,7 +50,7 @@ namespace LocalAuthentication {
 		///         <returns>To be added.</returns>
 		///         <remarks>To be added.</remarks>
 		[Export ("canEvaluatePolicy:error:")]
-		bool CanEvaluatePolicy (LAPolicy policy, out NSError error);
+		bool CanEvaluatePolicy (LAPolicy policy, [NullAllowed] out NSError error);
 
 		/// <param name="policy">To be added.</param>
 		///         <param name="localizedReason">To be added.</param>


### PR DESCRIPTION
Fixes https://github.com/dotnet/macios/issues/12981.