### PR TITLE
[UIKit] Add a weakly typed UIMenu.Identifier property and UIMenu.Create overload. Fixes #14177.

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -11364,9 +11364,11 @@ namespace UIKit {
 	[DisableDefaultCtor]
 	interface UIMenu {
 
-		[BindAs (typeof (UIMenuIdentifier))]
+		[Wrap ("UIMenuIdentifierExtensions.GetValue (WeakIdentifier)", IsVirtual = true)]
+		UIMenuIdentifier Identifier { get; }
+
 		[Export ("identifier")]
-		NSString Identifier { get; }
+		NSString WeakIdentifier { get; }
 
 		[Export ("options")]
 		UIMenuOptions Options { get; }
@@ -11399,8 +11401,12 @@ namespace UIKit {
 		UIMenu Create (string title, UIMenuElement [] children);
 
 		[Static]
+		[Wrap ("Create (title, image, identifier.GetConstant (), options, children)")]
+		UIMenu Create (string title, [NullAllowed] UIImage image, UIMenuIdentifier identifier, UIMenuOptions options, UIMenuElement [] children);
+
+		[Static]
 		[Export ("menuWithTitle:image:identifier:options:children:")]
-		UIMenu Create (string title, [NullAllowed] UIImage image, [NullAllowed][BindAs (typeof (UIMenuIdentifier))] NSString identifier, UIMenuOptions options, UIMenuElement [] children);
+		UIMenu Create (string title, [NullAllowed] UIImage image, [NullAllowed] NSString identifier, UIMenuOptions options, UIMenuElement [] children);
 
 		[Export ("menuByReplacingChildren:")]
 		UIMenu GetMenuByReplacingChildren (UIMenuElement [] newChildren);

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -17208,6 +17208,7 @@ M:UIKit.UILargeContentViewerInteractionDelegate_Extensions.GetItem(UIKit.IUILarg
 M:UIKit.UILargeContentViewerInteractionDelegate_Extensions.GetViewController(UIKit.IUILargeContentViewerInteractionDelegate,UIKit.UILargeContentViewerInteraction)
 M:UIKit.UILayoutGuide.Dispose(System.Boolean)
 M:UIKit.UIListContentView.UIListContentViewAppearance.#ctor(System.IntPtr)
+M:UIKit.UIMenu.Create(System.String,UIKit.UIImage,UIKit.UIMenuIdentifier,UIKit.UIMenuOptions,UIKit.UIMenuElement[])
 M:UIKit.UIMenuLeaf_Extensions.GetSelectedImage(UIKit.IUIMenuLeaf)
 M:UIKit.UIMenuLeaf_Extensions.SetSelectedImage(UIKit.IUIMenuLeaf,UIKit.UIImage)
 M:UIKit.UINavigationBar.Dispose(System.Boolean)
@@ -24124,6 +24125,7 @@ P:UIKit.UILargeContentViewerInteraction.Delegate
 P:UIKit.UILargeContentViewerInteraction.Enabled
 P:UIKit.UIListContentView.ListContentConfiguration
 P:UIKit.UIListSeparatorConfiguration.AutomaticInsets
+P:UIKit.UIMenu.Identifier
 P:UIKit.UIMenu.SelectedElements
 P:UIKit.UIMenuController.MenuVisible
 P:UIKit.UINavigationBar.UINavigationBarAppearance.CompactAppearance


### PR DESCRIPTION
Fixes https://github.com/dotnet/macios/issues/14177.