### PR TITLE
[msbuild] Improve detection of resources that would end up outside the app bundle.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CollectBundleResources.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CollectBundleResources.cs
@@ -227,8 +227,9 @@ namespace Xamarin.MacDev.Tasks {
 				return false;
 			}
 
-			if (logicalName.StartsWith (".." + Path.DirectorySeparatorChar, StringComparison.Ordinal)) {
-				task.Log.LogError (null, null, null, item.ItemSpec, 0, 0, 0, 0, MSBStrings.E0100, logicalName);
+			// Always check for both windows and non-windows style path separators, because we can get both on either platform.
+			if (logicalName.StartsWith ("..\\", StringComparison.Ordinal) || logicalName.StartsWith ("../", StringComparison.Ordinal)) {
+				task.Log.LogWarning (null, null, null, item.ItemSpec, 0, 0, 0, 0, MSBStrings.E0100, logicalName);
 				return false;
 			}
 

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CollectBundleResourcesTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CollectBundleResourcesTaskTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using NUnit.Framework;
+
+using Xamarin.Utils;
+
+namespace Xamarin.MacDev.Tasks {
+	[TestFixture]
+	public class CollectBundleResourcesTaskTests : TestBase {
+		[Test]
+		public void LogicalNameOutsideAppBundle ()
+		{
+			var currentDirectory = Environment.CurrentDirectory;
+			try {
+				var tmpdir = Cache.CreateTemporaryDirectory ();
+				var task = CreateTask<CollectBundleResources> ();
+				var item = new TaskItem ("image.png");
+				var projDir = Path.Combine (tmpdir, "B");
+				Directory.CreateDirectory (projDir);
+				Environment.CurrentDirectory = projDir;
+				File.WriteAllText (Path.Combine (projDir, item.ItemSpec), "image!");
+				item.SetMetadata ("LocalDefiningProjectFullPath", Path.Combine (tmpdir, "A", "SDK.csproj"));
+				item.SetMetadata ("LocalMSBuildProjectFullPath", Path.Combine (projDir, "Project.csproj"));
+				task.BundleResources = [item];
+				var rv = task.Execute ();
+
+				Assert.That (Engine.Logger.ErrorEvents.Count, Is.EqualTo (0), "Errors");
+
+				Assert.That (Engine.Logger.WarningsEvents.Count, Is.EqualTo (1), "Warnings");
+				Assert.That (Engine.Logger.WarningsEvents [0].Message, Is.EqualTo ("The path '../B/image.png' would result in a file outside of the app bundle and cannot be used."), "Warning Message");
+
+				Assert.That (rv, Is.True, "Execute");
+			} finally {
+				Environment.CurrentDirectory = currentDirectory;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Due to #23898, the build may end up with resources whose LogicalName property
(which is a path relative to the app bundle where the resource in question
would be located inside the app bundle) points to a location outside the app
bundle.

On macOS we correctly detect this and report an error:

> The path '../../../../../../../../../Users/rolf/test/bugs/issue2576178/RazorClassLibrary/wwwroot/background.png' would result in a file outside of the app bundle and cannot be used.

But no such thing was reported on Windows.

Additionally, this become a problem in .NET 10 on Windows because we now
process resources in library projects on Windows without a connection to a
Mac, while previously a connection to a Mac would be required to run into this
problem.

So:

* Fix the check to work on Windows as well.
* Also make it a warning (and just ignore the file in question) instead of an
  error, to keep the "works-by-luck" behavior of .NET 9.

This works around #23898 while we implement an actual fix.