### PR TITLE
[release/10.0.1xx-rc.2] [dotnet] Adjust MSI version to make incorrect MSI version calculation produce a higher MSI version.

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -207,7 +207,7 @@ endef
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call WorkloadTargets,$(platform),$(shell echo $(platform) | tr A-Z a-z),$($(platform)_NUGET_VERSION_NO_METADATA),$(shell echo $(platform) | tr a-z A-Z),$(NET8_$(platform)_NUGET_VERSION_NO_METADATA))))
 
 # Always use the commit distance as the third number in the VS component version, as it should always increase across all branches.
-$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(platform)_MSI_VERSION:=$($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_OS_VERSION).$($(shell echo $(platform) | tr a-z A-Z)_NUGET_COMMIT_DISTANCE).0))
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(platform)_MSI_VERSION:=$($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_OS_VERSION).$(shell echo $($(shell echo $(platform) | tr a-z A-Z)_NUGET_COMMIT_DISTANCE) + 258 | bc).0))
 
 include $(TOP)/scripts/generate-vs-workload/fragment.mk
 $(DOTNET_NUPKG_DIR)/vs-workload.props: Makefile $(GENERATE_VS_WORKLOAD)


### PR DESCRIPTION
The task to generate an actual MSI version from our version:

https://github.com/dotnet/arcade/blob/db534d10fc5ab858568b2f27d9b1383099a8019c/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateMsiVersion.cs#L28C18-L28C36

produces incorrect results.

1.  It has code to handle versions with commit counts, but this code path isn't
    used (technically because the task isn't passed the BuildNumber parameter,
    but why that happens I don't know).

2.  The code that is used instead, assigns 4 bits to the patch number:

    https://github.com/dotnet/arcade/blob/db534d10fc5ab858568b2f27d9b1383099a8019c/src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateMsiVersion.cs#L25

    which is *by far* not enough to handle our patch number (which is
    effectively the commit count) - currently ~10980.

3.  The task has no overflow checks, so the huge patch number overflows not
    only the minor version, but also the major version.

4.  The magic number in this pull request makes the overflow overflow just
    exactly so that it overflows just enough, but doesn't overflow too much.
    For a few commits at least, until the commit count changes enough to make
    math not work anymore.

This temporarily fixes a problem where inserting the macOS MSI into Visual
Studio fails because it's effectively a downgrade.

As a curiosity this only happens for macOS, because macOS bumps its major
version from 15 to 26, while all the other platforms bump their major version
from 18 to 26, and thus the version of the currently inserted MSI in VS for
these platforms is _lower_, so the new packages have a higher version number
(and no downgrade will occur).