### PR TITLE
[bgen] Fix APIs with both [Protected] and [Internal]. Fixes #6889.

### DIFF
--- a/src/bgen/Models/MemberInformation.cs
+++ b/src/bgen/Models/MemberInformation.cs
@@ -221,11 +221,15 @@ public class MemberInformation {
 		if (is_interface_impl || is_extension_method)
 			return "public";
 
-		var mod = is_protected ? "protected" : null;
-		mod += is_internal ? "internal" : null;
-		if (string.IsNullOrEmpty (mod))
-			mod = "public";
-		return mod;
+		if (is_protected && is_internal) {
+			return "protected internal";
+		} else if (is_protected) {
+			return "protected";
+		} else if (is_internal) {
+			return "internal";
+		} else {
+			return "public";
+		}
 	}
 
 	public string GetModifiers ()

--- a/tests/generator/BGenTests.cs
+++ b/tests/generator/BGenTests.cs
@@ -1620,5 +1620,15 @@ namespace GeneratorTests {
 					Assert.True (passesOwnsEqualsTrue (method), method.Name);
 			});
 		}
+
+		[Test]
+		[TestCase (Profile.iOS)]
+		public void BothProtectedAndInternal (Profile profile)
+		{
+			// https://github.com/dotnet/macios/issues/6889
+			Configuration.IgnoreIfIgnoredPlatform (profile.AsPlatform ());
+			var bgen = BuildFile (profile, "tests/both-protected-and-internal.cs");
+			bgen.AssertNoWarnings ();
+		}
 	}
 }

--- a/tests/generator/tests/both-protected-and-internal.cs
+++ b/tests/generator/tests/both-protected-and-internal.cs
@@ -1,0 +1,12 @@
+using Foundation;
+
+namespace iosbinding {
+
+	[BaseType (typeof (NSObject))]
+	interface SomeType {
+		[Export("method")]
+		[Internal]
+		[Protected]
+		void Method ();
+	}
+}


### PR DESCRIPTION
The 'protected' and 'internal' keywords weren't separated by a space, and
sadly the C# compiler doesn't understand 'protectedinternal', so make sure the
keywords are spaced out correctly.

Fixes: https://github.com/dotnet/macios/issues/6889