### PR TITLE
[net10.0] Fix setting the MSI version.

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -207,7 +207,7 @@ endef
 $(foreach platform,$(DOTNET_PLATFORMS),$(eval $(call WorkloadTargets,$(platform),$(shell echo $(platform) | tr A-Z a-z),$($(platform)_NUGET_VERSION_NO_METADATA),$(shell echo $(platform) | tr a-z A-Z),$(NET8_$(platform)_NUGET_VERSION_NO_METADATA))))
 
 # Always use the commit distance as the third number in the VS component version, as it should always increase across all branches.
-$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(platform)_MSI_VERSION:=$($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_OS_VERSION).$($(shell echo $(platform) | tr a-z A-Z)_NUGET_COMMIT_DISTANCE).0))
+$(foreach platform,$(DOTNET_PLATFORMS),$(eval $(platform)_MSI_VERSION:=$($(shell echo $(platform) | tr '[:lower:]' '[:upper:]')_NUGET_OS_VERSION).$($(shell echo $(platform) | tr a-z A-Z)_NUGET_COMMIT_DISTANCE)))
 
 include $(TOP)/scripts/generate-vs-workload/fragment.mk
 $(DOTNET_NUPKG_DIR)/vs-workload.props: Makefile $(GENERATE_VS_WORKLOAD)

--- a/scripts/generate-vs-workload/generate-vs-workload.cs
+++ b/scripts/generate-vs-workload/generate-vs-workload.cs
@@ -83,7 +83,7 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 	foreach (var entry in platforms) {
 		var platform = entry.Item1;
 		var version = entry.Item2;
-		writer.WriteLine ($"    <WorkloadPackages Include=\"$(NuGetPackagePath)\\Microsoft.NET.Sdk.{platform}.Manifest*.nupkg\" Version=\"{version}\" SupportsMachineArch=\"true\" />");
+		writer.WriteLine ($"    <WorkloadPackages Include=\"$(NuGetPackagePath)\\Microsoft.NET.Sdk.{platform}.Manifest*.nupkg\" Version=\"{version}.0\" MsiVersion=\"{version}\" SupportsMachineArch=\"true\" />");
 	}
 	writer.WriteLine ("  </ItemGroup>");
 	writer.WriteLine ("</Project>");


### PR DESCRIPTION
The code is trying to set the MSI version of any MSI packages we create, but
it doesn't quite work, because we need to set the 'MsiVersion' metadata to do
so:

https://dev.azure.com/devdiv/DevDiv/_git/Xamarin.yaml-templates/commit/1f881d8f9611b7350e2a5a0ac4211934815c291c?tab=details

So do that (but leave the existing 'version' metadata as-is just in case it's
important for some reason).