### PR TITLE
[UIKit] Protect RegisterForTraitChanges observers from premature GC toggle-ref collection

### DIFF
--- a/src/UIKit/UITraitChangeObservable.cs
+++ b/src/UIKit/UITraitChangeObservable.cs
@@ -26,6 +26,26 @@ namespace UIKit {
 			return Class.FromTypes (traits);
 		}
 
+		// Register the observing object with the toggle-ref GC bridge before we hand a
+		// reference to it to native code. Without this, the managed peer's toggle-ref status
+		// defaults to whatever xamarin_gc_toggleref_callback infers from -retainCount, which
+		// only reflects normal ObjC retains: it can't see that _UITraitChangeRegistry now also
+		// holds a reference to this object internally (observer registries are conventionally
+		// non-retaining, to avoid retain cycles with their observers). If -retainCount is 1 at
+		// the next GC, the bridge downgrades the peer to a weak GC handle and it can be
+		// collected while _UITraitChangeRegistry still references it, corrupting the shared
+		// registry (a crash then tends to surface later, in unrelated code that next touches
+		// the registry, rather than here). MarkDirty is idempotent and mirrors the pattern
+		// already used by UIControl.AddTarget, UIGestureRecognizer, and
+		// NSNotificationCenter.AddObserver for the same reason.
+		private static void MarkDirtyForTraitRegistration (IUITraitChangeObservable observable)
+		{
+			// NSObject.MarkDirty() is 'protected'; the (bool) overload is 'internal' and can be
+			// called from anywhere in this assembly, which is what we need from a static method
+			// on an unrelated interface.
+			(observable as NSObject)?.MarkDirty (false);
+		}
+
 		/// <summary>
 		/// Registers a callback handler that will be executed when one of the specified traits changes.
 		/// </summary>
@@ -39,6 +59,7 @@ namespace UIKit {
 
 		internal static IUITraitChangeRegistration _RegisterForTraitChanges (IUITraitChangeObservable This, Type [] traits, Action<IUITraitEnvironment, UITraitCollection> handler)
 		{
+			MarkDirtyForTraitRegistration (This);
 			return _RegisterForTraitChanges (This, ToClasses (traits), handler);
 		}
 
@@ -56,6 +77,7 @@ namespace UIKit {
 		internal static IUITraitChangeRegistration _RegisterForTraitChanges (IUITraitChangeObservable This, Action<IUITraitEnvironment, UITraitCollection> handler, params Type [] traits)
 		{
 			// Add an override with 'params', unfortunately this means reordering the parameters.
+			MarkDirtyForTraitRegistration (This);
 			return _RegisterForTraitChanges (This, ToClasses (traits), handler);
 		}
 
@@ -74,6 +96,7 @@ namespace UIKit {
 		internal static IUITraitChangeRegistration _RegisterForTraitChanges<T> (IUITraitChangeObservable This, Action<IUITraitEnvironment, UITraitCollection> handler)
 			where T : IUITraitDefinition
 		{
+			MarkDirtyForTraitRegistration (This);
 			return _RegisterForTraitChanges (This, ToClasses (typeof (T)), handler);
 		}
 
@@ -95,6 +118,7 @@ namespace UIKit {
 			where T1 : IUITraitDefinition
 			where T2 : IUITraitDefinition
 		{
+			MarkDirtyForTraitRegistration (This);
 			return _RegisterForTraitChanges (This, ToClasses (typeof (T1), typeof (T2)), handler);
 		}
 
@@ -119,6 +143,7 @@ namespace UIKit {
 			where T2 : IUITraitDefinition
 			where T3 : IUITraitDefinition
 		{
+			MarkDirtyForTraitRegistration (This);
 			return _RegisterForTraitChanges (This, ToClasses (typeof (T1), typeof (T2), typeof (T3)), handler);
 		}
 
@@ -146,6 +171,7 @@ namespace UIKit {
 			where T3 : IUITraitDefinition
 			where T4 : IUITraitDefinition
 		{
+			MarkDirtyForTraitRegistration (This);
 			return _RegisterForTraitChanges (This, ToClasses (typeof (T1), typeof (T2), typeof (T3), typeof (T4)), handler);
 		}
 
@@ -163,6 +189,10 @@ namespace UIKit {
 
 		internal static IUITraitChangeRegistration _RegisterForTraitChanges (IUITraitChangeObservable This, Type [] traits, NSObject target, Selector action)
 		{
+			MarkDirtyForTraitRegistration (This);
+			// 'target' receives the callback via -action:, so it needs the same protection as
+			// 'This' even though it isn't the object being observed.
+			target.MarkDirty (false);
 			return _RegisterForTraitChanges (This, ToClasses (traits), target, action);
 		}
 
@@ -179,6 +209,7 @@ namespace UIKit {
 
 		internal static IUITraitChangeRegistration _RegisterForTraitChanges (IUITraitChangeObservable This, Type [] traits, Selector action)
 		{
+			MarkDirtyForTraitRegistration (This);
 			return _RegisterForTraitChanges (This, ToClasses (traits), action);
 		}
 


### PR DESCRIPTION
## Summary

`RegisterForTraitChanges` (all overloads, including the `NSObject target`/`Selector` variant) hands a reference to the observing object to UIKitCore's private `_UITraitChangeRegistry`, but never calls `MarkDirty()` to register that object with the Mono toggle-ref GC bridge.

Every other API in this codebase that hands a reference to native code for a later callback already does this: `UIControl.AddTarget`, `UIGestureRecognizer`, `NSNotificationCenter.AddObserver`, `UIBarButtonItem`, `UIPickerView`. `UITraitChangeObservable.cs` appears to have been missed — plausibly because the interface was only fully wired up via default-interface-member inlining relatively recently (#20265, following #19410).

## Why this matters

Without `MarkDirty()`, `xamarin_gc_toggleref_callback` (`runtime/runtime.m`) falls back to inferring liveness purely from `-retainCount`, which only reflects normal ObjC retains. Observer registries are conventionally *non-retaining* (to avoid retain cycles with their observers), so `_UITraitChangeRegistry` holding a reference to an object doesn't show up in that object's `retainCount`. If `retainCount == 1` at the next GC, the bridge downgrades the managed peer to a weak GC handle, and it can be collected while `_UITraitChangeRegistry` still holds a now-dangling pointer to it — corrupting a registry that many unrelated UIKit code paths touch afterwards.

We've observed this manifest as `SIGSEGV`/`EXC_BAD_ACCESS` crashes inside `_UITraitChangeRegistry` on iOS 26 across a wide variety of unrelated call sites over many months in production (a .NET MAUI POS app): `UICollectionView` teardown, gesture-node updates, `ScrollEdgeEffectView`, and `UITextField` construction — none of which call `RegisterForTraitChanges` themselves. That's consistent with heap corruption surfacing far from its actual cause rather than N independent bugs. A related, narrower regression report on this MAUI version line: #34142 (auto-closed for lack of a minimal repro, not because it was fixed).

## Change

Adds a `MarkDirtyForTraitRegistration` helper and calls it at each hand-written fan-in point before the `Class[]`-based native registration call (for the `NSObject target` overload, `target` is also marked dirty, since it's the object native code calls back into via `-action:`). `MarkDirty(bool)` is idempotent (`NSObject2.cs`: returns early if `IsRegisteredToggleRef` is already set), so this is safe to call redundantly across the overload fan-in.

## Caveat — please have CI validate this

I could not build/test this locally: this checkout (tried both `main` and `release/10.0.1xx`) fails to resolve the pinned internal preview SDK/runtime packages (`10.0.400-preview.0.26381.105`, `Microsoft.NETCore.App.Runtime.Mono.*` `10.0.3`) from public NuGet feeds, which appears to be expected for an external contributor building outside Microsoft's CI. Opening as a **draft** so CI (which does have the right feed access) can validate compilation, and so a maintainer familiar with the toggle-ref bridge can sanity-check the fix location before I'd ask for a real review.

I don't have a minimal, isolated repro project yet (the crash requires sustained GC pressure + trait registration under real device conditions) — happy to build one if that would help move this forward, or if a maintainer can confirm/deny the hypothesis faster with instrumentation on their end.

## Test plan

- [ ] CI build succeeds
- [ ] Maintainer confirms `RegisterForTraitChanges` is the right place for this vs. a deeper fix in the trait-change registry's native binding
- [ ] If confirmed, a minimal repro project can be built to verify the crash no longer reproduces with this change