### PR TITLE
[devops] Vendor Maestro changelog tool

### DIFF
--- a/.github/workflows/maestro-changelog.yml
+++ b/.github/workflows/maestro-changelog.yml
@@ -45,7 +45,9 @@ jobs:
             issue_number: context.issue.number
           }).then ((comments) =>
           {
-            const changelogComment = comments.find(comment => comment.body.includes (".net ChangeLog for") && comment.user.login == 'github-actions[bot]')
+            const changelogComment = comments.find(comment =>
+              (comment.body.includes (".NET Changelog for") || comment.body.includes (".net ChangeLog for")) &&
+              comment.user.login == 'github-actions[bot]')
             if (changelogComment)
               commentId = changelogComment.id
           })

--- a/.github/workflows/maestro-changelog.yml
+++ b/.github/workflows/maestro-changelog.yml
@@ -22,7 +22,7 @@ jobs:
         persist-credentials: false
     - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
-        dotnet-version: '9'
+        global-json-file: ./global.json
 
     - name: 'Compute changelog'
       run: |

--- a/.github/workflows/maestro-changelog.yml
+++ b/.github/workflows/maestro-changelog.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
         dotnet-version: '9'
@@ -25,7 +27,7 @@ jobs:
     - name: 'Compute changelog'
       run: |
         set -exo pipefail
-        dotnet run --project scripts/changelog/changelog.csproj -- https://github.com/$GITHUB_REPOSITORY/pull/${GITHUB_REF_NAME/\/*/} > /tmp/changelog.txt 2>&1
+        dotnet run --project scripts/changelog/changelog.csproj --verbosity quiet -- https://github.com/$GITHUB_REPOSITORY/pull/${GITHUB_REF_NAME/\/*/} /tmp/changelog.txt
 
     - name: 'Add changelog'
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/maestro-changelog.yml
+++ b/.github/workflows/maestro-changelog.yml
@@ -17,6 +17,7 @@ jobs:
     if: github.event.pull_request.user.login == 'dotnet-maestro[bot]'
 
     steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
         dotnet-version: '9'
@@ -24,10 +25,7 @@ jobs:
     - name: 'Compute changelog'
       run: |
         set -exo pipefail
-        git clone https://github.com/spouliot/dotnet-tools
-        cd dotnet-tools/changelog
-        dotnet build
-        ./bin/Debug/net9.0/changelog https://github.com/$GITHUB_REPOSITORY/pull/${GITHUB_REF_NAME/\/*/} > /tmp/changelog.txt 2>&1
+        dotnet run --project scripts/changelog/changelog.csproj -- https://github.com/$GITHUB_REPOSITORY/pull/${GITHUB_REF_NAME/\/*/} > /tmp/changelog.txt 2>&1
 
     - name: 'Add changelog'
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/scripts/changelog/Program.cs
+++ b/scripts/changelog/Program.cs
@@ -126,7 +126,7 @@ namespace changelog {
 							if (string.IsNullOrEmpty (old_sha)) {
 								writer.WriteLine ($"* {uri} [{new_sha [0..7]}]({uri}/commits/{new_sha}) (new dependency)");
 							} else {
-								var diff_url = $"{uri}/compare/{old_sha}..{new_sha}.diff";
+								var diff_url = $"{uri}/compare/{old_sha}...{new_sha}.diff";
 								writer.WriteLine ($"* {uri} [{old_sha [0..7]}...{new_sha [0..7]}]({uri}/compare/{old_sha}...{new_sha})");
 								// skip duplicates (if same revisions are used)
 								if (!list.Contains (diff_url))

--- a/scripts/changelog/Program.cs
+++ b/scripts/changelog/Program.cs
@@ -19,32 +19,44 @@ namespace changelog {
 
 		static async Task Main (string [] args)
 		{
+			if (args.Length < 2) {
+				Console.Error.WriteLine ("Usage: changelog <pull-request-url-or-diff-file> <output-file> [repo-filter ...]");
+				Environment.ExitCode = 1;
+				return;
+			}
+
 			var pr = args [0];
-			for (int i = 1; i < args.Length; i++)
+			var outputFile = args [1];
+			for (int i = 2; i < args.Length; i++)
 				filters.Add (args [i]);
 
-			Console.WriteLine ($"# .net ChangeLog for {pr}");
-			if (pr.StartsWith ("https://github.com/", StringComparison.Ordinal)) {
-				pr = pr.Replace ("https://github.com/", "https://patch-diff.githubusercontent.com/raw/") + ".diff";
+			using (var writer = new StreamWriter (outputFile)) {
+				writer.WriteLine ($"# .net ChangeLog for {pr}");
+				if (pr.StartsWith ("https://github.com/", StringComparison.Ordinal)) {
+					pr = pr.Replace ("https://github.com/", "https://patch-diff.githubusercontent.com/raw/") + ".diff";
+				}
+				list.Add (pr);
+				await Process (writer);
+				writer.WriteLine ("Generated using https://github.com/spouliot/dotnet-tools/tree/master/changelog");
 			}
-			list.Add (pr);
-			await Process ();
-			Console.WriteLine ("Generated using https://github.com/spouliot/dotnet-tools/tree/master/changelog");
 		}
 
-		static async Task Process ()
+		static async Task Process (TextWriter writer)
 		{
 			using var client = new HttpClient ();
 			for (int i = 0; i < Math.Min (list.Count, level); i++) {
-				Console.WriteLine ($"## Level {i + 1}");
+				writer.WriteLine ($"## Level {i + 1}");
 				var url = list [i];
 				if (url.StartsWith ("https://", StringComparison.Ordinal)) {
-					var result = await client.GetAsync (list [i]);
-					ProcessDiff (result.Content.ReadAsStream ());
+					using var result = await client.GetAsync (list [i]);
+					result.EnsureSuccessStatusCode ();
+					using var stream = await result.Content.ReadAsStreamAsync ();
+					ProcessDiff (stream, writer);
 				} else {
-					ProcessDiff (new FileStream (url, FileMode.Open, FileAccess.Read));
+					using var stream = new FileStream (url, FileMode.Open, FileAccess.Read);
+					ProcessDiff (stream, writer);
 				}
-				Console.WriteLine ();
+				writer.WriteLine ();
 			}
 		}
 
@@ -60,12 +72,12 @@ namespace changelog {
 			return false;
 		}
 
-		static void ProcessDiff (Stream s)
+		static void ProcessDiff (Stream s, TextWriter writer)
 		{
 			bool processing = false;
-			var uri = String.Empty;
-			var old_sha = String.Empty;
-			var new_sha = String.Empty;
+			var uri = "";
+			var old_sha = "";
+			var new_sha = "";
 			using (var sr = new StreamReader (s)) {
 				while (!sr.EndOfStream) {
 					var line = sr.ReadLine ();
@@ -96,11 +108,11 @@ namespace changelog {
 							// skip duplicates (if same revisions are used)
 							if (!list.Contains (diff_url)) {
 								if (string.IsNullOrEmpty (old_sha)) {
-									Console.WriteLine ($"* {uri} [{new_sha [0..7]}]({uri}/commits/{new_sha}) (new dependency)");
+									writer.WriteLine ($"* {uri} [{new_sha [0..7]}]({uri}/commits/{new_sha}) (new dependency)");
 								} else if (string.IsNullOrEmpty (new_sha)) {
-									Console.WriteLine ($"* {uri} [{old_sha [0..7]}]({uri}/commits/{old_sha}) (removed dependency)");
+									writer.WriteLine ($"* {uri} [{old_sha [0..7]}]({uri}/commits/{old_sha}) (removed dependency)");
 								} else {
-									Console.WriteLine ($"* {uri} [{old_sha [0..7]}...{new_sha [0..7]}]({uri}/compare/{old_sha}...{new_sha})");
+									writer.WriteLine ($"* {uri} [{old_sha [0..7]}...{new_sha [0..7]}]({uri}/compare/{old_sha}...{new_sha})");
 								}
 								list.Add (diff_url);
 							}

--- a/scripts/changelog/Program.cs
+++ b/scripts/changelog/Program.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace changelog
+{
+
+	class Program
+	{
+		static List<string> list = new ();
+		static List<string> filters = new ();
+
+		// current repo (1) points to dotnet/installer (2)
+		// getting into other repos (pointed by dotnet/installer) can show different results
+		static int level = 2;
+
+		static async Task Main (string[] args)
+		{
+			var pr = args [0];
+			for (int i = 1; i < args.Length; i++)
+				filters.Add (args [i]);
+
+			Console.WriteLine ($"# .net ChangeLog for {pr}");
+			if (pr.StartsWith ("https://github.com/", StringComparison.Ordinal)) {
+				pr = pr.Replace ("https://github.com/", "https://patch-diff.githubusercontent.com/raw/") + ".diff";
+			}
+			list.Add (pr);
+			await Process ();
+			Console.WriteLine ("Generated using https://github.com/spouliot/dotnet-tools/tree/master/changelog");
+		}
+
+		static async Task Process ()
+		{
+			using var client = new HttpClient ();
+			for (int i = 0; i < Math.Min (list.Count, level); i++) {
+				Console.WriteLine ($"## Level {i + 1}");
+				var url = list [i];
+				if (url.StartsWith ("https://", StringComparison.Ordinal)) {
+					var result = await client.GetAsync (list [i]);
+					ProcessDiff (result.Content.ReadAsStream ());
+				} else {
+					ProcessDiff (new FileStream (url, FileMode.Open, FileAccess.Read));
+				}
+				Console.WriteLine ();
+			}
+		}
+
+		static bool Include (string uri)
+		{
+			if (filters.Count == 0)
+				return true;
+
+			foreach (var filter in filters) {
+				if (uri.EndsWith (filter, StringComparison.Ordinal))
+					return true;
+			}
+			return false;
+		}
+
+		static void ProcessDiff (Stream s)
+		{
+			bool processing = false;
+			var uri = String.Empty;
+			var old_sha = String.Empty;
+			var new_sha = String.Empty;
+			using (var sr = new StreamReader (s)) {
+				while (!sr.EndOfStream) {
+					var line = sr.ReadLine ();
+					if (line is null)
+						break;
+					if (line == "diff --git a/eng/Version.Details.xml b/eng/Version.Details.xml") {
+						processing = true;
+						continue;
+					}
+					if (processing) {
+						if (line.StartsWith ("diff --git ", StringComparison.Ordinal))
+							return;
+						if (line.Length < 1)
+							continue;
+						bool removal = (line [0] == '-');
+						bool addition = (line [0] == '+');
+						var tl = (removal || addition) ? line [1..] : line;
+						tl = tl.Trim ();
+						if (tl.StartsWith ("<Uri>", StringComparison.Ordinal)) {
+							uri = tl [5..^6];
+						} else if (removal && tl.StartsWith ("<Sha>", StringComparison.Ordinal)) {
+							old_sha = tl [5..^6];
+						} else if (addition && tl.StartsWith ("<Sha>", StringComparison.Ordinal)) {
+							new_sha = tl [5..^6];
+							var diff_url = $"{uri}/compare/{old_sha}..{new_sha}.diff";
+							if (!Include (uri))
+								continue;
+							// skip duplicates (if same revisions are used)
+							if (!list.Contains (diff_url)) {
+								if (string.IsNullOrEmpty (old_sha)) {
+									Console.WriteLine ($"* {uri} [{new_sha [0..7]}]({uri}/commits/{new_sha}) (new dependency)");
+								} else if (string.IsNullOrEmpty (new_sha)) {
+									Console.WriteLine ($"* {uri} [{old_sha [0..7]}]({uri}/commits/{old_sha}) (removed dependency)");
+								} else {
+									Console.WriteLine ($"* {uri} [{old_sha [0..7]}...{new_sha [0..7]}]({uri}/compare/{old_sha}...{new_sha})");
+								}
+								list.Add (diff_url);
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/scripts/changelog/Program.cs
+++ b/scripts/changelog/Program.cs
@@ -37,7 +37,7 @@ namespace changelog {
 				}
 				list.Add (pr);
 				await Process (writer);
-				writer.WriteLine ("Generated using https://github.com/spouliot/dotnet-tools/tree/master/changelog");
+				writer.WriteLine ("Generated using scripts/changelog");
 			}
 		}
 
@@ -98,23 +98,22 @@ namespace changelog {
 						tl = tl.Trim ();
 						if (tl.StartsWith ("<Uri>", StringComparison.Ordinal)) {
 							uri = tl [5..^6];
+							old_sha = "";
+							new_sha = "";
 						} else if (removal && tl.StartsWith ("<Sha>", StringComparison.Ordinal)) {
 							old_sha = tl [5..^6];
 						} else if (addition && tl.StartsWith ("<Sha>", StringComparison.Ordinal)) {
 							new_sha = tl [5..^6];
-							var diff_url = $"{uri}/compare/{old_sha}..{new_sha}.diff";
 							if (!Include (uri))
 								continue;
-							// skip duplicates (if same revisions are used)
-							if (!list.Contains (diff_url)) {
-								if (string.IsNullOrEmpty (old_sha)) {
-									writer.WriteLine ($"* {uri} [{new_sha [0..7]}]({uri}/commits/{new_sha}) (new dependency)");
-								} else if (string.IsNullOrEmpty (new_sha)) {
-									writer.WriteLine ($"* {uri} [{old_sha [0..7]}]({uri}/commits/{old_sha}) (removed dependency)");
-								} else {
-									writer.WriteLine ($"* {uri} [{old_sha [0..7]}...{new_sha [0..7]}]({uri}/compare/{old_sha}...{new_sha})");
-								}
-								list.Add (diff_url);
+							if (string.IsNullOrEmpty (old_sha)) {
+								writer.WriteLine ($"* {uri} [{new_sha [0..7]}]({uri}/commits/{new_sha}) (new dependency)");
+							} else {
+								var diff_url = $"{uri}/compare/{old_sha}..{new_sha}.diff";
+								writer.WriteLine ($"* {uri} [{old_sha [0..7]}...{new_sha [0..7]}]({uri}/compare/{old_sha}...{new_sha})");
+								// skip duplicates (if same revisions are used)
+								if (!list.Contains (diff_url))
+									list.Add (diff_url);
 							}
 						}
 					}

--- a/scripts/changelog/Program.cs
+++ b/scripts/changelog/Program.cs
@@ -31,14 +31,31 @@ namespace changelog {
 				filters.Add (args [i]);
 
 			using (var writer = new StreamWriter (outputFile)) {
-				writer.WriteLine ($"# .net ChangeLog for {pr}");
-				if (pr.StartsWith ("https://github.com/", StringComparison.Ordinal)) {
-					pr = pr.Replace ("https://github.com/", "https://patch-diff.githubusercontent.com/raw/") + ".diff";
-				}
+				writer.WriteLine ($"# .NET Changelog for {pr}");
+				if (TryGetGitHubPullRequestDiffUrl (pr, out var diffUrl))
+					pr = diffUrl;
 				list.Add (pr);
 				await Process (writer);
 				writer.WriteLine ("Generated using scripts/changelog");
 			}
+		}
+
+		static bool TryGetGitHubPullRequestDiffUrl (string url, out string diffUrl)
+		{
+			diffUrl = url;
+			if (!Uri.TryCreate (url, UriKind.Absolute, out var uri))
+				return false;
+			if (uri.Host != "github.com")
+				return false;
+			if (url.EndsWith (".diff", StringComparison.Ordinal))
+				return false;
+
+			var parts = uri.AbsolutePath.Split ('/', StringSplitOptions.RemoveEmptyEntries);
+			if (parts.Length != 4 || parts [2] != "pull")
+				return false;
+
+			diffUrl = $"https://patch-diff.githubusercontent.com/raw/{string.Join ('/', parts)}.diff";
+			return true;
 		}
 
 		static async Task Process (TextWriter writer)

--- a/scripts/changelog/Program.cs
+++ b/scripts/changelog/Program.cs
@@ -7,11 +7,9 @@ using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 
-namespace changelog
-{
+namespace changelog {
 
-	class Program
-	{
+	class Program {
 		static List<string> list = new ();
 		static List<string> filters = new ();
 
@@ -19,7 +17,7 @@ namespace changelog
 		// getting into other repos (pointed by dotnet/installer) can show different results
 		static int level = 2;
 
-		static async Task Main (string[] args)
+		static async Task Main (string [] args)
 		{
 			var pr = args [0];
 			for (int i = 1; i < args.Length; i++)

--- a/scripts/changelog/Program.cs
+++ b/scripts/changelog/Program.cs
@@ -10,8 +10,8 @@ using System.Threading.Tasks;
 namespace changelog {
 
 	class Program {
-		static List<string> list = new ();
-		static List<string> filters = new ();
+		static readonly List<string> list = new ();
+		static readonly List<string> filters = new ();
 
 		// current repo (1) points to dotnet/installer (2)
 		// getting into other repos (pointed by dotnet/installer) can show different results

--- a/scripts/changelog/README.md
+++ b/scripts/changelog/README.md
@@ -10,7 +10,7 @@ Markdown changelog.
 ## Usage
 
 ```sh
-dotnet run --project scripts/changelog/changelog.csproj -- https://github.com/dotnet/macios/pull/11175
+dotnet run --project scripts/changelog/changelog.csproj -- https://github.com/dotnet/macios/pull/11175 /tmp/changelog.txt
 ```
 
 Additional arguments filter the dependency repositories included in the output.

--- a/scripts/changelog/README.md
+++ b/scripts/changelog/README.md
@@ -1,0 +1,16 @@
+<!--
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT License.
+-->
+# Changelog
+
+This tool reads dependency changes from a pull request and formats them as a
+Markdown changelog.
+
+## Usage
+
+```sh
+dotnet run --project scripts/changelog/changelog.csproj -- https://github.com/dotnet/macios/pull/11175
+```
+
+Additional arguments filter the dependency repositories included in the output.

--- a/scripts/changelog/changelog.csproj
+++ b/scripts/changelog/changelog.csproj
@@ -1,0 +1,10 @@
+<!--
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT License.
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net9.0</TargetFramework>
+	</PropertyGroup>
+</Project>

--- a/scripts/changelog/changelog.csproj
+++ b/scripts/changelog/changelog.csproj
@@ -4,7 +4,6 @@ Licensed under the MIT License.
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<OutputType>Exe</OutputType>
 		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
 	</PropertyGroup>
 </Project>

--- a/scripts/changelog/changelog.csproj
+++ b/scripts/changelog/changelog.csproj
@@ -5,6 +5,6 @@ Licensed under the MIT License.
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
 	</PropertyGroup>
 </Project>

--- a/scripts/changelog/fragment.mk
+++ b/scripts/changelog/fragment.mk
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+include $(TOP)/scripts/template.mk
+$(eval $(call TemplateScript,CHANGELOG,changelog))


### PR DESCRIPTION
Replace the external dotnet-tools clone in the Maestro changelog workflow with a vendored scripts/changelog project.

The workflow now checks out the repository and runs the local tool instead of cloning spouliot/dotnet-tools.

🤖 Pull request created by Copilot