### PR TITLE
[dotnet-linker] Emit the macro/short form of IL instructions in generated method bodies.

### DIFF
--- a/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-TrimmableStatic-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-TrimmableStatic-size.txt
@@ -1,9 +1,9 @@
-AppBundleSize: 256,916,796 bytes (250,895.3 KB = 245.0 MB)
+AppBundleSize: 256,629,692 bytes (250,614.9 KB = 244.7 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    759 bytes (0.7 KB = 0.0 MB)
+    743 bytes (0.7 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
-    7,404,616 bytes (7,231.1 KB = 7.1 MB)
+    7,404,248 bytes (7,230.7 KB = 7.1 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/_Microsoft.macOS.TypeMap.dll:
     4,708,864 bytes (4,598.5 KB = 4.5 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/_SizeTestApp.TypeMap.dll:
@@ -11,7 +11,7 @@ Contents/MonoBundle/.xamarin/osx-arm64/_SizeTestApp.TypeMap.dll:
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.CSharp.dll:
     892,712 bytes (871.8 KB = 0.9 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.macOS.dll:
-    37,003,264 bytes (36,136.0 KB = 35.3 MB)
+    36,859,904 bytes (35,996.0 KB = 35.2 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.VisualBasic.Core.dll:
     1,334,568 bytes (1,303.3 KB = 1.3 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.VisualBasic.dll:
@@ -363,7 +363,7 @@ Contents/MonoBundle/.xamarin/osx-x64/_SizeTestApp.TypeMap.dll:
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.CSharp.dll:
     795,944 bytes (777.3 KB = 0.8 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.macOS.dll:
-    37,003,264 bytes (36,136.0 KB = 35.3 MB)
+    36,859,904 bytes (35,996.0 KB = 35.2 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.VisualBasic.Core.dll:
     1,166,120 bytes (1,138.8 KB = 1.1 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.VisualBasic.dll:

--- a/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-size.txt
@@ -1,13 +1,13 @@
-AppBundleSize: 247,542,554 bytes (241,740.8 KB = 236.1 MB)
+AppBundleSize: 247,219,818 bytes (241,425.6 KB = 235.8 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    775 bytes (0.8 KB = 0.0 MB)
+    743 bytes (0.7 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
-    8,029,800 bytes (7,841.6 KB = 7.7 MB)
+    8,029,656 bytes (7,841.5 KB = 7.7 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.CSharp.dll:
     892,712 bytes (871.8 KB = 0.9 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.macOS.dll:
-    36,715,520 bytes (35,855.0 KB = 35.0 MB)
+    36,554,240 bytes (35,697.5 KB = 34.9 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.VisualBasic.Core.dll:
     1,334,568 bytes (1,303.3 KB = 1.3 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.VisualBasic.dll:
@@ -355,7 +355,7 @@ Contents/MonoBundle/.xamarin/osx-arm64/WindowsBase.dll:
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.CSharp.dll:
     795,944 bytes (777.3 KB = 0.8 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.macOS.dll:
-    36,715,520 bytes (35,855.0 KB = 35.0 MB)
+    36,554,240 bytes (35,697.5 KB = 34.9 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.VisualBasic.Core.dll:
     1,166,120 bytes (1,138.8 KB = 1.1 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.VisualBasic.dll:

--- a/tools/dotnet-linker/AppBundleRewriter.cs
+++ b/tools/dotnet-linker/AppBundleRewriter.cs
@@ -2004,7 +2004,7 @@ namespace Xamarin.Linker {
 			il.Emit (OpCodes.Newobj, ctor);
 			il.Emit (OpCodes.Ret);
 
-			body.GenerateILOffsets ();
+			body.FinalizeGeneratedBody ();
 
 			// make sure the trimmer doesn't trim it away if the type is kept
 			if (context.App.Registrar == RegistrarMode.TrimmableStatic) {
@@ -2088,7 +2088,7 @@ namespace Xamarin.Linker {
 				throw new UnreachableException ();
 			}
 
-			body.GenerateILOffsets ();
+			body.FinalizeGeneratedBody ();
 
 			// make sure the trimmer doesn't trim it away if the type is kept
 			if (context.App.Registrar == RegistrarMode.TrimmableStatic) {

--- a/tools/dotnet-linker/CecilExtensions.cs
+++ b/tools/dotnet-linker/CecilExtensions.cs
@@ -4,6 +4,7 @@ using System.Text;
 
 using Mono.Cecil;
 using Mono.Cecil.Cil;
+using Mono.Cecil.Rocks;
 
 using Xamarin.Bundler;
 
@@ -76,8 +77,20 @@ namespace Xamarin.Linker {
 			return body;
 		}
 
-		public static void GenerateILOffsets (this MethodBody body)
+		// Use the macro/short form of instructions whenever possible. This makes the generated IL
+		// smaller, and it also works around a bug in the CoreCLR interpreter, which reads the operand
+		// of the long form of the ldloc/stloc instructions at the wrong offset (the bug was fixed in
+		// https://github.com/dotnet/runtime/pull/131547).
+		public static void OptimizeGeneratedBody (this MethodBody body)
 		{
+			body.OptimizeMacros ();
+		}
+
+		// Call this method once a generated method body is complete.
+		public static void FinalizeGeneratedBody (this MethodBody body)
+		{
+			body.OptimizeGeneratedBody ();
+
 			// This does not compute precise offsets, it just assigns a unique number to each instruction
 			// The trimmer relies on unique offsets to identify instructions
 			int instructionOffset = 0;
@@ -164,7 +177,7 @@ namespace Xamarin.Linker {
 			il.Emit (OpCodes.Ldarg_0);
 			il.Emit (OpCodes.Call, abr.System_Object__ctor);
 			il.Emit (OpCodes.Ret);
-			body.GenerateILOffsets ();
+			body.FinalizeGeneratedBody ();
 			return defaultCtor;
 		}
 

--- a/tools/dotnet-linker/CecilExtensions.cs
+++ b/tools/dotnet-linker/CecilExtensions.cs
@@ -77,19 +77,14 @@ namespace Xamarin.Linker {
 			return body;
 		}
 
-		// Use the macro/short form of instructions whenever possible. This makes the generated IL
-		// smaller, and it also works around a bug in the CoreCLR interpreter, which reads the operand
-		// of the long form of the ldloc/stloc instructions at the wrong offset (the bug was fixed in
-		// https://github.com/dotnet/runtime/pull/131547).
-		public static void OptimizeGeneratedBody (this MethodBody body)
-		{
-			body.OptimizeMacros ();
-		}
-
 		// Call this method once a generated method body is complete.
 		public static void FinalizeGeneratedBody (this MethodBody body)
 		{
-			body.OptimizeGeneratedBody ();
+			// Use the macro/short form of instructions whenever possible. This makes the generated IL
+			// smaller, and it also works around a bug in the CoreCLR interpreter, which reads the operand
+			// of the long form of the ldloc/stloc instructions at the wrong offset (the bug was fixed in
+			// https://github.com/dotnet/runtime/pull/131547).
+			body.OptimizeMacros ();
 
 			// This does not compute precise offsets, it just assigns a unique number to each instruction
 			// The trimmer relies on unique offsets to identify instructions

--- a/tools/dotnet-linker/Steps/InlineDlfcnMethodsStep.cs
+++ b/tools/dotnet-linker/Steps/InlineDlfcnMethodsStep.cs
@@ -403,8 +403,8 @@ public class InlineDlfcnMethodsStep : AssemblyModifierStep {
 		}
 		il.Append (il.Create (OpCodes.Ret));
 
-		// See the comment on CecilExtensions.OptimizeGeneratedBody for why this is needed.
-		body.OptimizeGeneratedBody ();
+		// See the comment in CecilExtensions.FinalizeGeneratedBody for why this is needed.
+		body.FinalizeGeneratedBody ();
 
 		return rv;
 	}
@@ -507,8 +507,8 @@ public class InlineDlfcnMethodsStep : AssemblyModifierStep {
 		}
 		il.Append (il.Create (OpCodes.Ret));
 
-		// See the comment on CecilExtensions.OptimizeGeneratedBody for why this is needed.
-		body.OptimizeGeneratedBody ();
+		// See the comment in CecilExtensions.FinalizeGeneratedBody for why this is needed.
+		body.FinalizeGeneratedBody ();
 
 		return rv;
 	}
@@ -564,8 +564,8 @@ public class InlineDlfcnMethodsStep : AssemblyModifierStep {
 		il.Append (il.Create (OpCodes.Stind_I));
 		il.Append (il.Create (OpCodes.Ret));
 
-		// See the comment on CecilExtensions.OptimizeGeneratedBody for why this is needed.
-		body.OptimizeGeneratedBody ();
+		// See the comment in CecilExtensions.FinalizeGeneratedBody for why this is needed.
+		body.FinalizeGeneratedBody ();
 
 		return rv;
 	}
@@ -918,8 +918,8 @@ public class InlineDlfcnMethodsStep : AssemblyModifierStep {
 					il.Append (il.Create (OpCodes.Ldind_I));
 					il.Append (il.Create (OpCodes.Ret));
 
-					// See the comment on CecilExtensions.OptimizeGeneratedBody for why this is needed.
-					method.Body.OptimizeGeneratedBody ();
+					// See the comment in CecilExtensions.FinalizeGeneratedBody for why this is needed.
+					method.Body.FinalizeGeneratedBody ();
 
 					modified = true;
 					return modified; // we replace the whole method body, so no need to continue processing the method

--- a/tools/dotnet-linker/Steps/InlineDlfcnMethodsStep.cs
+++ b/tools/dotnet-linker/Steps/InlineDlfcnMethodsStep.cs
@@ -403,6 +403,9 @@ public class InlineDlfcnMethodsStep : AssemblyModifierStep {
 		}
 		il.Append (il.Create (OpCodes.Ret));
 
+		// See the comment on CecilExtensions.OptimizeGeneratedBody for why this is needed.
+		body.OptimizeGeneratedBody ();
+
 		return rv;
 	}
 
@@ -504,6 +507,9 @@ public class InlineDlfcnMethodsStep : AssemblyModifierStep {
 		}
 		il.Append (il.Create (OpCodes.Ret));
 
+		// See the comment on CecilExtensions.OptimizeGeneratedBody for why this is needed.
+		body.OptimizeGeneratedBody ();
+
 		return rv;
 	}
 
@@ -557,6 +563,9 @@ public class InlineDlfcnMethodsStep : AssemblyModifierStep {
 		il.Append (il.Create (OpCodes.Call, abr.NativeObject_op_Implicit_IntPtr));
 		il.Append (il.Create (OpCodes.Stind_I));
 		il.Append (il.Create (OpCodes.Ret));
+
+		// See the comment on CecilExtensions.OptimizeGeneratedBody for why this is needed.
+		body.OptimizeGeneratedBody ();
 
 		return rv;
 	}
@@ -908,6 +917,9 @@ public class InlineDlfcnMethodsStep : AssemblyModifierStep {
 					il.Append (loadPointerInstructionStart); // il.Create (OpCodes.Ldloc, ptrVariable)
 					il.Append (il.Create (OpCodes.Ldind_I));
 					il.Append (il.Create (OpCodes.Ret));
+
+					// See the comment on CecilExtensions.OptimizeGeneratedBody for why this is needed.
+					method.Body.OptimizeGeneratedBody ();
 
 					modified = true;
 					return modified; // we replace the whole method body, so no need to continue processing the method

--- a/tools/dotnet-linker/Steps/ManagedRegistrarLookupTablesStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarLookupTablesStep.cs
@@ -289,7 +289,7 @@ namespace Xamarin.Linker {
 			il.Emit (OpCodes.Ldc_I4_M1);
 			il.Emit (OpCodes.Ret);
 
-			body.GenerateILOffsets ();
+			body.FinalizeGeneratedBody ();
 		}
 
 		void GenerateLookupType (AssemblyTrampolineInfo infos, TypeDefinition registrarType, List<TypeData> types)
@@ -331,7 +331,7 @@ namespace Xamarin.Linker {
 			il.Emit (OpCodes.Ldloc, temporary);
 			il.Emit (OpCodes.Ret);
 
-			body.GenerateILOffsets ();
+			body.FinalizeGeneratedBody ();
 		}
 
 		void GenerateConstructNSObject (TypeDefinition registrarType)
@@ -388,7 +388,7 @@ namespace Xamarin.Linker {
 			il.Emit (OpCodes.Ldnull);
 			il.Emit (OpCodes.Ret);
 
-			body.GenerateILOffsets ();
+			body.FinalizeGeneratedBody ();
 		}
 
 		void GenerateConstructINativeObject (TypeDefinition registrarType)
@@ -446,7 +446,7 @@ namespace Xamarin.Linker {
 			il.Emit (OpCodes.Ldnull);
 			il.Emit (OpCodes.Ret);
 
-			body.GenerateILOffsets ();
+			body.FinalizeGeneratedBody ();
 		}
 
 		// We need to preserve the constructor because it might not be used anywhere else.
@@ -502,7 +502,7 @@ namespace Xamarin.Linker {
 
 			il.Emit (OpCodes.Ret);
 
-			body.GenerateILOffsets ();
+			body.FinalizeGeneratedBody ();
 		}
 
 		void GenerateLookupUnmanagedFunction (TypeDefinition registrar_type, IList<TrampolineInfo> trampolineInfos)
@@ -536,7 +536,7 @@ namespace Xamarin.Linker {
 				il.Emit (OpCodes.Call, lookupMethods);
 			}
 			il.Emit (OpCodes.Ret);
-			body.GenerateILOffsets ();
+			body.FinalizeGeneratedBody ();
 		}
 
 		// If WrappedLook is true we'll wrap the ldftn instruction in a separate method, which can be useful for debugging,
@@ -584,7 +584,7 @@ namespace Xamarin.Linker {
 						var wrappedBody = wrappedLookup.CreateBody (out var wrappedIl);
 						wrappedIl.Emit (OpCodes.Ldftn, mr);
 						wrappedIl.Emit (OpCodes.Ret);
-						wrappedBody.GenerateILOffsets ();
+						wrappedBody.FinalizeGeneratedBody ();
 
 						targets [i] = Instruction.Create (OpCodes.Call, wrappedLookup);
 					} else {
@@ -656,7 +656,7 @@ namespace Xamarin.Linker {
 			il.Emit (OpCodes.Conv_I);
 			il.Emit (OpCodes.Ret);
 
-			body.GenerateILOffsets ();
+			body.FinalizeGeneratedBody ();
 
 			return method;
 		}

--- a/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
@@ -755,7 +755,7 @@ namespace Xamarin.Linker {
 			}
 			il.Emit (OpCodes.Ret);
 
-			body.GenerateILOffsets ();
+			body.FinalizeGeneratedBody ();
 		}
 
 		// Recursively substitutes generic parameters in a type reference according to the given map.
@@ -929,7 +929,7 @@ namespace Xamarin.Linker {
 			il.Emit (OpCodes.Callvirt, proxyInterfaceMethod);
 			il.Emit (OpCodes.Ret);
 
-			body.GenerateILOffsets ();
+			body.FinalizeGeneratedBody ();
 		}
 
 		public void EmitCallToExportedMethod (MethodDefinition method, MethodDefinition callback)
@@ -1243,7 +1243,7 @@ namespace Xamarin.Linker {
 				instr.Operand = leaveTryInstructionOperand;
 			eh.HandlerEnd = (Instruction) leaveEHInstruction.Operand;
 
-			body.GenerateILOffsets ();
+			body.FinalizeGeneratedBody ();
 		}
 
 		void AddExceptionHandler (ILProcessor il, VariableDefinition? returnVariable, Instruction placeholderNextInstruction, out ExceptionHandler eh, out Instruction leaveEHInstruction)
@@ -2039,7 +2039,7 @@ namespace Xamarin.Linker {
 			il.Emit (OpCodes.Call, ctor);
 			il.Emit (OpCodes.Ret);
 
-			body.GenerateILOffsets ();
+			body.FinalizeGeneratedBody ();
 
 			return clonedCtor;
 		}
@@ -2059,7 +2059,7 @@ namespace Xamarin.Linker {
 
 				var body = registerToggleRef!.CreateBody (out var il);
 				il.Emit (OpCodes.Ret);
-				body.GenerateILOffsets ();
+				body.FinalizeGeneratedBody ();
 			}
 		}
 	}


### PR DESCRIPTION
The trimmable static registrar (and the Dlfcn inlining step) generate method
bodies using the long form of the ldloc/stloc/ldarg/ldloca instructions.

This trips a bug in the CoreCLR interpreter, where the store/load peephole
optimization reads the operand of the long form of ldloc/stloc at the wrong
offset (ip + 1 instead of ip + 2). The resulting bogus local index is used to
index an array, which leads to an out-of-bounds read and a SIGBUS at runtime:

    make clean build run-bare -C tests/monotouch-test/dotnet/MacCatalyst TEST_VARIATION=trimmable-static-registrar

crashed in MonoTouchFixtures.ObjCRuntime.RegistrarTest.TestConstrainedGenericType.

The interpreter bug has been fixed in https://github.com/dotnet/runtime/pull/131547,
but we still need to work around it until we get a runtime with that fix.

Emitting the macro/short form of the instructions avoids the problematic
instruction sequence entirely, and it also makes the generated IL smaller,
which is a good thing in itself.

For monotouch-test on macOS, this removes all 3709 adjacent long-form
'stloc; ldloc' pairs from the generated _monotouchtest.TypeMap.dll.

Copilot-Session: a002000e-438e-48ff-9c22-c716d1a2e7aa