### PR TITLE
[CI] Add DotNetWatch CoreCLR Hot Reload diagnostics (investigation)

### DIFF
--- a/tests/dotnet/HotReloadTestApp/AppDelegate.cs
+++ b/tests/dotnet/HotReloadTestApp/AppDelegate.cs
@@ -21,11 +21,23 @@ public partial class Program {
 	{
 		GC.KeepAlive (typeof (NSObject)); // prevent linking away the platform assembly
 
+		Print ($"Runtime={RuntimeInformation.FrameworkDescription}");
+		Print ($"RuntimeVersion={Environment.Version}");
+		Print ($"ProcessArchitecture={RuntimeInformation.ProcessArchitecture}");
+		Print ($"OSDescription={RuntimeInformation.OSDescription}");
+		Print ($"BaseDirectory={AppContext.BaseDirectory}");
+		Print ($"CommandLine={Environment.CommandLine}");
+
 		Print (0);
 
-		for (var i = 0; i < 120 && ContinueLooping; i++) {
-			DoSomething (i + 1);
-			Thread.Sleep (TimeSpan.FromSeconds (1));
+		try {
+			for (var i = 0; i < 120 && ContinueLooping; i++) {
+				DoSomething (i + 1);
+				Thread.Sleep (TimeSpan.FromSeconds (1));
+			}
+		} catch (Exception e) {
+			Print ($"Exception={e}");
+			throw;
 		}
 
 		return ContinueLooping ? 1 : 0;
@@ -40,8 +52,10 @@ public partial class Program {
 	static string? LogPath = Environment.GetEnvironmentVariable ("HOTRELOAD_TEST_APP_LOGFILE");
 	static StreamWriter? logStream;
 	static void Print (int number)
+		=> Print ($"{number} Variable={Variable}");
+
+	static void Print (string msg)
 	{
-		var msg = $"{number} Variable={Variable}";
 		if (!string.IsNullOrEmpty (LogPath)) {
 			if (logStream is null) {
 				var fs = new FileStream (LogPath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.Read);

--- a/tests/dotnet/UnitTests/DotNetWatchTest.cs
+++ b/tests/dotnet/UnitTests/DotNetWatchTest.cs
@@ -68,6 +68,7 @@ namespace Xamarin.Tests {
 			var appOutput = new List<string> ();
 
 			var outputProcessor = new Action<string> (line => {
+				debugLog.WriteLine ($"[{DateTimeOffset.UtcNow:O}] [observed] {line}");
 				if (line.Contains ("Variable has not changed")) {
 					if (appStarted.TrySetResult (true))
 						debugLog.WriteLine ("Got 'Variable has not changed'");
@@ -107,7 +108,7 @@ namespace Xamarin.Tests {
 			pollThread.Start ();
 
 			Action<string> outputCallback = (line) => {
-				debugLog.WriteLine ($"[dotnet watch] {line}");
+				debugLog.WriteLine ($"[{DateTimeOffset.UtcNow:O}] [dotnet watch] {line}");
 				lock (output) {
 					output.Add (line);
 					outputProcessor (line);
@@ -130,6 +131,12 @@ namespace Xamarin.Tests {
 				{ "HOTRELOAD_TEST_APP_LOGFILE", logPath },
 				{ "AdditionalFile", additionalFile },
 			};
+			debugLog.WriteLine ($"Platform={platform}");
+			debugLog.WriteLine ($"Project={projectPath}");
+			debugLog.WriteLine ($"ProjectDirectory={projectDirectory}");
+			debugLog.WriteLine ($"AdditionalFile={additionalFile}");
+			debugLog.WriteLine ($"DotNet={DotNet.Executable}");
+			debugLog.WriteLine ($"Environment={string.Join (", ", env.Select (v => $"{v.Key}={v.Value}"))}");
 
 			var watchTask = Execution.RunWithCallbacksAsync (
 				DotNet.Executable,
@@ -146,12 +153,12 @@ namespace Xamarin.Tests {
 			// Wait for the app to start and show initial output
 			debugLog.WriteLine ("Waiting for app start...");
 			if (!appStarted.Task.Wait (TimeSpan.FromMinutes (1)))
-				Assert.Fail ($"Timed out waiting for the app to start. Output:\n{string.Join ("\n", output)}\nDebug output:\n{string.Join ("\n", File.ReadAllLines (debugLogPath))}");
+				FailWithDiagnostics (debugLogPath, logPath, $"Timed out waiting for the app to start. Output:\n{string.Join ("\n", output)}");
 			debugLog.WriteLine ("App started!");
 
 			debugLog.WriteLine ("Waiting for 'dotnet watch' to be waiting for changes...");
 			if (!waitingForChanges.Task.Wait (TimeSpan.FromMinutes (1)))
-				Assert.Fail ($"Timed out waiting for the 'dotnet watch' to be waiting for changes. Output:\n{string.Join ("\n", output)}\nDebug output:\n{string.Join ("\n", File.ReadAllLines (debugLogPath))}");
+				FailWithDiagnostics (debugLogPath, logPath, $"Timed out waiting for the 'dotnet watch' to be waiting for changes. Output:\n{string.Join ("\n", output)}");
 			debugLog.WriteLine ("Waiting for changes!");
 
 			// Write AdditionalFile.cs to trigger a rebuild via dotnet watch
@@ -160,7 +167,7 @@ namespace Xamarin.Tests {
 			// Wait for dotnet watch to pick up the change and the app to show the updated output
 			debugLog.WriteLine ("Waiting for app restart...");
 			if (!variableChanged.Task.Wait (TimeSpan.FromMinutes (1)))
-				Assert.Fail ($"Timed out waiting for the variable to change. Output:\n{string.Join ("\n", output)}\nDebug output:\n{string.Join ("\n", File.ReadAllLines (debugLogPath))}");
+				FailWithDiagnostics (debugLogPath, logPath, $"Timed out waiting for the variable to change. Output:\n{string.Join ("\n", output)}");
 			debugLog.WriteLine ("App restarted!");
 
 			// Cancel the watch process
@@ -174,6 +181,14 @@ namespace Xamarin.Tests {
 			} catch {
 				// Expected - the process was cancelled
 			}
+		}
+
+		static void FailWithDiagnostics (string debugLogPath, string appLogPath, string message)
+		{
+			TestContext.AddTestAttachment (debugLogPath, "dotnet watch diagnostic log");
+			if (File.Exists (appLogPath))
+				TestContext.AddTestAttachment (appLogPath, "Hot Reload test app output");
+			Assert.Fail ($"{message}\nDebug output:\n{string.Join ("\n", File.ReadAllLines (debugLogPath))}");
 		}
 
 		// Pick any device for the specified project, and compatible with the specified runtime identifier (if provided).

--- a/tests/xharness/Jenkins/TestTasks/DotNetTestTask.cs
+++ b/tests/xharness/Jenkins/TestTasks/DotNetTestTask.cs
@@ -35,7 +35,9 @@ namespace Xharness.Jenkins.TestTasks {
 					args.Add ($"--logger:nunit;LogFileName={Path.GetFileName (xml.FullPath)}");
 
 				var filter = TestProject?.Filter;
-				var envTestFilter = global::System.Environment.GetEnvironmentVariable ("TEST_FILTER");
+				var envTestFilter = global::System.Environment.GetEnvironmentVariable ("DOTNET_TEST_FILTER");
+				if (string.IsNullOrEmpty (envTestFilter))
+					envTestFilter = global::System.Environment.GetEnvironmentVariable ("TEST_FILTER");
 				if (!string.IsNullOrEmpty (envTestFilter)) {
 					if (!string.IsNullOrEmpty (filter)) {
 						filter = $"({envTestFilter}) & ({filter})";

--- a/tools/devops/automation/run-post-pr-build-tests.yml
+++ b/tools/devops/automation/run-post-pr-build-tests.yml
@@ -28,3 +28,6 @@ extends:
     isPR: true
     buildPackages: true
     useACES: true  # flip to false to opt PR simulator tests out of ACES; see templates/variables/common.yml
+    runWindowsIntegration: false
+    dotnetTestFilter: >-
+      FullyQualifiedName~Xamarin.Tests.DotNetWatchTest

--- a/tools/devops/automation/templates/pipelines/run-tests-pipeline.yml
+++ b/tools/devops/automation/templates/pipelines/run-tests-pipeline.yml
@@ -36,6 +36,11 @@ parameters:
     type: boolean
     default: false
 
+  - name: dotnetTestFilter
+    displayName: Filter .NET tests
+    type: string
+    default: ''
+
 resources:
   repositories:
     - repository: self
@@ -62,3 +67,4 @@ stages:
       runWindowsIntegration: ${{ parameters.runWindowsIntegration }}
       buildPackages: ${{ parameters.buildPackages }}
       useACES: ${{ parameters.useACES }}
+      dotnetTestFilter: ${{ parameters.dotnetTestFilter }}

--- a/tools/devops/automation/templates/tests-stage.yml
+++ b/tools/devops/automation/templates/tests-stage.yml
@@ -8,6 +8,10 @@ parameters:
   type: boolean
   default: true
 
+- name: dotnetTestFilter
+  type: string
+  default: ''
+
 - name: isPR
   type: boolean
 
@@ -230,6 +234,7 @@ stages:
     testPool: $(PRBuildPool)
     statusContext: 'VSTS: simulator tests'
     vsdropsPrefix: ${{ variables.vsdropsPrefix }}
+    dotnetTestFilter: ${{ parameters.dotnetTestFilter }}
     keyringPass: $(pass--lab--mac--builder--keychain)
     gitHubToken: $(Github.Token)
     xqaCertPass: $(xqa--certificates--password)

--- a/tools/devops/automation/templates/tests/build.yml
+++ b/tools/devops/automation/templates/tests/build.yml
@@ -55,6 +55,10 @@ parameters:
   type: string
   default: ''
 
+- name: dotnetTestFilter
+  type: string
+  default: ''
+
 - name: conditionVariable
   type: string
   default: ''
@@ -218,6 +222,7 @@ steps:
     testsLabels: ${{ parameters.testsLabels }}
     vsdropsPrefix: ${{ parameters.vsdropsPrefix }}
     testPrefix: ${{ parameters.testPrefix }}
+    dotnetTestFilter: ${{ parameters.dotnetTestFilter }}
 
 # clean the bot after we use it
 - template: ../common/teardown.yml

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -34,6 +34,10 @@ parameters:
   type: number
   default: 3
 
+- name: dotnetTestFilter
+  type: string
+  default: ''
+
 steps:
 - bash: |
     set -ex
@@ -122,6 +126,7 @@ steps:
   env:
     TEST_PREFIX: ${{ upper(parameters.testPrefix) }}
     TESTS_EXTRA_ARGUMENTS: ${{ parameters.testsLabels }}
+    DOTNET_TEST_FILTER: ${{ parameters.dotnetTestFilter }}
     USE_TCP_TUNNEL: 'true'
     PARAMETERS_TESTPREFIX: '${{ parameters.testPrefix }}'
     IS_PR: $(parameters.isPr)

--- a/tools/devops/automation/templates/tests/stage.yml
+++ b/tools/devops/automation/templates/tests/stage.yml
@@ -70,6 +70,10 @@ parameters:
   type: boolean
   default: false
 
+- name: dotnetTestFilter
+  type: string
+  default: ''
+
 stages:
 - stage: ${{ parameters.stageName }}
   displayName: ${{ parameters.displayName }}
@@ -138,6 +142,7 @@ stages:
         statusContext: $(STATUS_CONTEXT)
         testPlatform:  $(TEST_PLATFORM)
         vsdropsPrefix: ${{ parameters.vsdropsPrefix }}
+        dotnetTestFilter: ${{ parameters.dotnetTestFilter }}
         keyringPass: ${{ parameters.keyringPass }}
         testPrefix: $(TEST_PREFIX)
         gitHubToken: ${{ parameters.gitHubToken }}


### PR DESCRIPTION
Adds runtime and process diagnostics to DotNetWatch Hot Reload failures, attaches the watch/app logs to NUnit results, and narrows this investigation pipeline to DotNetWatchTest while disabling Windows integration.

Fixes https://github.com/dotnet/macios/issues/26470

🤖 Pull request created by Copilot