### PR TITLE
[xharness] Cap test output into the html report.

### DIFF
--- a/tests/xharness/Jenkins/Reports/HtmlReportWriter.cs
+++ b/tests/xharness/Jenkins/Reports/HtmlReportWriter.cs
@@ -676,7 +676,7 @@ namespace Xharness.Jenkins.Reports {
 				if (string.IsNullOrEmpty (failedTest.Message)) {
 					writer.WriteLine ("{0}<br />", failedTest.Name.AsHtml ());
 				} else {
-					writer.WriteLine ("{0}: {1}<br />", failedTest.Name.AsHtml (), failedTest.Message.AsHtml ());
+					writer.WriteLine ("{0}: {1}<br />", failedTest.Name.AsHtml (), failedTest.Message.Cap (1024).AsHtml ());
 				}
 				writer.WriteLine ("</li>");
 			}


### PR DESCRIPTION
Some asserts an output a lot of text, but we don't need all of that in the html report, so cap it.