### PR TITLE
[dotnet-linker] Write the generated typemap assemblies deterministically.

### DIFF
--- a/tests/dotnet/UnitTests/expected/MacCatalyst-MonoVM-interpreter-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacCatalyst-MonoVM-interpreter-size.txt
@@ -1,19 +1,19 @@
-AppBundleSize: 5,792,974 bytes (5,657.2 KB = 5.5 MB)
+AppBundleSize: 5,801,688 bytes (5,665.7 KB = 5.5 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    1,097 bytes (1.1 KB = 0.0 MB)
+    1,067 bytes (1.0 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
-    4,572,648 bytes (4,465.5 KB = 4.4 MB)
+    4,578,664 bytes (4,471.4 KB = 4.4 MB)
 Contents/MonoBundle/Microsoft.MacCatalyst.dll:
-    157,696 bytes (154.0 KB = 0.2 MB)
+    156,160 bytes (152.5 KB = 0.1 MB)
 Contents/MonoBundle/runtimeconfig.bin:
     1,405 bytes (1.4 KB = 0.0 MB)
 Contents/MonoBundle/SizeTestApp.dll:
     7,680 bytes (7.5 KB = 0.0 MB)
 Contents/MonoBundle/System.Private.CoreLib.aotdata.arm64:
-    41,240 bytes (40.3 KB = 0.0 MB)
+    41,408 bytes (40.4 KB = 0.0 MB)
 Contents/MonoBundle/System.Private.CoreLib.dll:
-    997,888 bytes (974.5 KB = 1.0 MB)
+    1,001,984 bytes (978.5 KB = 1.0 MB)
 Contents/MonoBundle/System.Runtime.dll:
     5,120 bytes (5.0 KB = 0.0 MB)
 Contents/MonoBundle/System.Runtime.InteropServices.dll:

--- a/tests/dotnet/UnitTests/expected/MacCatalyst-MonoVM-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacCatalyst-MonoVM-size.txt
@@ -1,13 +1,13 @@
-AppBundleSize: 16,326,608 bytes (15,944.0 KB = 15.6 MB)
+AppBundleSize: 16,333,572 bytes (15,950.8 KB = 15.6 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    1,039 bytes (1.0 KB = 0.0 MB)
+    1,067 bytes (1.0 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
-    13,818,632 bytes (13,494.8 KB = 13.2 MB)
+    13,826,168 bytes (13,502.1 KB = 13.2 MB)
 Contents/MonoBundle/aot-instances.aotdata.arm64:
     1,045,352 bytes (1,020.9 KB = 1.0 MB)
 Contents/MonoBundle/Microsoft.MacCatalyst.aotdata.arm64:
-    36,744 bytes (35.9 KB = 0.0 MB)
+    36,656 bytes (35.8 KB = 0.0 MB)
 Contents/MonoBundle/Microsoft.MacCatalyst.dll:
     51,200 bytes (50.0 KB = 0.0 MB)
 Contents/MonoBundle/runtimeconfig.bin:
@@ -15,7 +15,7 @@ Contents/MonoBundle/runtimeconfig.bin:
 Contents/MonoBundle/SizeTestApp.aotdata.arm64:
     1,552 bytes (1.5 KB = 0.0 MB)
 Contents/MonoBundle/SizeTestApp.dll:
-    7,680 bytes (7.5 KB = 0.0 MB)
+    7,168 bytes (7.0 KB = 0.0 MB)
 Contents/MonoBundle/System.Private.CoreLib.aotdata.arm64:
     814,120 bytes (795.0 KB = 0.8 MB)
 Contents/MonoBundle/System.Private.CoreLib.dll:

--- a/tests/dotnet/UnitTests/expected/MacCatalyst-NativeAOT-TrimmableStatic-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacCatalyst-NativeAOT-TrimmableStatic-size.txt
@@ -1,9 +1,9 @@
-AppBundleSize: 8,356,513 bytes (8,160.7 KB = 8.0 MB)
+AppBundleSize: 8,356,547 bytes (8,160.7 KB = 8.0 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    1,097 bytes (1.1 KB = 0.0 MB)
+    1,067 bytes (1.0 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
-    8,353,512 bytes (8,157.7 KB = 8.0 MB)
+    8,353,576 bytes (8,157.8 KB = 8.0 MB)
 Contents/MonoBundle/runtimeconfig.bin:
     1,896 bytes (1.9 KB = 0.0 MB)
 Contents/PkgInfo:

--- a/tests/dotnet/UnitTests/expected/MacCatalyst-NativeAOT-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacCatalyst-NativeAOT-size.txt
@@ -1,7 +1,7 @@
-AppBundleSize: 2,043,104 bytes (1,995.2 KB = 1.9 MB)
+AppBundleSize: 2,043,115 bytes (1,995.2 KB = 1.9 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    1,056 bytes (1.0 KB = 0.0 MB)
+    1,067 bytes (1.0 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
     2,040,232 bytes (1,992.4 KB = 1.9 MB)
 Contents/MonoBundle/runtimeconfig.bin:

--- a/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-TrimmableStatic-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-TrimmableStatic-size.txt
@@ -1,17 +1,17 @@
-AppBundleSize: 256,916,796 bytes (250,895.3 KB = 245.0 MB)
+AppBundleSize: 252,207,262 bytes (246,296.2 KB = 240.5 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    759 bytes (0.7 KB = 0.0 MB)
+    745 bytes (0.7 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
-    7,404,616 bytes (7,231.1 KB = 7.1 MB)
-Contents/MonoBundle/.xamarin/osx-arm64/_Microsoft.macOS.TypeMap.dll:
+    7,404,984 bytes (7,231.4 KB = 7.1 MB)
+Contents/MonoBundle/_Microsoft.macOS.TypeMap.dll:
     4,708,864 bytes (4,598.5 KB = 4.5 MB)
-Contents/MonoBundle/.xamarin/osx-arm64/_SizeTestApp.TypeMap.dll:
+Contents/MonoBundle/_SizeTestApp.TypeMap.dll:
     3,072 bytes (3.0 KB = 0.0 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.CSharp.dll:
     892,712 bytes (871.8 KB = 0.9 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.macOS.dll:
-    37,003,264 bytes (36,136.0 KB = 35.3 MB)
+    37,004,288 bytes (36,137.0 KB = 35.3 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.VisualBasic.Core.dll:
     1,334,568 bytes (1,303.3 KB = 1.3 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.VisualBasic.dll:
@@ -356,14 +356,10 @@ Contents/MonoBundle/.xamarin/osx-arm64/System.Xml.XPath.XDocument.dll:
     17,192 bytes (16.8 KB = 0.0 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/WindowsBase.dll:
     16,208 bytes (15.8 KB = 0.0 MB)
-Contents/MonoBundle/.xamarin/osx-x64/_Microsoft.macOS.TypeMap.dll:
-    4,708,864 bytes (4,598.5 KB = 4.5 MB)
-Contents/MonoBundle/.xamarin/osx-x64/_SizeTestApp.TypeMap.dll:
-    3,072 bytes (3.0 KB = 0.0 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.CSharp.dll:
     795,944 bytes (777.3 KB = 0.8 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.macOS.dll:
-    37,003,264 bytes (36,136.0 KB = 35.3 MB)
+    37,004,288 bytes (36,137.0 KB = 35.3 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.VisualBasic.Core.dll:
     1,166,120 bytes (1,138.8 KB = 1.1 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.VisualBasic.dll:

--- a/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-TrimmableStatic-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-TrimmableStatic-size.txt
@@ -1,4 +1,4 @@
-AppBundleSize: 252,207,262 bytes (246,296.2 KB = 240.5 MB)
+AppBundleSize: 251,918,494 bytes (246,014.2 KB = 240.2 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
     745 bytes (0.7 KB = 0.0 MB)
@@ -11,7 +11,7 @@ Contents/MonoBundle/_SizeTestApp.TypeMap.dll:
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.CSharp.dll:
     892,712 bytes (871.8 KB = 0.9 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.macOS.dll:
-    37,004,288 bytes (36,137.0 KB = 35.3 MB)
+    36,859,904 bytes (35,996.0 KB = 35.2 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.VisualBasic.Core.dll:
     1,334,568 bytes (1,303.3 KB = 1.3 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.VisualBasic.dll:
@@ -359,7 +359,7 @@ Contents/MonoBundle/.xamarin/osx-arm64/WindowsBase.dll:
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.CSharp.dll:
     795,944 bytes (777.3 KB = 0.8 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.macOS.dll:
-    37,004,288 bytes (36,137.0 KB = 35.3 MB)
+    36,859,904 bytes (35,996.0 KB = 35.2 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.VisualBasic.Core.dll:
     1,166,120 bytes (1,138.8 KB = 1.1 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.VisualBasic.dll:

--- a/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-size.txt
@@ -1,4 +1,4 @@
-AppBundleSize: 247,547,228 bytes (241,745.3 KB = 236.1 MB)
+AppBundleSize: 247,220,572 bytes (241,426.3 KB = 235.8 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
     745 bytes (0.7 KB = 0.0 MB)
@@ -7,7 +7,7 @@ Contents/MacOS/SizeTestApp:
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.CSharp.dll:
     892,712 bytes (871.8 KB = 0.9 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.macOS.dll:
-    36,717,568 bytes (35,857.0 KB = 35.0 MB)
+    36,554,240 bytes (35,697.5 KB = 34.9 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.VisualBasic.Core.dll:
     1,334,568 bytes (1,303.3 KB = 1.3 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.VisualBasic.dll:
@@ -355,7 +355,7 @@ Contents/MonoBundle/.xamarin/osx-arm64/WindowsBase.dll:
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.CSharp.dll:
     795,944 bytes (777.3 KB = 0.8 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.macOS.dll:
-    36,717,568 bytes (35,857.0 KB = 35.0 MB)
+    36,554,240 bytes (35,697.5 KB = 34.9 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.VisualBasic.Core.dll:
     1,166,120 bytes (1,138.8 KB = 1.1 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.VisualBasic.dll:

--- a/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-size.txt
@@ -1,13 +1,13 @@
-AppBundleSize: 247,542,554 bytes (241,740.8 KB = 236.1 MB)
+AppBundleSize: 247,547,228 bytes (241,745.3 KB = 236.1 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    775 bytes (0.8 KB = 0.0 MB)
+    745 bytes (0.7 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
-    8,029,800 bytes (7,841.6 KB = 7.7 MB)
+    8,030,408 bytes (7,842.2 KB = 7.7 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.CSharp.dll:
     892,712 bytes (871.8 KB = 0.9 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.macOS.dll:
-    36,715,520 bytes (35,855.0 KB = 35.0 MB)
+    36,717,568 bytes (35,857.0 KB = 35.0 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.VisualBasic.Core.dll:
     1,334,568 bytes (1,303.3 KB = 1.3 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.VisualBasic.dll:
@@ -355,7 +355,7 @@ Contents/MonoBundle/.xamarin/osx-arm64/WindowsBase.dll:
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.CSharp.dll:
     795,944 bytes (777.3 KB = 0.8 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.macOS.dll:
-    36,715,520 bytes (35,855.0 KB = 35.0 MB)
+    36,717,568 bytes (35,857.0 KB = 35.0 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.VisualBasic.Core.dll:
     1,166,120 bytes (1,138.8 KB = 1.1 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.VisualBasic.dll:

--- a/tests/dotnet/UnitTests/expected/MacOSX-NativeAOT-TrimmableStatic-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacOSX-NativeAOT-TrimmableStatic-size.txt
@@ -1,9 +1,9 @@
-AppBundleSize: 20,836,815 bytes (20,348.5 KB = 19.9 MB)
+AppBundleSize: 20,836,865 bytes (20,348.5 KB = 19.9 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    775 bytes (0.8 KB = 0.0 MB)
+    745 bytes (0.7 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
-    17,747,480 bytes (17,331.5 KB = 16.9 MB)
+    17,747,560 bytes (17,331.6 KB = 16.9 MB)
 Contents/MonoBundle/libSystem.Globalization.Native.dylib:
     267,872 bytes (261.6 KB = 0.3 MB)
 Contents/MonoBundle/libSystem.IO.Compression.Native.dylib:

--- a/tests/dotnet/UnitTests/expected/MacOSX-NativeAOT-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacOSX-NativeAOT-size.txt
@@ -1,9 +1,9 @@
-AppBundleSize: 7,373,837 bytes (7,201.0 KB = 7.0 MB)
+AppBundleSize: 7,373,887 bytes (7,201.1 KB = 7.0 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    759 bytes (0.7 KB = 0.0 MB)
+    745 bytes (0.7 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
-    4,284,600 bytes (4,184.2 KB = 4.1 MB)
+    4,284,664 bytes (4,184.2 KB = 4.1 MB)
 Contents/MonoBundle/libSystem.Globalization.Native.dylib:
     267,872 bytes (261.6 KB = 0.3 MB)
 Contents/MonoBundle/libSystem.IO.Compression.Native.dylib:

--- a/tests/dotnet/UnitTests/expected/TVOS-MonoVM-interpreter-size.txt
+++ b/tests/dotnet/UnitTests/expected/TVOS-MonoVM-interpreter-size.txt
@@ -1,21 +1,21 @@
-AppBundleSize: 3,571,144 bytes (3,487.4 KB = 3.4 MB)
+AppBundleSize: 3,576,458 bytes (3,492.6 KB = 3.4 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Info.plist:
-    1,163 bytes (1.1 KB = 0.0 MB)
+    1,133 bytes (1.1 KB = 0.0 MB)
 Microsoft.tvOS.dll:
-    152,064 bytes (148.5 KB = 0.1 MB)
+    153,088 bytes (149.5 KB = 0.1 MB)
 PkgInfo:
     8 bytes (0.0 KB = 0.0 MB)
 runtimeconfig.bin:
     1,405 bytes (1.4 KB = 0.0 MB)
 SizeTestApp:
-    2,366,536 bytes (2,311.1 KB = 2.3 MB)
+    2,366,592 bytes (2,311.1 KB = 2.3 MB)
 SizeTestApp.dll:
     7,680 bytes (7.5 KB = 0.0 MB)
 System.Private.CoreLib.aotdata.arm64:
-    41,328 bytes (40.4 KB = 0.0 MB)
+    41,496 bytes (40.5 KB = 0.0 MB)
 System.Private.CoreLib.dll:
-    987,648 bytes (964.5 KB = 0.9 MB)
+    991,744 bytes (968.5 KB = 0.9 MB)
 System.Runtime.dll:
     5,120 bytes (5.0 KB = 0.0 MB)
 System.Runtime.InteropServices.dll:

--- a/tests/dotnet/UnitTests/expected/TVOS-MonoVM-size.txt
+++ b/tests/dotnet/UnitTests/expected/TVOS-MonoVM-size.txt
@@ -1,11 +1,11 @@
-AppBundleSize: 9,267,538 bytes (9,050.3 KB = 8.8 MB)
+AppBundleSize: 9,267,030 bytes (9,049.8 KB = 8.8 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 aot-instances.aotdata.arm64:
     828,456 bytes (809.0 KB = 0.8 MB)
 Info.plist:
-    1,105 bytes (1.1 KB = 0.0 MB)
+    1,133 bytes (1.1 KB = 0.0 MB)
 Microsoft.tvOS.aotdata.arm64:
-    23,000 bytes (22.5 KB = 0.0 MB)
+    22,976 bytes (22.4 KB = 0.0 MB)
 Microsoft.tvOS.dll:
     49,152 bytes (48.0 KB = 0.0 MB)
 PkgInfo:
@@ -17,7 +17,7 @@ SizeTestApp:
 SizeTestApp.aotdata.arm64:
     1,464 bytes (1.4 KB = 0.0 MB)
 SizeTestApp.dll:
-    7,680 bytes (7.5 KB = 0.0 MB)
+    7,168 bytes (7.0 KB = 0.0 MB)
 System.Private.CoreLib.aotdata.arm64:
     640,920 bytes (625.9 KB = 0.6 MB)
 System.Private.CoreLib.dll:

--- a/tests/dotnet/UnitTests/expected/TVOS-NativeAOT-TrimmableStatic-size.txt
+++ b/tests/dotnet/UnitTests/expected/TVOS-NativeAOT-TrimmableStatic-size.txt
@@ -1,10 +1,10 @@
-AppBundleSize: 7,425,324 bytes (7,251.3 KB = 7.1 MB)
+AppBundleSize: 7,425,374 bytes (7,251.3 KB = 7.1 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Info.plist:
-    1,163 bytes (1.1 KB = 0.0 MB)
+    1,133 bytes (1.1 KB = 0.0 MB)
 PkgInfo:
     8 bytes (0.0 KB = 0.0 MB)
 runtimeconfig.bin:
     1,889 bytes (1.8 KB = 0.0 MB)
 SizeTestApp:
-    7,422,264 bytes (7,248.3 KB = 7.1 MB)
+    7,422,344 bytes (7,248.4 KB = 7.1 MB)

--- a/tests/dotnet/UnitTests/expected/TVOS-NativeAOT-size.txt
+++ b/tests/dotnet/UnitTests/expected/TVOS-NativeAOT-size.txt
@@ -1,10 +1,10 @@
-AppBundleSize: 2,011,806 bytes (1,964.7 KB = 1.9 MB)
+AppBundleSize: 2,011,845 bytes (1,964.7 KB = 1.9 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Info.plist:
-    1,166 bytes (1.1 KB = 0.0 MB)
+    1,133 bytes (1.1 KB = 0.0 MB)
 PkgInfo:
     8 bytes (0.0 KB = 0.0 MB)
 runtimeconfig.bin:
     1,808 bytes (1.8 KB = 0.0 MB)
 SizeTestApp:
-    2,008,824 bytes (1,961.7 KB = 1.9 MB)
+    2,008,896 bytes (1,961.8 KB = 1.9 MB)

--- a/tests/dotnet/UnitTests/expected/iOS-MonoVM-interpreter-size.txt
+++ b/tests/dotnet/UnitTests/expected/iOS-MonoVM-interpreter-size.txt
@@ -1,21 +1,21 @@
-AppBundleSize: 3,571,448 bytes (3,487.7 KB = 3.4 MB)
+AppBundleSize: 3,576,754 bytes (3,492.9 KB = 3.4 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Info.plist:
-    1,187 bytes (1.2 KB = 0.0 MB)
+    1,157 bytes (1.1 KB = 0.0 MB)
 Microsoft.iOS.dll:
-    152,064 bytes (148.5 KB = 0.1 MB)
+    153,088 bytes (149.5 KB = 0.1 MB)
 PkgInfo:
     8 bytes (0.0 KB = 0.0 MB)
 runtimeconfig.bin:
     1,405 bytes (1.4 KB = 0.0 MB)
 SizeTestApp:
-    2,366,816 bytes (2,311.3 KB = 2.3 MB)
+    2,366,864 bytes (2,311.4 KB = 2.3 MB)
 SizeTestApp.dll:
     7,680 bytes (7.5 KB = 0.0 MB)
 System.Private.CoreLib.aotdata.arm64:
-    41,328 bytes (40.4 KB = 0.0 MB)
+    41,496 bytes (40.5 KB = 0.0 MB)
 System.Private.CoreLib.dll:
-    987,648 bytes (964.5 KB = 0.9 MB)
+    991,744 bytes (968.5 KB = 0.9 MB)
 System.Runtime.dll:
     5,120 bytes (5.0 KB = 0.0 MB)
 System.Runtime.InteropServices.dll:

--- a/tests/dotnet/UnitTests/expected/iOS-MonoVM-size.txt
+++ b/tests/dotnet/UnitTests/expected/iOS-MonoVM-size.txt
@@ -1,9 +1,9 @@
-AppBundleSize: 9,267,100 bytes (9,049.9 KB = 8.8 MB)
+AppBundleSize: 9,267,086 bytes (9,049.9 KB = 8.8 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 aot-instances.aotdata.arm64:
     828,456 bytes (809.0 KB = 0.8 MB)
 Info.plist:
-    1,171 bytes (1.1 KB = 0.0 MB)
+    1,157 bytes (1.1 KB = 0.0 MB)
 Microsoft.iOS.aotdata.arm64:
     23,336 bytes (22.8 KB = 0.0 MB)
 Microsoft.iOS.dll:

--- a/tests/dotnet/UnitTests/expected/iOS-NativeAOT-TrimmableStatic-size.txt
+++ b/tests/dotnet/UnitTests/expected/iOS-NativeAOT-TrimmableStatic-size.txt
@@ -1,10 +1,10 @@
-AppBundleSize: 8,585,907 bytes (8,384.7 KB = 8.2 MB)
+AppBundleSize: 8,585,957 bytes (8,384.7 KB = 8.2 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Info.plist:
-    1,187 bytes (1.2 KB = 0.0 MB)
+    1,157 bytes (1.1 KB = 0.0 MB)
 PkgInfo:
     8 bytes (0.0 KB = 0.0 MB)
 runtimeconfig.bin:
     1,888 bytes (1.8 KB = 0.0 MB)
 SizeTestApp:
-    8,582,824 bytes (8,381.7 KB = 8.2 MB)
+    8,582,904 bytes (8,381.7 KB = 8.2 MB)

--- a/tests/dotnet/UnitTests/expected/iOS-NativeAOT-size.txt
+++ b/tests/dotnet/UnitTests/expected/iOS-NativeAOT-size.txt
@@ -1,10 +1,10 @@
-AppBundleSize: 2,028,466 bytes (1,980.9 KB = 1.9 MB)
+AppBundleSize: 2,028,485 bytes (1,980.9 KB = 1.9 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Info.plist:
-    1,146 bytes (1.1 KB = 0.0 MB)
+    1,157 bytes (1.1 KB = 0.0 MB)
 PkgInfo:
     8 bytes (0.0 KB = 0.0 MB)
 runtimeconfig.bin:
     1,808 bytes (1.8 KB = 0.0 MB)
 SizeTestApp:
-    2,025,504 bytes (1,978.0 KB = 1.9 MB)
+    2,025,512 bytes (1,978.0 KB = 1.9 MB)

--- a/tools/dotnet-linker/Steps/TrimmableRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/TrimmableRegistrarStep.cs
@@ -136,9 +136,21 @@ namespace Xamarin.Linker {
 			// We write the assembly here even if it hasn't changed, because otherwise we'll just end up re-creating
 			// it again during the next incremental build.
 			if (!useEntryAssemblyAsRootTypeMapAssembly) {
-				rootTypeMapAssembly.Write (createdRootTypeMapAssemblyPath);
+				WriteDeterministically (rootTypeMapAssembly, createdRootTypeMapAssemblyPath);
 			}
 			return rootTypeMapAssembly;
+		}
+
+		// Writes the assembly to disk with a deterministic module version id (MVID) and timestamp.
+		// The MVIDs of the typemap assemblies end up in the generated registrar code, so if we let Cecil
+		// compute a new random MVID every time, the registrar code would change on every build, and we'd
+		// have to recompile (and relink) it every time.
+		static void WriteDeterministically (AssemblyDefinition assembly, string path)
+		{
+			assembly.Write (path, new WriterParameters {
+				DeterministicMvid = true,
+				Timestamp = 0,
+			});
 		}
 
 		MethodReference CreateMethodReference (MethodReference methodReference, params TypeReference [] declaringTypeGenericArguments)
@@ -720,7 +732,7 @@ namespace Xamarin.Linker {
 
 				// We write the assembly here even if it hasn't changed, because otherwise we'll just end up re-creating
 				// it again during the next incremental build.
-				typeMapAssembly.Write (typeMapAssemblyPath);
+				WriteDeterministically (typeMapAssembly, typeMapAssemblyPath);
 			}
 
 			foreach (var kvp in postActionsByAssembly) {


### PR DESCRIPTION

The typemap assemblies we generate got a new random module version id (MVID) and a new timestamp every time they were written, which means they'd be different for every build even if nothing had changed.

This is bad for incremental builds, because the MVID of every assembly in the app ends up in the generated native registrar code, so the registrar code would change on every build, forcing a recompile and a relink of the native executable.

Fix this by asking Cecil to compute the MVID from the contents of the assembly (and to use a fixed timestamp), which means the MVID now only changes when the contents of the typemap assembly actually change.

Verified by doing two clean builds of MySimpleApp (iOS/ios-arm64/CoreCLR) and comparing the MVIDs of every assembly in the app bundle as well as the generated registrar.mm: they're now identical (before this change the four typemap assemblies differed, and so did registrar.mm).

🤖 Pull request created by Copilot
