### PR TITLE
[dotnet-linker] Don't unconditionally preserve smart enum conversions in trimmed assemblies.

### DIFF
--- a/tests/assembly-preparer/PreserveSmartEnumConversionsTest.cs
+++ b/tests/assembly-preparer/PreserveSmartEnumConversionsTest.cs
@@ -48,6 +48,11 @@ public class PreserveSmartEnumConversionsTests : BaseClass {
 		var cctor = type.GetStaticConstructor ();
 		Assert.That (cctor, Is.Null, "No static constructor should be needed.");
 
+		AssertHasDynamicDependencies (platform, type, "get_RWProperty", "set_RWProperty", "get_ROProperty", "set_WOProperty", "Method1", "Method2", "Method3", "Method4");
+	}
+
+	static void AssertHasDynamicDependencies (ApplePlatform platform, TypeDefinition type, params string [] methodNames)
+	{
 		void AssertHasDynamicDependency (ICustomAttributeProvider provider, string memberSignature, string typeName, string assemblyName)
 		{
 			var ddaAttributes = provider.CustomAttributes.Where (v => v.AttributeType.FullName == "System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute").ToArray ();
@@ -101,7 +106,7 @@ public class PreserveSmartEnumConversionsTests : BaseClass {
 			Assert.Fail (msg);
 		}
 
-		void AssertHasDynamicDependencies (ICustomAttributeProvider provider)
+		void AssertMethodHasDynamicDependencies (ICustomAttributeProvider provider)
 		{
 			// 'GetConstant' has no parameter list, because it's the only method with that name (unlike 'GetValue').
 			AssertHasDynamicDependency (provider, "GetConstant", "CoreAnimation.CAToneMapModeExtensions", $"Microsoft.{platform.AsString ()}");
@@ -109,14 +114,8 @@ public class PreserveSmartEnumConversionsTests : BaseClass {
 		}
 
 		Assert.Multiple (() => {
-			AssertHasDynamicDependencies (type.Methods.Single (v => v.Name == "get_RWProperty"));
-			AssertHasDynamicDependencies (type.Methods.Single (v => v.Name == "set_RWProperty"));
-			AssertHasDynamicDependencies (type.Methods.Single (v => v.Name == "get_ROProperty"));
-			AssertHasDynamicDependencies (type.Methods.Single (v => v.Name == "set_WOProperty"));
-			AssertHasDynamicDependencies (type.Methods.Single (v => v.Name == "Method1"));
-			AssertHasDynamicDependencies (type.Methods.Single (v => v.Name == "Method2"));
-			AssertHasDynamicDependencies (type.Methods.Single (v => v.Name == "Method3"));
-			AssertHasDynamicDependencies (type.Methods.Single (v => v.Name == "Method4"));
+			foreach (var methodName in methodNames)
+				AssertMethodHasDynamicDependencies (type.Methods.Single (v => v.Name == methodName));
 		});
 	}
 
@@ -127,9 +126,9 @@ public class PreserveSmartEnumConversionsTests : BaseClass {
 	[TestCase (ApplePlatform.MacOSX, true)]
 	public void HotReloadCompatibleBuildTest (ApplePlatform platform, bool isCoreCLR)
 	{
-		// When $(HotReloadCompatibleBuild) is enabled, the step must not modify the referencing
-		// (possibly user/reloadable) assembly - otherwise Hot Reload breaks. Instead it must emit an
-		// ILLink root-descriptor XML that preserves the framework-side conversion methods.
+		// When $(HotReloadCompatibleBuild) is enabled and the referencing assembly isn't trimmed, the step
+		// must not modify that (possibly user/reloadable) assembly - otherwise Hot Reload breaks. Instead it
+		// must emit an ILLink root-descriptor XML that preserves the framework-side conversion methods.
 		var code = @"
 		using System;
 		using CoreAnimation;
@@ -147,9 +146,9 @@ public class PreserveSmartEnumConversionsTests : BaseClass {
 		}";
 
 		var cacheDirectory = Xamarin.Cache.CreateTemporaryDirectory ();
-		var extraConfig = $"HotReloadCompatibleBuild=true\n\t\tCacheDirectory={cacheDirectory}";
+		var extraConfig = $"CacheDirectory={cacheDirectory}";
 
-		AssertPrepare (platform, isCoreCLR, code, out var assemblyDefinition, extraConfig);
+		AssertPrepare (platform, isCoreCLR, RegistrarMode.Dynamic, code, out var assemblyDefinition, hotReloadCompatibleBuild: true, testAssemblyTrimMode: "copy", extraConfig: extraConfig);
 
 		var type = assemblyDefinition.MainModule.Types.Single (v => v.Name == "MyClass");
 
@@ -179,5 +178,53 @@ public class PreserveSmartEnumConversionsTests : BaseClass {
 			.ToArray ();
 		Assert.That (signatures, Does.Contain ("Foundation.NSString GetConstant(CoreAnimation.CAToneMapMode)"), "GetConstant must be preserved.");
 		Assert.That (signatures, Does.Contain ("CoreAnimation.CAToneMapMode GetValue(Foundation.NSString)"), "GetValue must be preserved.");
+	}
+
+	[Test]
+	[TestCase (ApplePlatform.MacCatalyst, false)]
+	[TestCase (ApplePlatform.iOS, false)]
+	[TestCase (ApplePlatform.TVOS, false)]
+	[TestCase (ApplePlatform.MacOSX, true)]
+	public void HotReloadCompatibleBuildTrimmedAssemblyTest (ApplePlatform platform, bool isCoreCLR)
+	{
+		// Assemblies that are trimmed can't be hot reloaded, so even when $(HotReloadCompatibleBuild) is
+		// enabled we must inject [DynamicDependency] attributes into them (instead of preserving the
+		// conversion methods unconditionally using the root-descriptor XML).
+		var code = @"
+		using System;
+		using CoreAnimation;
+		using Foundation;
+		using ObjCRuntime;
+
+		class MyClass : NSObject {
+			[BindAs (typeof (CAToneMapMode), OriginalType = typeof (NSString))]
+			public CAToneMapMode RWProperty { get; set; }
+
+			[return: BindAs (typeof (CAToneMapMode), OriginalType = typeof (NSString))]
+			public CAToneMapMode Method1 () { return default; }
+
+			public void Method2 ([BindAs (typeof (CAToneMapMode), OriginalType = typeof (NSString))] CAToneMapMode p1) {}
+		}";
+
+		var cacheDirectory = Xamarin.Cache.CreateTemporaryDirectory ();
+		var extraConfig = $"CacheDirectory={cacheDirectory}";
+
+		AssertPrepare (platform, isCoreCLR, RegistrarMode.Dynamic, code, out var assemblyDefinition, hotReloadCompatibleBuild: true, testAssemblyTrimMode: "link", extraConfig: extraConfig);
+
+		var type = assemblyDefinition.MainModule.Types.Single (v => v.Name == "MyClass");
+		var cctor = type.GetStaticConstructor ();
+		Assert.That (cctor, Is.Null, "No static constructor should be needed.");
+
+		AssertHasDynamicDependencies (platform, type, "get_RWProperty", "set_RWProperty", "Method1", "Method2");
+
+		// The root-descriptor XML must not mention the smart enum from the trimmed assembly.
+		var xmlPath = Path.Combine (cacheDirectory, "preserve-smart-enum-conversions.xml");
+		if (File.Exists (xmlPath)) {
+			var document = XDocument.Load (xmlPath);
+			var extensionType = document
+				.Descendants ("type")
+				.SingleOrDefault (v => (string?) v.Attribute ("fullname") == "CoreAnimation.CAToneMapModeExtensions");
+			Assert.That (extensionType, Is.Null, "The extension type must not be present in the root-descriptor XML.");
+		}
 	}
 }

--- a/tests/linker/link all/PreserveTest.cs
+++ b/tests/linker/link all/PreserveTest.cs
@@ -137,19 +137,9 @@ namespace LinkAll.Attributes {
 			Assert.That (smartExtensions.GetMethod ("GetConstant"), Is.Not.Null, "GetConstant");
 			Assert.That (smartExtensions.GetMethod ("GetValue"), Is.Not.Null, "GetValue");
 
-#if HOTRELOAD_COMPATIBLE_BUILD && PREPARE_ASSEMBLIES
-			// In a hot-reload-compatible build (the assembly-preparer runs with
-			// HotReloadCompatibleBuild=true, which is the default for Debug builds),
-			// smart enum conversions are preserved unconditionally via a root-descriptor
-			// XML instead of by modifying user assemblies. Root descriptors can't express
-			// conditional preservation, so unused smart enums are intentionally kept.
-			Assert.That (typeof (NSObject).Assembly.GetType ("AVFoundation.AVMediaTypes"), Is.Not.Null, "AVMediaTypes");
-			Assert.That (typeof (NSObject).Assembly.GetType ("AVFoundation.AVMediaTypesExtensions"), Is.Not.Null, "AVMediaTypesExtensions");
-#else
 			// Unused smart enums and their extensions should be linked away
 			Assert.That (typeof (NSObject).Assembly.GetType ("AVFoundation.AVMediaTypes"), Is.Null, "AVMediaTypes");
 			Assert.That (typeof (NSObject).Assembly.GetType ("AVFoundation.AVMediaTypesExtensions"), Is.Null, "AVMediaTypesExtensions");
-#endif
 		}
 
 		[Test]

--- a/tools/dotnet-linker/PreserveSmartEnumConversionsStep.cs
+++ b/tools/dotnet-linker/PreserveSmartEnumConversionsStep.cs
@@ -18,20 +18,23 @@ namespace Xamarin.Linker.Steps {
 		protected override string Name { get; } = "Smart Enum Conversion Preserver";
 		protected override int ErrorCode { get; } = 2200;
 
-		// When set, we can't modify user assemblies (that would break Hot Reload), so instead of injecting
-		// [DynamicDependency] attributes into the referencing (possibly user) assembly, we collect the
-		// framework-side conversion methods and emit an ILLink root-descriptor XML that preserves them
+		// When set for a given assembly, we can't modify it (that would break Hot Reload), so instead of
+		// injecting [DynamicDependency] attributes into the referencing (possibly user) assembly, we collect
+		// the framework-side conversion methods and emit an ILLink root-descriptor XML that preserves them
 		// unconditionally. This only makes sense in the assembly-preparer, where the descriptor is consumed
 		// by the subsequent trimmer pass (in the trimmer itself we keep the current attribute-injection
 		// behaviour, which doesn't affect Hot Reload since Hot Reload requires the assembly-preparer).
-		bool UseXmlDescriptionFile {
-			get {
+		//
+		// Assemblies that are trimmed can't be hot reloaded, so we can modify those, and it's important that
+		// we do: preserving every smart enum conversion in our platform assembly unconditionally would keep
+		// a lot of code (and thus native frameworks) alive that should have been trimmed away.
+		bool UseXmlDescriptionFile (AssemblyDefinition assembly)
+		{
 #if ASSEMBLY_PREPARER
-				return Configuration.HotReloadCompatibleBuild;
+			return Configuration.HotReloadCompatibleBuild && Annotations.GetAction (assembly) != AssemblyAction.Link;
 #else
-				return false;
+			return false;
 #endif
-			}
 		}
 
 		// The framework-side conversion methods to preserve via the root-descriptor XML.
@@ -71,16 +74,16 @@ namespace Xamarin.Linker.Steps {
 			if (conds.Length == 0)
 				return false;
 
-			if (UseXmlDescriptionFile) {
-				// Don't modify the (possibly user) assembly: collect the framework-side conversion methods so
-				// they can be preserved unconditionally via a root-descriptor XML instead.
-				xmlDescriptor.PreserveMethod (pair.Item1);
-				xmlDescriptor.PreserveMethod (pair.Item2);
-				return false;
-			}
-
 			var modified = false;
 			foreach (var condition in conds) {
+				if (UseXmlDescriptionFile (condition.Module.Assembly)) {
+					// Don't modify the (possibly user) assembly: collect the framework-side conversion methods
+					// so they can be preserved unconditionally via a root-descriptor XML instead.
+					xmlDescriptor.PreserveMethod (pair.Item1);
+					xmlDescriptor.PreserveMethod (pair.Item2);
+					continue;
+				}
+
 				modified |= abr.AddDynamicDependencyAttribute (condition, pair.Item1);
 				modified |= abr.AddDynamicDependencyAttribute (condition, pair.Item2);
 			}
@@ -90,7 +93,7 @@ namespace Xamarin.Linker.Steps {
 
 		protected override void TryEndProcess ()
 		{
-			if (!UseXmlDescriptionFile || xmlDescriptor.IsEmpty)
+			if (xmlDescriptor.IsEmpty)
 				return;
 
 			var xmlPath = Path.Combine (Configuration.CacheDirectory, "preserve-smart-enum-conversions.xml");


### PR DESCRIPTION

`PreserveSmartEnumConversionsStep` has two ways of preserving the smart enum conversion methods:

* Inject a `[DynamicDependency]` attribute on the method that references the smart enum. This is conditional: the conversion methods only survive if the referencing method survives.
* Emit an ILLink root descriptor file. This preserves the conversion methods unconditionally, and is required when we can't modify the assembly (hot reload).

Which one to use was decided by the global `HotReloadCompatibleBuild` option, which defaults to true for all debug builds. That meant that every smart enum referenced anywhere in the platform assembly was preserved unconditionally, which in turn kept a lot of code alive that should have been trimmed away (15+ extra namespaces surviving in the platform assembly, which made us link with the corresponding frameworks).

Assemblies with `AssemblyAction.Link` are being trimmed, so they're not hot reloadable and can safely be modified - this is the same condition we already use in `RemoveUserResourcesSubStep`, `ListExportedSymbols` and `InlineDlfcnMethodsStep`.

Verified by inspecting a Full-linked `Microsoft.iOS.dll`: the number of surviving namespaces went from 19 down to 6.

🤖 Pull request created by Copilot
