### PR TITLE
[dotnet-linker] Remove crossgen2 TypeRef workaround. Fixes #26343.

### DIFF
--- a/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-TrimmableStatic-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-TrimmableStatic-size.txt
@@ -1,11 +1,11 @@
-AppBundleSize: 262,291,610 bytes (256,144.2 KB = 250.1 MB)
+AppBundleSize: 262,159,610 bytes (256,015.2 KB = 250.0 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
     717 bytes (0.7 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
     7,350,184 bytes (7,177.9 KB = 7.0 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/_Microsoft.macOS.TypeMap.dll:
-    4,776,960 bytes (4,665.0 KB = 4.6 MB)
+    4,710,960 bytes (4,600.5 KB = 4.5 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/_Microsoft.macOS.TypeMaps.dll:
     2,048 bytes (2.0 KB = 0.0 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/_SizeTestApp.TypeMap.dll:
@@ -377,7 +377,7 @@ Contents/MonoBundle/.xamarin/osx-arm64/System.Xml.XPath.XDocument.dll:
 Contents/MonoBundle/.xamarin/osx-arm64/WindowsBase.dll:
     16,168 bytes (15.8 KB = 0.0 MB)
 Contents/MonoBundle/.xamarin/osx-x64/_Microsoft.macOS.TypeMap.dll:
-    4,776,960 bytes (4,665.0 KB = 4.6 MB)
+    4,710,960 bytes (4,600.5 KB = 4.5 MB)
 Contents/MonoBundle/.xamarin/osx-x64/_Microsoft.macOS.TypeMaps.dll:
     2,048 bytes (2.0 KB = 0.0 MB)
 Contents/MonoBundle/.xamarin/osx-x64/_SizeTestApp.TypeMap.dll:

--- a/tools/dotnet-linker/Steps/TrimmableRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/TrimmableRegistrarStep.cs
@@ -180,63 +180,6 @@ namespace Xamarin.Linker {
 			il.Append (il.Create (OpCodes.Throw));
 		}
 
-		// The types named by our type-map entries are only mentioned in the custom attribute blobs (as
-		// assembly-qualified names), which means the type map assembly ends up without a TypeRef row for them.
-		// That's valid metadata: ECMA-335 II.23.3 only requires the type to be stored as a SerString with its
-		// canonical name, and neither the CustomAttribute (II.22.10) nor the TypeRef (II.22.38) validity rules
-		// require a corresponding TypeRef row. The runtime agrees: it resolves these types by parsing the string,
-		// not by looking at the TypeRef table (and the type map design explicitly says the assembly name in
-		// TypeMapAssemblyTargetAttribute doesn't need a matching AssemblyRef row either).
-		//
-		// crossgen2 nonetheless assumes such a TypeRef row exists: it can't resolve the type back to a module
-		// token, and crashes with a NotImplementedException (in ModuleTokenResolver.GetModuleTokenForType) when it
-		// ReadyToRun-compiles the type map assembly. See https://github.com/dotnet/runtime/issues/131527.
-		//
-		// Work around that by emitting an unused method that loads the token of every externally defined type we
-		// name, which makes Cecil emit the corresponding TypeRef rows. The method is never called, so it's trimmed
-		// away again by ILLink.
-		void EmitTypeReferencesForTypeMaps (AssemblyDefinition typeMapAssembly)
-		{
-			// Only crossgen2 needs this, and the added metadata isn't free, so don't do it for the other runtimes.
-			// We don't narrow this down to ReadyToRun builds, because that would mean different behavior between
-			// .NET versions (ReadyToRun is a .NET 11+ feature), and the cost for the interpreted CoreCLR
-			// configurations is small (~64 KB per runtime identifier in the platform type map assembly).
-			if (App.XamarinRuntime != XamarinRuntime.CoreCLR)
-				return;
-
-			var module = typeMapAssembly.MainModule;
-			var externalTypes = new List<TypeReference> ();
-			var seen = new HashSet<string> (StringComparer.Ordinal);
-
-			foreach (var attribute in typeMapAssembly.CustomAttributes) {
-				foreach (var argument in attribute.ConstructorArguments) {
-					if (argument.Value is not TypeReference type)
-						continue;
-					// Types defined in the type map assembly itself already have a TypeDef row.
-					if (type.Scope == module)
-						continue;
-					// Deduplicate on the scope too: two different assemblies can have types with the same full name.
-					if (seen.Add (type.Scope?.Name + "!" + type.FullName))
-						externalTypes.Add (type);
-				}
-			}
-
-			if (externalTypes.Count == 0)
-				return;
-
-			var holderType = new TypeDefinition ("", "<TypeReferences>", TypeAttributes.NotPublic | TypeAttributes.Abstract | TypeAttributes.Sealed, abr.System_Object);
-			module.Types.Add (holderType);
-
-			var method = holderType.AddMethod ("KeepTypeReferences", MethodAttributes.Private | MethodAttributes.HideBySig | MethodAttributes.Static, abr.System_Void);
-			method.CreateBody (out var il);
-			foreach (var type in externalTypes) {
-				// 'ldtoken' works for open generic types too, unlike a field or parameter of that type.
-				il.Append (il.Create (OpCodes.Ldtoken, type));
-				il.Append (il.Create (OpCodes.Pop));
-			}
-			il.Append (il.Create (OpCodes.Ret));
-		}
-
 		protected override void TryEndProcess (out List<Exception>? exceptions)
 		{
 			CustomAttribute attribute;
@@ -712,8 +655,6 @@ namespace Xamarin.Linker {
 						typeMapAssembly.CustomAttributes.Add (attribute);
 					}
 				}
-
-				EmitTypeReferencesForTypeMaps (typeMapAssembly);
 
 				abr.ClearCurrentAssembly ();
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/macios/issues/26343.