### PR TITLE
[release/11.0.1xx-rc.1] Update dependencies from dotnet/macios

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -12,6 +12,7 @@
     <!--  Begin: Package sources from dotnet-dotnet -->
     <!--  End: Package sources from dotnet-dotnet -->
     <!--  Begin: Package sources from dotnet-macios -->
+    <add key="darc-pub-dotnet-macios-bf48bb9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-bf48bb9d/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-macios -->
     <!--  Begin: Package sources from dotnet-emsdk -->
     <!--  End: Package sources from dotnet-emsdk -->

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -19,16 +19,16 @@ This file should be imported by eng/Versions.props
     <!-- dotnet-macios dependencies -->
     <MicrosoftiOSSdknet100_260PackageVersion>26.0.11017</MicrosoftiOSSdknet100_260PackageVersion>
     <MicrosoftiOSSdknet100_265PackageVersion>26.5.10318</MicrosoftiOSSdknet100_265PackageVersion>
-    <MicrosoftiOSSdknet100_270PackageVersion>27.0.10241-xcode27.0</MicrosoftiOSSdknet100_270PackageVersion>
+    <MicrosoftiOSSdknet100_270PackageVersion>27.0.10539-xcode27.0</MicrosoftiOSSdknet100_270PackageVersion>
     <MicrosoftMacCatalystSdknet100_260PackageVersion>26.0.11017</MicrosoftMacCatalystSdknet100_260PackageVersion>
     <MicrosoftMacCatalystSdknet100_265PackageVersion>26.5.10318</MicrosoftMacCatalystSdknet100_265PackageVersion>
-    <MicrosoftMacCatalystSdknet100_270PackageVersion>27.0.10241-xcode27.0</MicrosoftMacCatalystSdknet100_270PackageVersion>
+    <MicrosoftMacCatalystSdknet100_270PackageVersion>27.0.10539-xcode27.0</MicrosoftMacCatalystSdknet100_270PackageVersion>
     <MicrosoftmacOSSdknet100_260PackageVersion>26.0.11017</MicrosoftmacOSSdknet100_260PackageVersion>
     <MicrosoftmacOSSdknet100_265PackageVersion>26.5.10318</MicrosoftmacOSSdknet100_265PackageVersion>
-    <MicrosoftmacOSSdknet100_270PackageVersion>27.0.10241-xcode27.0</MicrosoftmacOSSdknet100_270PackageVersion>
+    <MicrosoftmacOSSdknet100_270PackageVersion>27.0.10539-xcode27.0</MicrosoftmacOSSdknet100_270PackageVersion>
     <MicrosofttvOSSdknet100_260PackageVersion>26.0.11017</MicrosofttvOSSdknet100_260PackageVersion>
     <MicrosofttvOSSdknet100_265PackageVersion>26.5.10318</MicrosofttvOSSdknet100_265PackageVersion>
-    <MicrosofttvOSSdknet100_270PackageVersion>27.0.10241-xcode27.0</MicrosofttvOSSdknet100_270PackageVersion>
+    <MicrosofttvOSSdknet100_270PackageVersion>27.0.10539-xcode27.0</MicrosofttvOSSdknet100_270PackageVersion>
     <!-- dotnet-xharness dependencies -->
     <MicrosoftDotNetXHarnessiOSSharedPackageVersion>11.0.0-prerelease.26431.4</MicrosoftDotNetXHarnessiOSSharedPackageVersion>
   </PropertyGroup>

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -18,19 +18,19 @@ This file should be imported by eng/Versions.props
     <MicrosoftTemplateEngineAuthoringTasksPackageVersion>11.0.100-rc.1.26426.105</MicrosoftTemplateEngineAuthoringTasksPackageVersion>
     <!-- dotnet-macios dependencies -->
     <MicrosoftiOSSdknet100_260PackageVersion>26.0.11017</MicrosoftiOSSdknet100_260PackageVersion>
-    <MicrosoftiOSSdknet100_265PackageVersion>26.5.10315</MicrosoftiOSSdknet100_265PackageVersion>
+    <MicrosoftiOSSdknet100_265PackageVersion>26.5.10318</MicrosoftiOSSdknet100_265PackageVersion>
     <MicrosoftiOSSdknet100_270PackageVersion>27.0.10241-xcode27.0</MicrosoftiOSSdknet100_270PackageVersion>
     <MicrosoftMacCatalystSdknet100_260PackageVersion>26.0.11017</MicrosoftMacCatalystSdknet100_260PackageVersion>
-    <MicrosoftMacCatalystSdknet100_265PackageVersion>26.5.10315</MicrosoftMacCatalystSdknet100_265PackageVersion>
+    <MicrosoftMacCatalystSdknet100_265PackageVersion>26.5.10318</MicrosoftMacCatalystSdknet100_265PackageVersion>
     <MicrosoftMacCatalystSdknet100_270PackageVersion>27.0.10241-xcode27.0</MicrosoftMacCatalystSdknet100_270PackageVersion>
     <MicrosoftmacOSSdknet100_260PackageVersion>26.0.11017</MicrosoftmacOSSdknet100_260PackageVersion>
-    <MicrosoftmacOSSdknet100_265PackageVersion>26.5.10315</MicrosoftmacOSSdknet100_265PackageVersion>
+    <MicrosoftmacOSSdknet100_265PackageVersion>26.5.10318</MicrosoftmacOSSdknet100_265PackageVersion>
     <MicrosoftmacOSSdknet100_270PackageVersion>27.0.10241-xcode27.0</MicrosoftmacOSSdknet100_270PackageVersion>
     <MicrosofttvOSSdknet100_260PackageVersion>26.0.11017</MicrosofttvOSSdknet100_260PackageVersion>
-    <MicrosofttvOSSdknet100_265PackageVersion>26.5.10315</MicrosofttvOSSdknet100_265PackageVersion>
+    <MicrosofttvOSSdknet100_265PackageVersion>26.5.10318</MicrosofttvOSSdknet100_265PackageVersion>
     <MicrosofttvOSSdknet100_270PackageVersion>27.0.10241-xcode27.0</MicrosofttvOSSdknet100_270PackageVersion>
     <!-- dotnet-xharness dependencies -->
-    <MicrosoftDotNetXHarnessiOSSharedPackageVersion>11.0.0-prerelease.26427.1</MicrosoftDotNetXHarnessiOSSharedPackageVersion>
+    <MicrosoftDotNetXHarnessiOSSharedPackageVersion>11.0.0-prerelease.26431.4</MicrosoftDotNetXHarnessiOSSharedPackageVersion>
   </PropertyGroup>
   <!--Property group for alternate package version names-->
   <PropertyGroup>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,21 +43,21 @@
       <Sha>23eb1c2c9465fe76c810c8a69982c1254161f4b0</Sha>
     </Dependency>
     <!-- This is a subscription of the .NET 10/Xcode 26.5 versions of our packages -->
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.5" Version="26.5.10315">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.5" Version="26.5.10318">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>ac895e19154cd3305df029b18849b2e5ed98e036</Sha>
+      <Sha>bf48bb9ddc6999f39aa838032bd7f7f742767884</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net10.0_26.5" Version="26.5.10315">
+    <Dependency Name="Microsoft.macOS.Sdk.net10.0_26.5" Version="26.5.10318">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>ac895e19154cd3305df029b18849b2e5ed98e036</Sha>
+      <Sha>bf48bb9ddc6999f39aa838032bd7f7f742767884</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net10.0_26.5" Version="26.5.10315">
+    <Dependency Name="Microsoft.iOS.Sdk.net10.0_26.5" Version="26.5.10318">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>ac895e19154cd3305df029b18849b2e5ed98e036</Sha>
+      <Sha>bf48bb9ddc6999f39aa838032bd7f7f742767884</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_26.5" Version="26.5.10315">
+    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_26.5" Version="26.5.10318">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>ac895e19154cd3305df029b18849b2e5ed98e036</Sha>
+      <Sha>bf48bb9ddc6999f39aa838032bd7f7f742767884</Sha>
     </Dependency>
     <!-- This is a subscription of the .NET 10/Xcode 27.0 versions of our packages -->
     <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_27.0" Version="27.0.10241-xcode27.0">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -60,21 +60,21 @@
       <Sha>bf48bb9ddc6999f39aa838032bd7f7f742767884</Sha>
     </Dependency>
     <!-- This is a subscription of the .NET 10/Xcode 27.0 versions of our packages -->
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_27.0" Version="27.0.10241-xcode27.0">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_27.0" Version="27.0.10539-xcode27.0">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>6807aae9f1f542afdcca3552940930793cb9ae7f</Sha>
+      <Sha>feb67499296f24185cc71f6d5ec9d101be6f692c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net10.0_27.0" Version="27.0.10241-xcode27.0">
+    <Dependency Name="Microsoft.macOS.Sdk.net10.0_27.0" Version="27.0.10539-xcode27.0">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>6807aae9f1f542afdcca3552940930793cb9ae7f</Sha>
+      <Sha>feb67499296f24185cc71f6d5ec9d101be6f692c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net10.0_27.0" Version="27.0.10241-xcode27.0">
+    <Dependency Name="Microsoft.iOS.Sdk.net10.0_27.0" Version="27.0.10539-xcode27.0">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>6807aae9f1f542afdcca3552940930793cb9ae7f</Sha>
+      <Sha>feb67499296f24185cc71f6d5ec9d101be6f692c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_27.0" Version="27.0.10241-xcode27.0">
+    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_27.0" Version="27.0.10539-xcode27.0">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>6807aae9f1f542afdcca3552940930793cb9ae7f</Sha>
+      <Sha>feb67499296f24185cc71f6d5ec9d101be6f692c</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>


### PR DESCRIPTION
Backport of https://github.com/dotnet/macios/pull/26519

This pull request updates the following dependencies

[marker]: <> (Begin:0454d3ab-7df0-4900-9ff6-1d1027534cf4)
## From https://github.com/dotnet/macios
- **Subscription**: [0454d3ab-7df0-4900-9ff6-1d1027534cf4](https://maestro.dot.net/subscriptions?search=0454d3ab-7df0-4900-9ff6-1d1027534cf4)
- **Build**: [20260901.6](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=15168757) ([329806](https://maestro.dot.net/channel/5173/github:dotnet:macios/build/329806))
- **Date Produced**: September 1, 2026 6:05:00 PM UTC
- **Commit**: [bf48bb9ddc6999f39aa838032bd7f7f742767884](https://github.com/dotnet/macios/commit/bf48bb9ddc6999f39aa838032bd7f7f742767884)
- **Branch**: [release/10.0.1xx](https://github.com/dotnet/macios/tree/release/10.0.1xx)

[DependencyUpdate]: <> (Begin)

- **Dependency Updates**:
  - From [26.5.10315 to 26.5.10318][1]
     - Microsoft.iOS.Sdk.net10.0_26.5
     - Microsoft.MacCatalyst.Sdk.net10.0_26.5
     - Microsoft.macOS.Sdk.net10.0_26.5
     - Microsoft.tvOS.Sdk.net10.0_26.5

[1]: https://github.com/dotnet/macios/compare/ac895e1915...bf48bb9ddc

[DependencyUpdate]: <> (End)


[marker]: <> (End:0454d3ab-7df0-4900-9ff6-1d1027534cf4)
