### PR TITLE
[release/10.0.1xx] [dotnet] Update Xcode 27.0 packages for .NET 10.

### DIFF
--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -18,19 +18,19 @@ This file should be imported by eng/Versions.props
     <MicrosoftTemplateEngineAuthoringTasksPackageVersion>10.0.400</MicrosoftTemplateEngineAuthoringTasksPackageVersion>
     <!-- dotnet-macios dependencies -->
     <MicrosoftiOSSdknet100_260PackageVersion>26.0.11017</MicrosoftiOSSdknet100_260PackageVersion>
-    <MicrosoftiOSSdknet100_270PackageVersion>27.0.10539-xcode27.0</MicrosoftiOSSdknet100_270PackageVersion>
+    <MicrosoftiOSSdknet100_270PackageVersion>27.0.10540-xcode27.0</MicrosoftiOSSdknet100_270PackageVersion>
     <MicrosoftiOSSdknet90_185PackageVersion>18.5.9227</MicrosoftiOSSdknet90_185PackageVersion>
     <MicrosoftiOSSdknet90_265PackageVersion>26.5.9004</MicrosoftiOSSdknet90_265PackageVersion>
     <MicrosoftMacCatalystSdknet100_260PackageVersion>26.0.11017</MicrosoftMacCatalystSdknet100_260PackageVersion>
-    <MicrosoftMacCatalystSdknet100_270PackageVersion>27.0.10539-xcode27.0</MicrosoftMacCatalystSdknet100_270PackageVersion>
+    <MicrosoftMacCatalystSdknet100_270PackageVersion>27.0.10540-xcode27.0</MicrosoftMacCatalystSdknet100_270PackageVersion>
     <MicrosoftMacCatalystSdknet90_185PackageVersion>18.5.9227</MicrosoftMacCatalystSdknet90_185PackageVersion>
     <MicrosoftMacCatalystSdknet90_265PackageVersion>26.5.9004</MicrosoftMacCatalystSdknet90_265PackageVersion>
     <MicrosoftmacOSSdknet100_260PackageVersion>26.0.11017</MicrosoftmacOSSdknet100_260PackageVersion>
-    <MicrosoftmacOSSdknet100_270PackageVersion>27.0.10539-xcode27.0</MicrosoftmacOSSdknet100_270PackageVersion>
+    <MicrosoftmacOSSdknet100_270PackageVersion>27.0.10540-xcode27.0</MicrosoftmacOSSdknet100_270PackageVersion>
     <MicrosoftmacOSSdknet90_155PackageVersion>15.5.9227</MicrosoftmacOSSdknet90_155PackageVersion>
     <MicrosoftmacOSSdknet90_265PackageVersion>26.5.9004</MicrosoftmacOSSdknet90_265PackageVersion>
     <MicrosofttvOSSdknet100_260PackageVersion>26.0.11017</MicrosofttvOSSdknet100_260PackageVersion>
-    <MicrosofttvOSSdknet100_270PackageVersion>27.0.10539-xcode27.0</MicrosofttvOSSdknet100_270PackageVersion>
+    <MicrosofttvOSSdknet100_270PackageVersion>27.0.10540-xcode27.0</MicrosofttvOSSdknet100_270PackageVersion>
     <MicrosofttvOSSdknet90_185PackageVersion>18.5.9227</MicrosofttvOSSdknet90_185PackageVersion>
     <MicrosofttvOSSdknet90_265PackageVersion>26.5.9004</MicrosofttvOSSdknet90_265PackageVersion>
     <!-- dotnet-xharness dependencies -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -94,21 +94,21 @@
       <Sha>23eb1c2c9465fe76c810c8a69982c1254161f4b0</Sha>
     </Dependency>
     <!-- This is a subscription of the .NET 10/Xcode 27.0 versions of our packages -->
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_27.0" Version="27.0.10539-xcode27.0">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_27.0" Version="27.0.10540-xcode27.0">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>feb67499296f24185cc71f6d5ec9d101be6f692c</Sha>
+      <Sha>d2751f691ac071bb76bd3ee571879e6c5e977caa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net10.0_27.0" Version="27.0.10539-xcode27.0">
+    <Dependency Name="Microsoft.macOS.Sdk.net10.0_27.0" Version="27.0.10540-xcode27.0">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>feb67499296f24185cc71f6d5ec9d101be6f692c</Sha>
+      <Sha>d2751f691ac071bb76bd3ee571879e6c5e977caa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net10.0_27.0" Version="27.0.10539-xcode27.0">
+    <Dependency Name="Microsoft.iOS.Sdk.net10.0_27.0" Version="27.0.10540-xcode27.0">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>feb67499296f24185cc71f6d5ec9d101be6f692c</Sha>
+      <Sha>d2751f691ac071bb76bd3ee571879e6c5e977caa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_27.0" Version="27.0.10539-xcode27.0">
+    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_27.0" Version="27.0.10540-xcode27.0">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>feb67499296f24185cc71f6d5ec9d101be6f692c</Sha>
+      <Sha>d2751f691ac071bb76bd3ee571879e6c5e977caa</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>


### PR DESCRIPTION
Update the Xcode 27.0 SDK subscriptions to BAR build 20260901.9 (329844).

Source branch: xcode27.0
Source commit: d2751f691ac071bb76bd3ee571879e6c5e977caa