### PR TITLE
[dotnet-linker] Escape explicit interface member names

### DIFF
--- a/tests/assembly-preparer/ApplyPreserveAttributeTests.cs
+++ b/tests/assembly-preparer/ApplyPreserveAttributeTests.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Mono.Cecil.Rocks;
+
+namespace AssemblyPreparerTests;
+
+public class ApplyPreserveAttributeTests : BaseClass {
+	[Test]
+	[TestCase (ApplePlatform.MacCatalyst, false)]
+	[TestCase (ApplePlatform.iOS, false)]
+	[TestCase (ApplePlatform.TVOS, false)]
+	[TestCase (ApplePlatform.MacOSX, true)]
+	public void ExplicitInterfaceMembers (ApplePlatform platform, bool isCoreCLR)
+	{
+		var code = @"
+		using System;
+		using Foundation;
+
+		interface IMyInterface {
+			int MyProperty { get; set; }
+			event EventHandler MyEvent;
+		}
+
+		[Preserve (AllMembers = true)]
+		class MyClass : IMyInterface {
+			int IMyInterface.MyProperty { get; set; }
+			event EventHandler IMyInterface.MyEvent {
+				add {}
+				remove {}
+			}
+		}
+		";
+
+		AssertPrepare (platform, isCoreCLR, code, out var assemblyDefinition);
+
+		var moduleConstructor = assemblyDefinition.MainModule.Types.Single (v => v.Name == "<Module>").GetStaticConstructor ();
+		Assert.That (moduleConstructor, Is.Not.Null, "Module constructor");
+		var signatures = moduleConstructor.CustomAttributes
+			.Where (v => v.AttributeType.Name == "DynamicDependencyAttribute")
+			.Where (v => v.ConstructorArguments.Count == 2)
+			.Where (v => v.ConstructorArguments [0].Value is string)
+			.Where (v => ((TypeReference) v.ConstructorArguments [1].Value).FullName == "MyClass")
+			.Select (v => (string) v.ConstructorArguments [0].Value)
+			.ToArray ();
+
+		Assert.That (signatures, Does.Contain ("IMyInterface#MyProperty"), "Property");
+		Assert.That (signatures, Does.Contain ("IMyInterface#MyEvent"), "Event");
+		Assert.That (signatures, Has.None.Contains ("IMyInterface."), "Unescaped explicit interface member");
+	}
+}

--- a/tools/dotnet-linker/AppBundleRewriter.cs
+++ b/tools/dotnet-linker/AppBundleRewriter.cs
@@ -1681,12 +1681,10 @@ namespace Xamarin.Linker {
 				if (!method.HasCustomAttribute ("System.Runtime.CompilerServices", "CompilerGeneratedAttribute"))
 					signatures.Add (DocumentationComments.GetNameSignature (method));
 			}
-			// Properties and events don't have a documentation comment signature helper, but the trimmer will
-			// match any member with the given name, which is good enough (and it's what we want here anyway).
 			foreach (var property in type.Properties)
-				signatures.Add (property.Name);
+				signatures.Add (DocumentationComments.GetSignature (property));
 			foreach (var @event in type.Events)
-				signatures.Add (@event.Name);
+				signatures.Add (DocumentationComments.GetSignature (@event));
 
 			if (signatures.Count == 0) {
 				// The type has no declared members, so add a placeholder member and preserve that,

--- a/tools/dotnet-linker/DocumentionComments.cs
+++ b/tools/dotnet-linker/DocumentionComments.cs
@@ -19,6 +19,12 @@ namespace Xamarin.Utils {
 			if (member is MethodDefinition md)
 				return GetSignature (md);
 
+			if (member is PropertyDefinition pd)
+				return GetSignature (pd);
+
+			if (member is EventDefinition ed)
+				return GetSignature (ed);
+
 			if (member is TypeDefinition td)
 				return GetSignature (td);
 
@@ -35,6 +41,16 @@ namespace Xamarin.Utils {
 		public static string GetSignature (FieldDefinition field)
 		{
 			return field.Name.Replace ('.', '#');
+		}
+
+		public static string GetSignature (PropertyDefinition property)
+		{
+			return property.Name.Replace ('.', '#');
+		}
+
+		public static string GetSignature (EventDefinition @event)
+		{
+			return @event.Name.Replace ('.', '#');
 		}
 
 		public static string GetSignature (MethodDefinition method)


### PR DESCRIPTION
Use documentation-comment escaping for explicit-interface properties and events when generating DynamicDependency attributes. This prevents first-build IL2037 warnings when the member name contains dots.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3057591.


Copilot-Session: a6097bb2-1e91-4dd7-ab9b-fa4a7ab070a0