### PR TITLE
[xharness] Bump assembly-preparer test timeout to 30 minutes.

### DIFF
--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -355,7 +355,7 @@ namespace Xharness {
 					Label = TestLabel.AssemblyProcessing,
 					ProjectPath = Path.GetFullPath (Path.Combine (HarnessConfiguration.RootDirectory, "assembly-preparer", "assembly-preparer-tests.csproj")),
 					Name = "Assembly processing tests",
-					Timeout = (TimeSpan?) TimeSpan.FromMinutes (10),
+					Timeout = (TimeSpan?) TimeSpan.FromMinutes (30),
 					Filter = "",
 				},
 				new {


### PR DESCRIPTION

Increase the xharness timeout for assembly-preparer tests from 10 to 30 minutes to accommodate longer-running test execution.

Fixes https://github.com/dotnet/macios/issues/26528.

🤖 Pull request created by Copilot