### PR TITLE
[xcode27.0][Signing] Sign new Xamarin.Messaging dependencies

### DIFF
--- a/dotnet/Workloads/SignList.xml
+++ b/dotnet/Workloads/SignList.xml
@@ -143,6 +143,8 @@
     <!-- Xamarin.Messaging -->
     <FirstParty Include="Merq.dll" />
     <FirstParty Include="Merq.Core.dll" />
+    <FirstParty Include="Microsoft.Extensions.DependencyInjection.Abstractions.dll" />
+    <FirstParty Include="Microsoft.Extensions.Logging.Abstractions.dll" />
     <!-- Broker.zip -->
     <FirstParty Include="Broker.exe" />
     <FirstParty Include="Broker.resources.dll" />


### PR DESCRIPTION
The Xamarin.Messaging 18.11.15 update adds
Microsoft.Extensions.DependencyInjection.Abstractions.dll and Microsoft.Extensions.Logging.Abstractions.dll to the net10.0 MSBuild tools in each workload pack.

The signing pipeline rejected these unsigned assemblies because they were not classified in SignList.xml, causing the Sign Package Contents task to fail in Azure DevOps build 15183644.

Classify both assemblies as first-party so the iOS, tvOS, macOS, and Mac Catalyst workload packages include them in package signing.