### PR TITLE
[AppKit] Document ten AppKit enum types

### DIFF
--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -1929,12 +1929,13 @@ namespace AppKit {
 	#endregion
 
 	#region NSRulerView
+	/// <summary>Specifies the orientation of a ruler view.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSRulerOrientation : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>A horizontal ruler.</summary>
 		Horizontal,
-		/// <summary>To be added.</summary>
+		/// <summary>A vertical ruler.</summary>
 		Vertical,
 	}
 	#endregion

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2147,14 +2147,15 @@ namespace AppKit {
 		Downstream,
 	}
 
+	/// <summary>Specifies the unit used when modifying a text selection.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSSelectionGranularity : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Selects text by character.</summary>
 		Character,
-		/// <summary>To be added.</summary>
+		/// <summary>Selects text by word.</summary>
 		Word,
-		/// <summary>To be added.</summary>
+		/// <summary>Selects text by paragraph.</summary>
 		Paragraph,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2297,12 +2297,13 @@ namespace AppKit {
 		BigEndian32Bit = 1 << 11,
 	}
 
+	/// <summary>Specifies the orientation of printed pages.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSPrintingOrientation : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Prints pages in portrait orientation.</summary>
 		Portrait,
-		/// <summary>To be added.</summary>
+		/// <summary>Prints pages in landscape orientation.</summary>
 		Landscape,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2201,18 +2201,19 @@ namespace AppKit {
 		NSLineSweepUp,
 	}
 
+	/// <summary>Specifies the direction in which text layout moves between lines.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSLineMovementDirection : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Does not move between lines.</summary>
 		None,
-		/// <summary>To be added.</summary>
+		/// <summary>Moves to the left.</summary>
 		Left,
-		/// <summary>To be added.</summary>
+		/// <summary>Moves to the right.</summary>
 		Right,
-		/// <summary>To be added.</summary>
+		/// <summary>Moves downward.</summary>
 		Down,
-		/// <summary>To be added.</summary>
+		/// <summary>Moves upward.</summary>
 		Up,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -1879,14 +1879,15 @@ namespace AppKit {
 
 	#region NSBezelPath
 
+	/// <summary>Specifies the shape of the endpoints of an open path.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSLineCapStyle : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Ends the path at the endpoint.</summary>
 		Butt,
-		/// <summary>To be added.</summary>
+		/// <summary>Uses a semicircular cap centered on the endpoint.</summary>
 		Round,
-		/// <summary>To be added.</summary>
+		/// <summary>Uses a square cap that extends beyond the endpoint.</summary>
 		Square,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -1903,12 +1903,13 @@ namespace AppKit {
 		Bevel,
 	}
 
+	/// <summary>Specifies the rule used to determine which areas of a path are filled.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSWindingRule : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Fills areas using the nonzero winding rule.</summary>
 		NonZero,
-		/// <summary>To be added.</summary>
+		/// <summary>Fills areas using the even-odd winding rule.</summary>
 		EvenOdd,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -1891,14 +1891,15 @@ namespace AppKit {
 		Square,
 	}
 
+	/// <summary>Specifies the shape used to join connected path segments.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSLineJoinStyle : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Joins segments by extending their outer edges until they meet.</summary>
 		Miter,
-		/// <summary>To be added.</summary>
+		/// <summary>Joins segments with a rounded corner.</summary>
 		Round,
-		/// <summary>To be added.</summary>
+		/// <summary>Joins segments with a beveled corner.</summary>
 		Bevel,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2307,14 +2307,15 @@ namespace AppKit {
 		Landscape,
 	}
 
+	/// <summary>Specifies how content is adjusted when it exceeds a printed page.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSPrintingPaginationMode : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Automatically determines how to paginate the content.</summary>
 		Auto,
-		/// <summary>To be added.</summary>
+		/// <summary>Scales the content to fit the page.</summary>
 		Fit,
-		/// <summary>To be added.</summary>
+		/// <summary>Clips content that extends beyond the page.</summary>
 		Clip,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2307,15 +2307,15 @@ namespace AppKit {
 		Landscape,
 	}
 
-	/// <summary>Specifies how content is adjusted when it exceeds a printed page.</summary>
+	/// <summary>Specifies how printed content is paginated along one axis.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSPrintingPaginationMode : ulong {
-		/// <summary>Automatically determines how to paginate the content.</summary>
+		/// <summary>Divides the content into equal-sized page rectangles.</summary>
 		Auto,
-		/// <summary>Scales the content to fit the page.</summary>
+		/// <summary>Scales the content to produce one row or column of pages.</summary>
 		Fit,
-		/// <summary>Clips content that extends beyond the page.</summary>
+		/// <summary>Clips the content to produce one row or column of pages.</summary>
 		Clip,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2187,16 +2187,17 @@ namespace AppKit {
 	}
 	#endregion
 
+	/// <summary>Specifies the direction in which text layout sweeps across a line.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSLineSweepDirection : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Sweeps toward the left.</summary>
 		NSLineSweepLeft,
-		/// <summary>To be added.</summary>
+		/// <summary>Sweeps toward the right.</summary>
 		NSLineSweepRight,
-		/// <summary>To be added.</summary>
+		/// <summary>Sweeps downward.</summary>
 		NSLineSweepDown,
-		/// <summary>To be added.</summary>
+		/// <summary>Sweeps upward.</summary>
 		NSLineSweepUp,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2137,12 +2137,13 @@ namespace AppKit {
 		DashDotDot = 0x0400,
 	}
 
+	/// <summary>Specifies the direction associated with a selection at a line boundary.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSSelectionAffinity : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>The selection is associated with the preceding line.</summary>
 		Upstream,
-		/// <summary>To be added.</summary>
+		/// <summary>The selection is associated with the following line.</summary>
 		Downstream,
 	}
 

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22527,7 +22527,6 @@ T:AppKit.NSLevelIndicatorPlaceholderVisibility
 T:AppKit.NSLevelIndicatorStyle
 T:AppKit.NSLineBreakMode
 T:AppKit.NSLineBreakStrategy
-T:AppKit.NSLineJoinStyle
 T:AppKit.NSLineMovementDirection
 T:AppKit.NSLineSweepDirection
 T:AppKit.NSMatrixMode

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22798,7 +22798,6 @@ T:AppKit.NSViewResizingMask
 T:AppKit.NSVisualEffectBlendingMode
 T:AppKit.NSVisualEffectMaterial
 T:AppKit.NSVisualEffectState
-T:AppKit.NSWindingRule
 T:AppKit.NSWindowAnimationBehavior
 T:AppKit.NSWindowApplicationPresentationOptions
 T:AppKit.NSWindowBackingLocation

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22598,7 +22598,6 @@ T:AppKit.NSRulerEditorChildCriterion
 T:AppKit.NSRulerEditorDisplayValue
 T:AppKit.NSRulerEditorPredicateParts
 T:AppKit.NSRulerMarkerClientViewDelegation
-T:AppKit.NSRulerOrientation
 T:AppKit.NSRulerViewUnits
 T:AppKit.NSRunResponse
 T:AppKit.NSSaveOperationType

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22527,7 +22527,6 @@ T:AppKit.NSLevelIndicatorPlaceholderVisibility
 T:AppKit.NSLevelIndicatorStyle
 T:AppKit.NSLineBreakMode
 T:AppKit.NSLineBreakStrategy
-T:AppKit.NSLineCapStyle
 T:AppKit.NSLineJoinStyle
 T:AppKit.NSLineMovementDirection
 T:AppKit.NSLineSweepDirection

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22528,7 +22528,6 @@ T:AppKit.NSLevelIndicatorStyle
 T:AppKit.NSLineBreakMode
 T:AppKit.NSLineBreakStrategy
 T:AppKit.NSLineMovementDirection
-T:AppKit.NSLineSweepDirection
 T:AppKit.NSMatrixMode
 T:AppKit.NSMenuItemBadgeType
 T:AppKit.NSMenuPresentationStyle

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22616,7 +22616,6 @@ T:AppKit.NSSegmentDistribution
 T:AppKit.NSSegmentStyle
 T:AppKit.NSSegmentSwitchTracking
 T:AppKit.NSSelectionDirection
-T:AppKit.NSSelectionGranularity
 T:AppKit.NSSharingCollaborationMode
 T:AppKit.NSSharingContentScope
 T:AppKit.NSSharingServiceAnchoringViewForSharingService

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22576,7 +22576,6 @@ T:AppKit.NSPopoverBehavior
 T:AppKit.NSPopUpArrowPosition
 T:AppKit.NSPressureBehavior
 T:AppKit.NSPrinterTableStatus
-T:AppKit.NSPrintingOrientation
 T:AppKit.NSPrintingPageOrder
 T:AppKit.NSPrintingPaginationMode
 T:AppKit.NSPrintPanelOptions

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22615,7 +22615,6 @@ T:AppKit.NSSegmentBackgroundStyle_NSSegmentedCell
 T:AppKit.NSSegmentDistribution
 T:AppKit.NSSegmentStyle
 T:AppKit.NSSegmentSwitchTracking
-T:AppKit.NSSelectionAffinity
 T:AppKit.NSSelectionDirection
 T:AppKit.NSSelectionGranularity
 T:AppKit.NSSharingCollaborationMode

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22577,7 +22577,6 @@ T:AppKit.NSPopUpArrowPosition
 T:AppKit.NSPressureBehavior
 T:AppKit.NSPrinterTableStatus
 T:AppKit.NSPrintingPageOrder
-T:AppKit.NSPrintingPaginationMode
 T:AppKit.NSPrintPanelOptions
 T:AppKit.NSPrintPanelResult
 T:AppKit.NSPrintRenderingQuality

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22527,7 +22527,6 @@ T:AppKit.NSLevelIndicatorPlaceholderVisibility
 T:AppKit.NSLevelIndicatorStyle
 T:AppKit.NSLineBreakMode
 T:AppKit.NSLineBreakStrategy
-T:AppKit.NSLineMovementDirection
 T:AppKit.NSMatrixMode
 T:AppKit.NSMenuItemBadgeType
 T:AppKit.NSMenuPresentationStyle


### PR DESCRIPTION
Document ten AppKit enum types and all their members:

- `NSLineCapStyle`
- `NSLineJoinStyle`
- `NSWindingRule`
- `NSRulerOrientation`
- `NSSelectionAffinity`
- `NSSelectionGranularity`
- `NSLineSweepDirection`
- `NSLineMovementDirection`
- `NSPrintingOrientation`
- `NSPrintingPaginationMode`

Remove the corresponding entries from the Cecil documentation known-failures baseline.

The batch contains one initial commit per type and stays within the 100-line change budget.

🤖 Pull request created by Copilot