### PR TITLE
[devops] Don't be lenient with bash failures.

### DIFF
--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -71,8 +71,7 @@ steps:
   displayName: 'Fix device discovery (reset launchctl)'
 
 - bash: |
-    make -C src build/generator-frameworks.g.cs
-    make -C src build/ios/Constants.cs
+    set -ex
     make -C msbuild Versions.g.cs
   workingDirectory: $(System.DefaultWorkingDirectory)/$(BUILD_REPOSITORY_TITLE)
   displayName: Generate constants files 


### PR DESCRIPTION
For the 'Generate constants files' step:

* Call 'set -ex' to fail for any failure.
* Remove commands that fail.