### PR TITLE
[AppKit] Document ten more AppKit enum types

### DIFF
--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -303,12 +303,13 @@ namespace AppKit {
 		MaxYEdge,
 	}
 
+	/// <summary>Specifies the layout direction of the user interface.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSUserInterfaceLayoutDirection : long {
-		/// <summary>To be added.</summary>
+		/// <summary>Arranges interface elements from left to right.</summary>
 		LeftToRight,
-		/// <summary>To be added.</summary>
+		/// <summary>Arranges interface elements from right to left.</summary>
 		RightToLeft,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2396,16 +2396,17 @@ namespace AppKit {
 		DecrementArrow,
 	}
 
+	/// <summary>Specifies the order in which pages are printed.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSPrintingPageOrder : long {
-		/// <summary>To be added.</summary>
+		/// <summary>Prints pages in descending order.</summary>
 		Descending = -1,
-		/// <summary>To be added.</summary>
+		/// <summary>Prints pages using an application-defined order.</summary>
 		Special,
-		/// <summary>To be added.</summary>
+		/// <summary>Prints pages in ascending order.</summary>
 		Ascending,
-		/// <summary>To be added.</summary>
+		/// <summary>The page order is unknown.</summary>
 		Unknown,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -1755,16 +1755,17 @@ namespace AppKit {
 	#endregion
 
 	#region NSMatrix
+	/// <summary>Specifies how a matrix tracks and selects its cells.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSMatrixMode : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Allows a single cell to be selected at a time.</summary>
 		Radio,
-		/// <summary>To be added.</summary>
+		/// <summary>Highlights cells during interaction.</summary>
 		Highlight,
-		/// <summary>To be added.</summary>
+		/// <summary>Provides list-style cell selection.</summary>
 		List,
-		/// <summary>To be added.</summary>
+		/// <summary>Tracks interaction within individual cells.</summary>
 		Track,
 	}
 	#endregion

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -1761,11 +1761,11 @@ namespace AppKit {
 	public enum NSMatrixMode : ulong {
 		/// <summary>Allows a single cell to be selected at a time.</summary>
 		Radio,
-		/// <summary>Highlights cells during interaction.</summary>
+		/// <summary>Highlights a cell while asking it to track the mouse.</summary>
 		Highlight,
-		/// <summary>Provides list-style cell selection.</summary>
+		/// <summary>Highlights cells without asking them to track the mouse.</summary>
 		List,
-		/// <summary>Tracks interaction within individual cells.</summary>
+		/// <summary>Allows individual cells to track the mouse.</summary>
 		Track,
 	}
 	#endregion

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -585,12 +585,13 @@ namespace AppKit {
 		Never,
 	}
 
+	/// <summary>Specifies how an image is resized to fill its destination.</summary>
 	[NoMacCatalyst]
 	[Native (ConvertToNative = "NSImageResizingModeExtensions.ToNative", ConvertToManaged = "NSImageResizingModeExtensions.ToManaged")]
 	public enum NSImageResizingMode : long {
-		/// <summary>To be added.</summary>
+		/// <summary>Stretches the image to fill the destination.</summary>
 		Stretch,
-		/// <summary>To be added.</summary>
+		/// <summary>Tiles the image to fill the destination.</summary>
 		Tile,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -610,18 +610,19 @@ namespace AppKit {
 		Critical,
 	}
 
+	/// <summary>Specifies a response returned by a modal session.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSModalResponse : long {
-		/// <summary>To be added.</summary>
+		/// <summary>Indicates that the user accepted the modal session.</summary>
 		OK = 1,
-		/// <summary>To be added.</summary>
+		/// <summary>Indicates that the user canceled the modal session.</summary>
 		Cancel = 0,
-		/// <summary>To be added.</summary>
+		/// <summary>Indicates that the modal session should stop.</summary>
 		Stop = -1000,
-		/// <summary>To be added.</summary>
+		/// <summary>Indicates that the modal session should abort.</summary>
 		Abort = -1001,
-		/// <summary>To be added.</summary>
+		/// <summary>Indicates that the modal session should continue.</summary>
 		Continue = -1002,
 	}
 	#endregion

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -262,14 +262,15 @@ namespace AppKit {
 		RingAbove,
 	}
 
+	/// <summary>Specifies the focus ring displayed by a control.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSFocusRingType : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Uses the default focus ring.</summary>
 		Default,
-		/// <summary>To be added.</summary>
+		/// <summary>Does not display a focus ring.</summary>
 		None,
-		/// <summary>To be added.</summary>
+		/// <summary>Displays a focus ring outside the control.</summary>
 		Exterior,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2400,11 +2400,11 @@ namespace AppKit {
 	[NoMacCatalyst]
 	[Native]
 	public enum NSPrintingPageOrder : long {
-		/// <summary>Prints pages in descending order.</summary>
+		/// <summary>Prints pages from front to back.</summary>
 		Descending = -1,
-		/// <summary>Prints pages using an application-defined order.</summary>
+		/// <summary>Prints pages in the order received by the spooler without rearranging them.</summary>
 		Special,
-		/// <summary>Prints pages in ascending order.</summary>
+		/// <summary>Prints pages from back to front.</summary>
 		Ascending,
 		/// <summary>The page order is unknown.</summary>
 		Unknown,

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -461,14 +461,15 @@ namespace AppKit {
 		ProportionallyUpOrDown,
 	}
 
+	/// <summary>Specifies the state of a cell.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSCellStateValue : long {
-		/// <summary>To be added.</summary>
+		/// <summary>The cell has a mixed state.</summary>
 		Mixed = -1,
-		/// <summary>To be added.</summary>
+		/// <summary>The cell is off.</summary>
 		Off,
-		/// <summary>To be added.</summary>
+		/// <summary>The cell is on.</summary>
 		On,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -238,14 +238,15 @@ namespace AppKit {
 		Buffered,
 	}
 
+	/// <summary>Specifies how a window is ordered relative to other windows.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSWindowOrderingMode : long {
-		/// <summary>To be added.</summary>
+		/// <summary>Orders the window below another window.</summary>
 		Below = -1,
-		/// <summary>To be added.</summary>
+		/// <summary>Removes the window from the screen.</summary>
 		Out,
-		/// <summary>To be added.</summary>
+		/// <summary>Orders the window above another window.</summary>
 		Above,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -250,14 +250,15 @@ namespace AppKit {
 		Above,
 	}
 
+	/// <summary>Specifies where a focus ring is drawn relative to content.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSFocusRingPlacement : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Draws only the focus ring.</summary>
 		RingOnly,
-		/// <summary>To be added.</summary>
+		/// <summary>Draws the focus ring below the content.</summary>
 		RingBelow,
-		/// <summary>To be added.</summary>
+		/// <summary>Draws the focus ring above the content.</summary>
 		RingAbove,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -1771,14 +1771,15 @@ namespace AppKit {
 	#endregion
 
 	#region NSBrowser
+	/// <summary>Specifies how browser columns can be resized.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSBrowserColumnResizingType : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Prevents columns from being resized.</summary>
 		None,
-		/// <summary>To be added.</summary>
+		/// <summary>Automatically resizes columns.</summary>
 		Auto,
-		/// <summary>To be added.</summary>
+		/// <summary>Allows the user to resize columns.</summary>
 		User,
 	}
 

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22776,7 +22776,6 @@ T:AppKit.NSTypesetterBehavior
 T:AppKit.NSTypesetterControlCharacterAction
 T:AppKit.NSUnderlinePattern
 T:AppKit.NSUsableScrollerParts
-T:AppKit.NSUserInterfaceLayoutDirection
 T:AppKit.NSUserInterfaceLayoutOrientation
 T:AppKit.NSVerticalDirections
 T:AppKit.NSView_NSCandidateListTouchBarItem

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22469,7 +22469,6 @@ T:AppKit.NSEventSubtype
 T:AppKit.NSEventSwipeTrackingOptions
 T:AppKit.NSEventTrackHandler
 T:AppKit.NSEventType
-T:AppKit.NSFocusRingType
 T:AppKit.NSFontCollectionVisibility
 T:AppKit.NSFontDescriptorSystemDesign
 T:AppKit.NSFontError

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22569,7 +22569,6 @@ T:AppKit.NSPopoverBehavior
 T:AppKit.NSPopUpArrowPosition
 T:AppKit.NSPressureBehavior
 T:AppKit.NSPrinterTableStatus
-T:AppKit.NSPrintingPageOrder
 T:AppKit.NSPrintPanelOptions
 T:AppKit.NSPrintPanelResult
 T:AppKit.NSPrintRenderingQuality

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22394,7 +22394,6 @@ T:AppKit.NSBindingOptions
 T:AppKit.NSBitmapFormat
 T:AppKit.NSBitmapImageFileType
 T:AppKit.NSBoxType
-T:AppKit.NSBrowserColumnResizingType
 T:AppKit.NSButtonType
 T:AppKit.NSCellAttribute
 T:AppKit.NSCellHit

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22806,7 +22806,6 @@ T:AppKit.NSWindowLevel
 T:AppKit.NSWindowMenu
 T:AppKit.NSWindowNSWindow
 T:AppKit.NSWindowNumberListOptions
-T:AppKit.NSWindowOrderingMode
 T:AppKit.NSWindowResize
 T:AppKit.NSWindowSharingType
 T:AppKit.NSWindowSheetRect

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22469,7 +22469,6 @@ T:AppKit.NSEventSubtype
 T:AppKit.NSEventSwipeTrackingOptions
 T:AppKit.NSEventTrackHandler
 T:AppKit.NSEventType
-T:AppKit.NSFocusRingPlacement
 T:AppKit.NSFocusRingType
 T:AppKit.NSFontCollectionVisibility
 T:AppKit.NSFontDescriptorSystemDesign

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22399,7 +22399,6 @@ T:AppKit.NSButtonType
 T:AppKit.NSCellAttribute
 T:AppKit.NSCellHit
 T:AppKit.NSCellImagePosition
-T:AppKit.NSCellStateValue
 T:AppKit.NSCellStyleMask
 T:AppKit.NSCharacterCollection
 T:AppKit.NSCloudKitSharingServiceOptions

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22523,7 +22523,6 @@ T:AppKit.NSLevelIndicatorPlaceholderVisibility
 T:AppKit.NSLevelIndicatorStyle
 T:AppKit.NSLineBreakMode
 T:AppKit.NSLineBreakStrategy
-T:AppKit.NSMatrixMode
 T:AppKit.NSMenuItemBadgeType
 T:AppKit.NSMenuPresentationStyle
 T:AppKit.NSMenuProperty

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22509,7 +22509,6 @@ T:AppKit.NSImageLoadStatus
 T:AppKit.NSImageName
 T:AppKit.NSImageRect
 T:AppKit.NSImageRepLoadStatus
-T:AppKit.NSImageResizingMode
 T:AppKit.NSImageResizingModeExtensions
 T:AppKit.NSImageScale
 T:AppKit.NSImageScaling

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22528,7 +22528,6 @@ T:AppKit.NSMenuItemBadgeType
 T:AppKit.NSMenuPresentationStyle
 T:AppKit.NSMenuProperty
 T:AppKit.NSMenuSelectionMode
-T:AppKit.NSModalResponse
 T:AppKit.NSMutableAttributedStringAppKitAddons
 T:AppKit.NSObject_NSEditorRegistration
 T:AppKit.NSObject_NSFontPanelValidationAdditions


### PR DESCRIPTION
Document ten AppKit enum types and all their members:

- `NSWindowOrderingMode`
- `NSFocusRingPlacement`
- `NSFocusRingType`
- `NSUserInterfaceLayoutDirection`
- `NSCellStateValue`
- `NSImageResizingMode`
- `NSModalResponse`
- `NSMatrixMode`
- `NSBrowserColumnResizingType`
- `NSPrintingPageOrder`

Remove the corresponding entries from the Cecil documentation known-failures baseline.

The batch contains one initial commit per type and stays within the 100-line change budget.

🤖 Pull request created by Copilot