### PR TITLE
[AppKit] Document ten more AppKit enum types

### DIFF
--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2688,15 +2688,16 @@ namespace AppKit {
 		DashedHorizontalGridLine = 1 << 3,
 	}
 
+	/// <summary>Specifies how a gradient extends beyond its starting and ending locations.</summary>
 	[NoMacCatalyst]
 	[Flags]
 	[Native]
 	public enum NSGradientDrawingOptions : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Does not extend the gradient beyond its starting or ending location.</summary>
 		None = 0,
-		/// <summary>To be added.</summary>
+		/// <summary>Extends the gradient before its starting location using the starting color.</summary>
 		BeforeStartingLocation = (1 << 0),
-		/// <summary>To be added.</summary>
+		/// <summary>Extends the gradient after its ending location using the ending color.</summary>
 		AfterEndingLocation = (1 << 1),
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2432,12 +2432,13 @@ namespace AppKit {
 		ShowsPreview = 131072,
 	}
 
+	/// <summary>Specifies how a text block value is interpreted.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSTextBlockValueType : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>The value is an absolute number of points.</summary>
 		Absolute,
-		/// <summary>To be added.</summary>
+		/// <summary>The value is a percentage of the containing text block.</summary>
 		Percentage,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2486,12 +2486,13 @@ namespace AppKit {
 		Baseline,
 	}
 
+	/// <summary>Specifies how a text table calculates column widths.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSTextTableLayoutAlgorithm : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Calculates column widths based on the table's contents.</summary>
 		Automatic,
-		/// <summary>To be added.</summary>
+		/// <summary>Uses the table's specified column widths without considering its contents.</summary>
 		Fixed,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2598,14 +2598,15 @@ namespace AppKit {
 		Label,
 	}
 
+	/// <summary>Specifies the size of toolbar items.</summary>
 	[MacCatalyst (13, 1)]
 	[Native]
 	public enum NSToolbarSizeMode : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Uses the toolbar's default item size.</summary>
 		Default,
-		/// <summary>To be added.</summary>
+		/// <summary>Uses regular-sized toolbar items.</summary>
 		Regular,
-		/// <summary>To be added.</summary>
+		/// <summary>Uses small toolbar items.</summary>
 		Small,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2472,16 +2472,17 @@ namespace AppKit {
 		Margin,
 	}
 
+	/// <summary>Specifies the vertical alignment of content in a text block.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSTextBlockVerticalAlignment : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Aligns content with the top of the text block.</summary>
 		Top,
-		/// <summary>To be added.</summary>
+		/// <summary>Centers content vertically in the text block.</summary>
 		Middle,
-		/// <summary>To be added.</summary>
+		/// <summary>Aligns content with the bottom of the text block.</summary>
 		Bottom,
-		/// <summary>To be added.</summary>
+		/// <summary>Aligns content with the text block's baseline.</summary>
 		Baseline,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2651,12 +2651,13 @@ namespace AppKit {
 		FeedbackStyleGap = 2,
 	}
 
+	/// <summary>Specifies where a table view performs a drop operation.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSTableViewDropOperation : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Performs the drop on the specified row.</summary>
 		On,
-		/// <summary>To be added.</summary>
+		/// <summary>Performs the drop above the specified row.</summary>
 		Above,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2460,14 +2460,15 @@ namespace AppKit {
 		MaximumHeight = 6,
 	}
 
+	/// <summary>Identifies a layer of a text block.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSTextBlockLayer : long {
-		/// <summary>To be added.</summary>
+		/// <summary>The padding layer between the text and the border.</summary>
 		Padding = -1,
-		/// <summary>To be added.</summary>
+		/// <summary>The border layer surrounding the padding.</summary>
 		Border,
-		/// <summary>To be added.</summary>
+		/// <summary>The margin layer outside the border.</summary>
 		Margin,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2584,16 +2584,17 @@ namespace AppKit {
 		WritingPromised = 1 << 9,
 	}
 
+	/// <summary>Specifies how a toolbar displays its items.</summary>
 	[MacCatalyst (13, 1)]
 	[Native]
 	public enum NSToolbarDisplayMode : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Uses the toolbar's default display mode.</summary>
 		Default,
-		/// <summary>To be added.</summary>
+		/// <summary>Displays both the icon and label for each toolbar item.</summary>
 		IconAndLabel,
-		/// <summary>To be added.</summary>
+		/// <summary>Displays only the icon for each toolbar item.</summary>
 		Icon,
-		/// <summary>To be added.</summary>
+		/// <summary>Displays only the label for each toolbar item.</summary>
 		Label,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2442,20 +2442,21 @@ namespace AppKit {
 		Percentage,
 	}
 
+	/// <summary>Identifies a dimension of a text block.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSTextBlockDimension : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>The text block's width.</summary>
 		Width = 0,
-		/// <summary>To be added.</summary>
+		/// <summary>The minimum width of the text block.</summary>
 		MinimumWidth = 1,
-		/// <summary>To be added.</summary>
+		/// <summary>The maximum width of the text block.</summary>
 		MaximumWidth = 2,
-		/// <summary>To be added.</summary>
+		/// <summary>The text block's height.</summary>
 		Height = 4,
-		/// <summary>To be added.</summary>
+		/// <summary>The minimum height of the text block.</summary>
 		MinimumHeight = 5,
-		/// <summary>To be added.</summary>
+		/// <summary>The maximum height of the text block.</summary>
 		MaximumHeight = 6,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2661,15 +2661,16 @@ namespace AppKit {
 		Above,
 	}
 
+	/// <summary>Specifies how a table column can be resized.</summary>
 	[NoMacCatalyst]
 	[Flags]
 	[Native]
 	public enum NSTableColumnResizing : long {
-		/// <summary>To be added.</summary>
+		/// <summary>Disables resizing for the table column.</summary>
 		None = -1,
-		/// <summary>To be added.</summary>
+		/// <summary>Allows the table view to resize the column automatically.</summary>
 		Autoresizing = (1 << 0),
-		/// <summary>To be added.</summary>
+		/// <summary>Allows the user to resize the column.</summary>
 		UserResizingMask = (1 << 1),
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2666,7 +2666,7 @@ namespace AppKit {
 	[Flags]
 	[Native]
 	public enum NSTableColumnResizing : long {
-		/// <summary>Includes all table column resizing options.</summary>
+		/// <summary>Represents -1, which sets all table column resizing option bits.</summary>
 		None = -1,
 		/// <summary>Allows the table view to resize the column automatically.</summary>
 		Autoresizing = (1 << 0),

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2666,7 +2666,7 @@ namespace AppKit {
 	[Flags]
 	[Native]
 	public enum NSTableColumnResizing : long {
-		/// <summary>Disables resizing for the table column.</summary>
+		/// <summary>Includes all table column resizing options.</summary>
 		None = -1,
 		/// <summary>Allows the table view to resize the column automatically.</summary>
 		Autoresizing = (1 << 0),

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22633,7 +22633,6 @@ T:AppKit.NSStringAttributeKey
 T:AppKit.NSStringDrawing_NSAttributedString
 T:AppKit.NSStringDrawing_NSString
 T:AppKit.NSSurfaceOrder
-T:AppKit.NSTableColumnResizing
 T:AppKit.NSTableReorder
 T:AppKit.NSTableRowActionEdge
 T:AppKit.NSTableViewAnimation

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22676,7 +22676,6 @@ T:AppKit.NSTabViewPredicate
 T:AppKit.NSTabViewType
 T:AppKit.NSTextAlignment
 T:AppKit.NSTextAlignmentExtensions
-T:AppKit.NSTextBlockVerticalAlignment
 T:AppKit.NSTextCheckingOptions
 T:AppKit.NSTextContentManagerEnumerationOptions
 T:AppKit.NSTextContentType

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22676,7 +22676,6 @@ T:AppKit.NSTabViewPredicate
 T:AppKit.NSTabViewType
 T:AppKit.NSTextAlignment
 T:AppKit.NSTextAlignmentExtensions
-T:AppKit.NSTextBlockLayer
 T:AppKit.NSTextBlockVerticalAlignment
 T:AppKit.NSTextCheckingOptions
 T:AppKit.NSTextContentManagerEnumerationOptions

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22714,7 +22714,6 @@ T:AppKit.NSTextSelectionNavigationDirection
 T:AppKit.NSTextSelectionNavigationLayoutOrientation
 T:AppKit.NSTextSelectionNavigationModifier
 T:AppKit.NSTextSelectionNavigationWritingDirection
-T:AppKit.NSTextTableLayoutAlgorithm
 T:AppKit.NSTextTabType
 T:AppKit.NSTextView_SharingService
 T:AppKit.NSTextViewCellPasteboard

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22744,7 +22744,6 @@ T:AppKit.NSTitlebarSeparatorStyle
 T:AppKit.NSTitlePosition
 T:AppKit.NSTokenStyle
 T:AppKit.NSToolbarCanInsert
-T:AppKit.NSToolbarDisplayMode
 T:AppKit.NSToolbarIdentifiers
 T:AppKit.NSToolbarImmovableItemIdentifiers
 T:AppKit.NSToolbarItemGroupControlRepresentation

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22678,7 +22678,6 @@ T:AppKit.NSTextAlignment
 T:AppKit.NSTextAlignmentExtensions
 T:AppKit.NSTextBlockDimension
 T:AppKit.NSTextBlockLayer
-T:AppKit.NSTextBlockValueType
 T:AppKit.NSTextBlockVerticalAlignment
 T:AppKit.NSTextCheckingOptions
 T:AppKit.NSTextContentManagerEnumerationOptions

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22676,7 +22676,6 @@ T:AppKit.NSTabViewPredicate
 T:AppKit.NSTabViewType
 T:AppKit.NSTextAlignment
 T:AppKit.NSTextAlignmentExtensions
-T:AppKit.NSTextBlockDimension
 T:AppKit.NSTextBlockLayer
 T:AppKit.NSTextBlockVerticalAlignment
 T:AppKit.NSTextCheckingOptions

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22750,7 +22750,6 @@ T:AppKit.NSToolbarItemGroupControlRepresentation
 T:AppKit.NSToolbarItemGroupSelectionMode
 T:AppKit.NSToolbarItemStyle
 T:AppKit.NSToolbarItemVisibilityPriority
-T:AppKit.NSToolbarSizeMode
 T:AppKit.NSToolbarWillInsert
 T:AppKit.NSTouch_NSTouchBar
 T:AppKit.NSTouchBarItemIdentifier

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22490,7 +22490,6 @@ T:AppKit.NSGLFormat
 T:AppKit.NSGLTextureCubeMap
 T:AppKit.NSGLTextureTarget
 T:AppKit.NSGlyphInscription
-T:AppKit.NSGradientDrawingOptions
 T:AppKit.NSGradientType
 T:AppKit.NSGridCellPlacement
 T:AppKit.NSGridRowAlignment

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22649,7 +22649,6 @@ T:AppKit.NSTableViewDiffableDataSourceCellProvider
 T:AppKit.NSTableViewDiffableDataSourceRowProvider
 T:AppKit.NSTableViewDiffableDataSourceSectionHeaderViewProvider
 T:AppKit.NSTableViewDraggingDestinationFeedbackStyle
-T:AppKit.NSTableViewDropOperation
 T:AppKit.NSTableViewEventString
 T:AppKit.NSTableViewGridStyle
 T:AppKit.NSTableViewIndexFilter


### PR DESCRIPTION
Document ten AppKit enum types and all their members:

- `NSTextBlockValueType`
- `NSTextBlockDimension`
- `NSTextBlockLayer`
- `NSTextBlockVerticalAlignment`
- `NSTextTableLayoutAlgorithm`
- `NSToolbarDisplayMode`
- `NSToolbarSizeMode`
- `NSTableViewDropOperation`
- `NSTableColumnResizing`
- `NSGradientDrawingOptions`

Remove the corresponding Cecil documentation known-failure entries.

🤖 Pull request created by Copilot