### PR TITLE
[msbuild] Copy WriteLinesToFile output to Windows

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1086,18 +1086,7 @@
 		<WriteLinesToFile
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
-			File="$(_CustomLinkerOptionsFile)"
-			Lines="$(_CustomLinkerOptions)"
-			Overwrite="true" />
-
-		<!--
-			When building remotely from Windows, the task above writes the file on the Mac (because it's passed
-			a SessionId), but the PrepareAssemblies task isn't remoted, so it needs the file on the local machine
-			as well. Write it locally too in that case (the contents are identical, since all the properties are
-			evaluated locally in either case).
-		-->
-		<WriteLinesToFile
-			Condition="'$(IsMacEnabled)' == 'true' And '$(BuildSessionId)' != '' And '$(PrepareAssemblies)' == 'true'"
+			CopyToWindows="true"
 			File="$(_CustomLinkerOptionsFile)"
 			Lines="$(_CustomLinkerOptions)"
 			Overwrite="true" />

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/WriteLinesToFile.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/WriteLinesToFile.cs
@@ -6,10 +6,19 @@ using Xamarin.Messaging.Build.Client;
 namespace Microsoft.Build.Tasks {
 	public class WriteLinesToFile : Microsoft_Build_Tasks_Core::Microsoft.Build.Tasks.WriteLinesToFile, IHasSessionId {
 		public string SessionId { get; set; } = string.Empty;
+		public bool CopyToWindows { get; set; }
+
 		public override bool Execute ()
 		{
-			if (this.ShouldExecuteRemotely (SessionId))
-				return XamarinTask.ExecuteRemotely (this);
+			if (this.ShouldExecuteRemotely (SessionId)) {
+				if (!XamarinTask.ExecuteRemotely (this, out var taskRunner))
+					return false;
+
+				if (CopyToWindows)
+					XamarinTask.CopyFilesToWindowsAsync (this, taskRunner, new [] { File }).Wait ();
+
+				return true;
+			}
 
 			return base.Execute ();
 		}

--- a/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/WriteLinesToFile.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/MsBuildTasks/WriteLinesToFile.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Build.Tasks {
 				if (!XamarinTask.ExecuteRemotely (this, out var taskRunner))
 					return false;
 
+				// File isn't an [Output] property, so no empty placeholder is created on Windows.
 				if (CopyToWindows)
 					XamarinTask.CopyFilesToWindowsAsync (this, taskRunner, new [] { File }).Wait ();
 


### PR DESCRIPTION

Add an opt-in `CopyToWindows` property to the remoted `WriteLinesToFile` task so generated files can be copied back from the Mac build host.

Use the new property for the custom linker options file instead of writing identical contents once remotely and once locally.

🤖 Pull request created by Copilot