### PR TITLE
[dotnet] Remove stale template packs when installing. Fixes #26540.

### DIFF
--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -328,6 +328,7 @@ $(DOTNET_PACKS_PATH)/$($(1)_NUGET_REF_NAME)/$2: | $(DOTNET_PACKS_PATH)/$($(1)_NU
 	$$(Q_LN) ln -Fs $$(abspath $(DOTNET_DESTDIR)/$($(1)_NUGET_REF_NAME)) $$(abspath $$@)
 
 $(DOTNET_TEMPLATE_PACKS_PATH)/Microsoft.$1.Templates.$(2).nupkg: $(TEMPLATE_PACKS_$(call uppercase,$(1))) | $(DOTNET_TEMPLATE_PACKS_PATH)
+	$$(Q) rm -f $(DOTNET_TEMPLATE_PACKS_PATH)/Microsoft.$1.Templates.*.nupkg
 	$$(Q) $$(CP) $$< $$@
 
 WORKLOAD_TARGETS += \

--- a/tests/dotnet/UnitTests/TemplateTest.cs
+++ b/tests/dotnet/UnitTests/TemplateTest.cs
@@ -222,6 +222,7 @@ namespace Xamarin.Tests {
 			var outputDir = Path.Combine (tmpDir, info.Template);
 			DotNet.AssertNew (outputDir, info.Template, language: language.AsLanguageIdentifier ());
 			var proj = Path.Combine (outputDir, $"{info.Template}.{language.AsFileExtension ()}");
+			AssertCurrentTargetFramework (proj, info.Platform);
 			var properties = GetDefaultProperties ();
 			var rv = DotNet.AssertBuild (proj, properties);
 			var warnings = BinLog.GetBuildLogWarnings (rv.BinLogPath).FilterWarnings (info.Platform).Select (v => v.Message);
@@ -277,11 +278,12 @@ namespace Xamarin.Tests {
 			var tmpDir = Cache.CreateTemporaryDirectory ();
 			var outputDir = Path.Combine (tmpDir, info.Template);
 			DotNet.AssertNew (outputDir, info.Template, language: language.AsLanguageIdentifier ());
+			var proj = Path.Combine (outputDir, $"{info.Template}.{language.AsFileExtension ()}");
+			AssertCurrentTargetFramework (proj, platform);
 
 			foreach (var item in itemTemplates)
 				DotNet.AssertNew (outputDir, item.Template, "item_" + item.Template, language: language.AsLanguageIdentifier ());
 
-			var proj = Path.Combine (outputDir, $"{info.Template}.{language.AsFileExtension ()}");
 			var properties = GetDefaultProperties ();
 			var rv = DotNet.AssertBuild (proj, properties);
 			var warnings = BinLog.GetBuildLogWarnings (rv.BinLogPath).FilterWarnings (platform).Select (v => v.Message);
@@ -306,6 +308,12 @@ namespace Xamarin.Tests {
 				var appExecutable = GetNativeExecutable (platform, appPath);
 				ExecuteWithMagicWordAndAssert (appExecutable);
 			}
+		}
+
+		static void AssertCurrentTargetFramework (string projectPath, ApplePlatform platform)
+		{
+			var expectedTargetFramework = $"<TargetFramework>{platform.ToFramework (Configuration.DotNetTfm)}</TargetFramework>";
+			Assert.That (File.ReadAllText (projectPath), Does.Contain (expectedTargetFramework), $"The generated project must target the current .NET TFM.");
 		}
 
 		static void InsertCodeToExitAppAfterLaunch (TemplateLanguage language, string outputDir)


### PR DESCRIPTION

Incremental installs copied each new versioned template package into the local SDK without removing older versions. This left duplicate template identities in the template engine cache, which could cause `dotnet new` to select a package targeting an older .NET TFM.

Remove previous versions of each platform's template package before installing the current one. Also assert in the template tests that every generated project targets the current `Configuration.DotNetTfm`.

Fixes https://github.com/dotnet/macios/issues/26540

🤖 Pull request created by Copilot