### PR TITLE
[Foundation] Cache NSObject user type classification.

### DIFF
--- a/runtime/xamarin/main.h
+++ b/runtime/xamarin/main.h
@@ -58,6 +58,8 @@ enum NSObjectFlags {
 	NSObjectFlagsHasManagedRef = 32,
 	// 64, // Used by SoM
 	NSObjectFlagsIsCustomType = 128,
+	NSObjectFlagsKnowsIfIsUserType = 256,
+	NSObjectFlagsIsUserType = 512,
 };
 
 enum XamarinGCHandleType : int {

--- a/runtime/xamarin/main.h
+++ b/runtime/xamarin/main.h
@@ -58,7 +58,7 @@ enum NSObjectFlags {
 	NSObjectFlagsHasManagedRef = 32,
 	// 64, // Used by SoM
 	NSObjectFlagsIsCustomType = 128,
-	NSObjectFlagsKnowsIfIsUserType = 256,
+	NSObjectFlagsIsUserTypeKnown = 256,
 	NSObjectFlagsIsUserType = 512,
 };
 

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -266,6 +266,8 @@ namespace Foundation {
 			HasManagedRef = 32,
 			// 64, // Used by SoM
 			IsCustomType = 128,
+			KnowsIfIsUserType = 256,
+			IsUserType = 512,
 		}
 
 		// Must be kept in sync with the same enum in trampolines.h
@@ -310,6 +312,24 @@ namespace Foundation {
 
 		internal bool InFinalizerQueue {
 			get { return ((flags & Flags.InFinalizerQueue) == Flags.InFinalizerQueue); }
+		}
+
+		bool TryGetIsUserType (NativeHandle handle, out bool isUserType, [NotNullWhen (false)] out string? errorMessage)
+		{
+			var currentFlags = flags;
+			if ((currentFlags & Flags.KnowsIfIsUserType) == Flags.KnowsIfIsUserType) {
+				isUserType = (currentFlags & Flags.IsUserType) == Flags.IsUserType;
+				errorMessage = null;
+				return true;
+			}
+
+			if (!Runtime.TryGetIsUserType (handle, out isUserType, out errorMessage))
+				return false;
+
+			flags = isUserType
+				? flags | Flags.KnowsIfIsUserType | Flags.IsUserType
+				: (flags | Flags.KnowsIfIsUserType) & ~Flags.IsUserType;
+			return true;
 		}
 
 		bool IsCustomType {
@@ -517,7 +537,7 @@ namespace Foundation {
 
 			bool native_ref = (flags & Flags.NativeRef) == Flags.NativeRef;
 
-			if (!Runtime.TryGetIsUserType (handle, out var isUserType, out var error_message))
+			if (!TryGetIsUserType (handle, out var isUserType, out var error_message))
 				throw new InvalidOperationException ($"Unable to create a managed reference for the pointer {handle} whose managed type is {GetType ().FullName} because it wasn't possible to get the class of the pointer: {error_message}");
 
 			// Issue #25861: when we've just alloc'd a user type, defer adding it to the
@@ -543,7 +563,6 @@ namespace Foundation {
 		void CreateManagedRef (bool isUserType, bool retain)
 		{
 			HasManagedRef = true;
-
 			if (isUserType) {
 				var gchandle_flags = XamarinGCHandleFlags.HasManagedRef | XamarinGCHandleFlags.InitialSet;
 				var gchandle = GCHandle.Alloc (this, GCHandleType.WeakTrackResurrection);
@@ -570,7 +589,7 @@ namespace Foundation {
 		// if the ivar is already set.
 		void EnsureManagedReference (NativeHandle newHandle)
 		{
-			if (!Runtime.TryGetIsUserType (newHandle, out var isUserType, out var _) || !isUserType)
+			if (!TryGetIsUserType (newHandle, out var isUserType, out var _) || !isUserType)
 				return;
 			if (Runtime.GetGCHandleForObject (newHandle) != IntPtr.Zero)
 				return;
@@ -597,7 +616,7 @@ namespace Foundation {
 		void ReleaseManagedRef ()
 		{
 			var handle = this.Handle; // Get a copy of the handle, because it will be cleared out when calling Runtime.NativeObjectHasDied, and we still need the handle later.
-			if (!Runtime.TryGetIsUserType (handle, out var user_type, out var error_message))
+			if (!TryGetIsUserType (handle, out var user_type, out var error_message))
 				throw new InvalidOperationException ($"Unable to release the managed reference for the pointer {handle} whose managed type is {GetType ().FullName} because it wasn't possible to get the class of the pointer: {error_message}");
 			HasManagedRef = false;
 			if (!user_type) {
@@ -861,6 +880,7 @@ namespace Foundation {
 						Runtime.UnregisterNSObject (handle, this);
 				}
 
+				flags &= ~(Flags.KnowsIfIsUserType | Flags.IsUserType);
 				handle = value;
 
 				if (handle != IntPtr.Zero)

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -266,7 +266,7 @@ namespace Foundation {
 			HasManagedRef = 32,
 			// 64, // Used by SoM
 			IsCustomType = 128,
-			KnowsIfIsUserType = 256,
+			IsUserTypeKnown = 256,
 			IsUserType = 512,
 		}
 
@@ -314,21 +314,21 @@ namespace Foundation {
 			get { return ((flags & Flags.InFinalizerQueue) == Flags.InFinalizerQueue); }
 		}
 
-		bool TryGetIsUserType (NativeHandle handle, out bool isUserType, [NotNullWhen (false)] out string? errorMessage)
+		bool TryGetIsUserType (NativeHandle handle, out bool isUserType, [NotNullWhen (false)] out string? error_message)
 		{
 			var currentFlags = flags;
-			if ((currentFlags & Flags.KnowsIfIsUserType) == Flags.KnowsIfIsUserType) {
+			if ((currentFlags & Flags.IsUserTypeKnown) == Flags.IsUserTypeKnown) {
 				isUserType = (currentFlags & Flags.IsUserType) == Flags.IsUserType;
-				errorMessage = null;
+				error_message = null;
 				return true;
 			}
 
-			if (!Runtime.TryGetIsUserType (handle, out isUserType, out errorMessage))
+			if (!Runtime.TryGetIsUserType (handle, out isUserType, out error_message))
 				return false;
 
 			flags = isUserType
-				? flags | Flags.KnowsIfIsUserType | Flags.IsUserType
-				: (flags | Flags.KnowsIfIsUserType) & ~Flags.IsUserType;
+				? flags | Flags.IsUserTypeKnown | Flags.IsUserType
+				: (flags | Flags.IsUserTypeKnown) & ~Flags.IsUserType;
 			return true;
 		}
 
@@ -563,6 +563,7 @@ namespace Foundation {
 		void CreateManagedRef (bool isUserType, bool retain)
 		{
 			HasManagedRef = true;
+
 			if (isUserType) {
 				var gchandle_flags = XamarinGCHandleFlags.HasManagedRef | XamarinGCHandleFlags.InitialSet;
 				var gchandle = GCHandle.Alloc (this, GCHandleType.WeakTrackResurrection);
@@ -880,7 +881,7 @@ namespace Foundation {
 						Runtime.UnregisterNSObject (handle, this);
 				}
 
-				flags &= ~(Flags.KnowsIfIsUserType | Flags.IsUserType);
+				flags &= ~(Flags.IsUserTypeKnown | Flags.IsUserType);
 				handle = value;
 
 				if (handle != IntPtr.Zero)

--- a/tests/dotnet/UnitTests/expected/MacCatalyst-CoreCLR-Interpreter-preservedapis.txt
+++ b/tests/dotnet/UnitTests/expected/MacCatalyst-CoreCLR-Interpreter-preservedapis.txt
@@ -581,6 +581,7 @@ Microsoft.MacCatalyst.dll:Foundation.NSObject.set_HasManagedRef(System.Boolean)
 Microsoft.MacCatalyst.dll:Foundation.NSObject.set_IsDirectBinding(System.Boolean)
 Microsoft.MacCatalyst.dll:Foundation.NSObject.set_RemoveFromObjectMap(System.Boolean)
 Microsoft.MacCatalyst.dll:Foundation.NSObject.ToString()
+Microsoft.MacCatalyst.dll:Foundation.NSObject.TryGetIsUserType(ObjCRuntime.NativeHandle, out System.Boolean&, out System.String&)
 Microsoft.MacCatalyst.dll:Foundation.NSObject.xamarin_release_managed_ref(System.IntPtr, System.Byte)
 Microsoft.MacCatalyst.dll:Foundation.NSObject.xamarin_set_gchandle_with_flags_safe(System.IntPtr, System.IntPtr, Foundation.NSObject/XamarinGCHandleFlags, System.IntPtr)
 Microsoft.MacCatalyst.dll:Foundation.NSObject[] Foundation.NSDictionary::Keys()
@@ -593,6 +594,8 @@ Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::H
 Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::InFinalizerQueue
 Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsCustomType
 Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsDirectBinding
+Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsUserType
+Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsUserTypeKnown
 Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::NativeRef
 Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::RegisteredToggleRef
 Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObjectData::flags

--- a/tests/dotnet/UnitTests/expected/MacCatalyst-CoreCLR-R2R-preservedapis.txt
+++ b/tests/dotnet/UnitTests/expected/MacCatalyst-CoreCLR-R2R-preservedapis.txt
@@ -581,6 +581,7 @@ Microsoft.MacCatalyst.dll:Foundation.NSObject.set_HasManagedRef(System.Boolean)
 Microsoft.MacCatalyst.dll:Foundation.NSObject.set_IsDirectBinding(System.Boolean)
 Microsoft.MacCatalyst.dll:Foundation.NSObject.set_RemoveFromObjectMap(System.Boolean)
 Microsoft.MacCatalyst.dll:Foundation.NSObject.ToString()
+Microsoft.MacCatalyst.dll:Foundation.NSObject.TryGetIsUserType(ObjCRuntime.NativeHandle, out System.Boolean&, out System.String&)
 Microsoft.MacCatalyst.dll:Foundation.NSObject.xamarin_release_managed_ref(System.IntPtr, System.Byte)
 Microsoft.MacCatalyst.dll:Foundation.NSObject.xamarin_set_gchandle_with_flags_safe(System.IntPtr, System.IntPtr, Foundation.NSObject/XamarinGCHandleFlags, System.IntPtr)
 Microsoft.MacCatalyst.dll:Foundation.NSObject[] Foundation.NSDictionary::Keys()
@@ -593,6 +594,8 @@ Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::H
 Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::InFinalizerQueue
 Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsCustomType
 Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsDirectBinding
+Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsUserType
+Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsUserTypeKnown
 Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::NativeRef
 Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::RegisteredToggleRef
 Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObjectData::flags

--- a/tests/dotnet/UnitTests/expected/MacCatalyst-MonoVM-interpreter-preservedapis.txt
+++ b/tests/dotnet/UnitTests/expected/MacCatalyst-MonoVM-interpreter-preservedapis.txt
@@ -167,6 +167,7 @@ Microsoft.MacCatalyst.dll:Foundation.NSObject.set_HasManagedRef(System.Boolean)
 Microsoft.MacCatalyst.dll:Foundation.NSObject.set_IsDirectBinding(System.Boolean)
 Microsoft.MacCatalyst.dll:Foundation.NSObject.set_RemoveFromObjectMap(System.Boolean)
 Microsoft.MacCatalyst.dll:Foundation.NSObject.ToString()
+Microsoft.MacCatalyst.dll:Foundation.NSObject.TryGetIsUserType(ObjCRuntime.NativeHandle, out System.Boolean&, out System.String&)
 Microsoft.MacCatalyst.dll:Foundation.NSObject.xamarin_release_managed_ref(System.IntPtr, System.Byte)
 Microsoft.MacCatalyst.dll:Foundation.NSObject.xamarin_set_gchandle_with_flags_safe(System.IntPtr, System.IntPtr, Foundation.NSObject/XamarinGCHandleFlags, System.IntPtr)
 Microsoft.MacCatalyst.dll:Foundation.NSObject[] Foundation.NSDictionary::Keys()
@@ -178,6 +179,8 @@ Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::H
 Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::InFinalizerQueue
 Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsCustomType
 Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsDirectBinding
+Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsUserType
+Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsUserTypeKnown
 Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::NativeRef
 Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::RegisteredToggleRef
 Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObjectData::flags

--- a/tests/dotnet/UnitTests/expected/MacCatalyst-MonoVM-preservedapis.txt
+++ b/tests/dotnet/UnitTests/expected/MacCatalyst-MonoVM-preservedapis.txt
@@ -150,6 +150,7 @@ Microsoft.MacCatalyst.dll:Foundation.NSObject.set_Handle(ObjCRuntime.NativeHandl
 Microsoft.MacCatalyst.dll:Foundation.NSObject.set_HasManagedRef(System.Boolean)
 Microsoft.MacCatalyst.dll:Foundation.NSObject.set_IsDirectBinding(System.Boolean)
 Microsoft.MacCatalyst.dll:Foundation.NSObject.ToString()
+Microsoft.MacCatalyst.dll:Foundation.NSObject.TryGetIsUserType(ObjCRuntime.NativeHandle, out System.Boolean&, out System.String&)
 Microsoft.MacCatalyst.dll:Foundation.NSObject.xamarin_release_managed_ref(System.IntPtr, System.Byte)
 Microsoft.MacCatalyst.dll:Foundation.NSObject.xamarin_set_gchandle_with_flags_safe(System.IntPtr, System.IntPtr, Foundation.NSObject/XamarinGCHandleFlags, System.IntPtr)
 Microsoft.MacCatalyst.dll:Foundation.NSObject[] Foundation.NSDictionary::Keys()
@@ -161,6 +162,8 @@ Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::H
 Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::InFinalizerQueue
 Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsCustomType
 Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsDirectBinding
+Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsUserType
+Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsUserTypeKnown
 Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::NativeRef
 Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::RegisteredToggleRef
 Microsoft.MacCatalyst.dll:Foundation.NSObject/Flags Foundation.NSObjectData::flags

--- a/tests/dotnet/UnitTests/expected/TVOS-CoreCLR-Interpreter-preservedapis.txt
+++ b/tests/dotnet/UnitTests/expected/TVOS-CoreCLR-Interpreter-preservedapis.txt
@@ -524,6 +524,7 @@ Microsoft.tvOS.dll:Foundation.NSObject.set_HasManagedRef(System.Boolean)
 Microsoft.tvOS.dll:Foundation.NSObject.set_IsDirectBinding(System.Boolean)
 Microsoft.tvOS.dll:Foundation.NSObject.set_RemoveFromObjectMap(System.Boolean)
 Microsoft.tvOS.dll:Foundation.NSObject.ToString()
+Microsoft.tvOS.dll:Foundation.NSObject.TryGetIsUserType(ObjCRuntime.NativeHandle, out System.Boolean&, out System.String&)
 Microsoft.tvOS.dll:Foundation.NSObject.xamarin_release_managed_ref(System.IntPtr, System.Byte)
 Microsoft.tvOS.dll:Foundation.NSObject.xamarin_set_gchandle_with_flags_safe(System.IntPtr, System.IntPtr, Foundation.NSObject/XamarinGCHandleFlags, System.IntPtr)
 Microsoft.tvOS.dll:Foundation.NSObject[] Foundation.NSDictionary::Keys()
@@ -536,6 +537,8 @@ Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::HasManag
 Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::InFinalizerQueue
 Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsCustomType
 Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsDirectBinding
+Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsUserType
+Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsUserTypeKnown
 Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::NativeRef
 Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::RegisteredToggleRef
 Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObjectData::flags

--- a/tests/dotnet/UnitTests/expected/TVOS-CoreCLR-R2R-preservedapis.txt
+++ b/tests/dotnet/UnitTests/expected/TVOS-CoreCLR-R2R-preservedapis.txt
@@ -524,6 +524,7 @@ Microsoft.tvOS.dll:Foundation.NSObject.set_HasManagedRef(System.Boolean)
 Microsoft.tvOS.dll:Foundation.NSObject.set_IsDirectBinding(System.Boolean)
 Microsoft.tvOS.dll:Foundation.NSObject.set_RemoveFromObjectMap(System.Boolean)
 Microsoft.tvOS.dll:Foundation.NSObject.ToString()
+Microsoft.tvOS.dll:Foundation.NSObject.TryGetIsUserType(ObjCRuntime.NativeHandle, out System.Boolean&, out System.String&)
 Microsoft.tvOS.dll:Foundation.NSObject.xamarin_release_managed_ref(System.IntPtr, System.Byte)
 Microsoft.tvOS.dll:Foundation.NSObject.xamarin_set_gchandle_with_flags_safe(System.IntPtr, System.IntPtr, Foundation.NSObject/XamarinGCHandleFlags, System.IntPtr)
 Microsoft.tvOS.dll:Foundation.NSObject[] Foundation.NSDictionary::Keys()
@@ -536,6 +537,8 @@ Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::HasManag
 Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::InFinalizerQueue
 Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsCustomType
 Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsDirectBinding
+Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsUserType
+Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsUserTypeKnown
 Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::NativeRef
 Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::RegisteredToggleRef
 Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObjectData::flags

--- a/tests/dotnet/UnitTests/expected/TVOS-MonoVM-interpreter-preservedapis.txt
+++ b/tests/dotnet/UnitTests/expected/TVOS-MonoVM-interpreter-preservedapis.txt
@@ -159,6 +159,7 @@ Microsoft.tvOS.dll:Foundation.NSObject.set_HasManagedRef(System.Boolean)
 Microsoft.tvOS.dll:Foundation.NSObject.set_IsDirectBinding(System.Boolean)
 Microsoft.tvOS.dll:Foundation.NSObject.set_RemoveFromObjectMap(System.Boolean)
 Microsoft.tvOS.dll:Foundation.NSObject.ToString()
+Microsoft.tvOS.dll:Foundation.NSObject.TryGetIsUserType(ObjCRuntime.NativeHandle, out System.Boolean&, out System.String&)
 Microsoft.tvOS.dll:Foundation.NSObject.xamarin_release_managed_ref(System.IntPtr, System.Byte)
 Microsoft.tvOS.dll:Foundation.NSObject.xamarin_set_gchandle_with_flags_safe(System.IntPtr, System.IntPtr, Foundation.NSObject/XamarinGCHandleFlags, System.IntPtr)
 Microsoft.tvOS.dll:Foundation.NSObject[] Foundation.NSDictionary::Keys()
@@ -170,6 +171,8 @@ Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::HasManag
 Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::InFinalizerQueue
 Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsCustomType
 Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsDirectBinding
+Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsUserType
+Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsUserTypeKnown
 Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::NativeRef
 Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::RegisteredToggleRef
 Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObjectData::flags

--- a/tests/dotnet/UnitTests/expected/TVOS-MonoVM-preservedapis.txt
+++ b/tests/dotnet/UnitTests/expected/TVOS-MonoVM-preservedapis.txt
@@ -142,6 +142,7 @@ Microsoft.tvOS.dll:Foundation.NSObject.set_Handle(ObjCRuntime.NativeHandle)
 Microsoft.tvOS.dll:Foundation.NSObject.set_HasManagedRef(System.Boolean)
 Microsoft.tvOS.dll:Foundation.NSObject.set_IsDirectBinding(System.Boolean)
 Microsoft.tvOS.dll:Foundation.NSObject.ToString()
+Microsoft.tvOS.dll:Foundation.NSObject.TryGetIsUserType(ObjCRuntime.NativeHandle, out System.Boolean&, out System.String&)
 Microsoft.tvOS.dll:Foundation.NSObject.xamarin_release_managed_ref(System.IntPtr, System.Byte)
 Microsoft.tvOS.dll:Foundation.NSObject.xamarin_set_gchandle_with_flags_safe(System.IntPtr, System.IntPtr, Foundation.NSObject/XamarinGCHandleFlags, System.IntPtr)
 Microsoft.tvOS.dll:Foundation.NSObject[] Foundation.NSDictionary::Keys()
@@ -153,6 +154,8 @@ Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::HasManag
 Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::InFinalizerQueue
 Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsCustomType
 Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsDirectBinding
+Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsUserType
+Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsUserTypeKnown
 Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::NativeRef
 Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::RegisteredToggleRef
 Microsoft.tvOS.dll:Foundation.NSObject/Flags Foundation.NSObjectData::flags

--- a/tests/dotnet/UnitTests/expected/iOS-CoreCLR-Interpreter-preservedapis.txt
+++ b/tests/dotnet/UnitTests/expected/iOS-CoreCLR-Interpreter-preservedapis.txt
@@ -554,6 +554,7 @@ Microsoft.iOS.dll:Foundation.NSObject.set_HasManagedRef(System.Boolean)
 Microsoft.iOS.dll:Foundation.NSObject.set_IsDirectBinding(System.Boolean)
 Microsoft.iOS.dll:Foundation.NSObject.set_RemoveFromObjectMap(System.Boolean)
 Microsoft.iOS.dll:Foundation.NSObject.ToString()
+Microsoft.iOS.dll:Foundation.NSObject.TryGetIsUserType(ObjCRuntime.NativeHandle, out System.Boolean&, out System.String&)
 Microsoft.iOS.dll:Foundation.NSObject.xamarin_release_managed_ref(System.IntPtr, System.Byte)
 Microsoft.iOS.dll:Foundation.NSObject.xamarin_set_gchandle_with_flags_safe(System.IntPtr, System.IntPtr, Foundation.NSObject/XamarinGCHandleFlags, System.IntPtr)
 Microsoft.iOS.dll:Foundation.NSObject[] Foundation.NSDictionary::Keys()
@@ -566,6 +567,8 @@ Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::HasManage
 Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::InFinalizerQueue
 Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsCustomType
 Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsDirectBinding
+Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsUserType
+Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsUserTypeKnown
 Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::NativeRef
 Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::RegisteredToggleRef
 Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObjectData::flags

--- a/tests/dotnet/UnitTests/expected/iOS-CoreCLR-R2R-preservedapis.txt
+++ b/tests/dotnet/UnitTests/expected/iOS-CoreCLR-R2R-preservedapis.txt
@@ -554,6 +554,7 @@ Microsoft.iOS.dll:Foundation.NSObject.set_HasManagedRef(System.Boolean)
 Microsoft.iOS.dll:Foundation.NSObject.set_IsDirectBinding(System.Boolean)
 Microsoft.iOS.dll:Foundation.NSObject.set_RemoveFromObjectMap(System.Boolean)
 Microsoft.iOS.dll:Foundation.NSObject.ToString()
+Microsoft.iOS.dll:Foundation.NSObject.TryGetIsUserType(ObjCRuntime.NativeHandle, out System.Boolean&, out System.String&)
 Microsoft.iOS.dll:Foundation.NSObject.xamarin_release_managed_ref(System.IntPtr, System.Byte)
 Microsoft.iOS.dll:Foundation.NSObject.xamarin_set_gchandle_with_flags_safe(System.IntPtr, System.IntPtr, Foundation.NSObject/XamarinGCHandleFlags, System.IntPtr)
 Microsoft.iOS.dll:Foundation.NSObject[] Foundation.NSDictionary::Keys()
@@ -566,6 +567,8 @@ Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::HasManage
 Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::InFinalizerQueue
 Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsCustomType
 Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsDirectBinding
+Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsUserType
+Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsUserTypeKnown
 Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::NativeRef
 Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::RegisteredToggleRef
 Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObjectData::flags

--- a/tests/dotnet/UnitTests/expected/iOS-MonoVM-interpreter-preservedapis.txt
+++ b/tests/dotnet/UnitTests/expected/iOS-MonoVM-interpreter-preservedapis.txt
@@ -159,6 +159,7 @@ Microsoft.iOS.dll:Foundation.NSObject.set_HasManagedRef(System.Boolean)
 Microsoft.iOS.dll:Foundation.NSObject.set_IsDirectBinding(System.Boolean)
 Microsoft.iOS.dll:Foundation.NSObject.set_RemoveFromObjectMap(System.Boolean)
 Microsoft.iOS.dll:Foundation.NSObject.ToString()
+Microsoft.iOS.dll:Foundation.NSObject.TryGetIsUserType(ObjCRuntime.NativeHandle, out System.Boolean&, out System.String&)
 Microsoft.iOS.dll:Foundation.NSObject.xamarin_release_managed_ref(System.IntPtr, System.Byte)
 Microsoft.iOS.dll:Foundation.NSObject.xamarin_set_gchandle_with_flags_safe(System.IntPtr, System.IntPtr, Foundation.NSObject/XamarinGCHandleFlags, System.IntPtr)
 Microsoft.iOS.dll:Foundation.NSObject[] Foundation.NSDictionary::Keys()
@@ -170,6 +171,8 @@ Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::HasManage
 Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::InFinalizerQueue
 Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsCustomType
 Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsDirectBinding
+Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsUserType
+Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsUserTypeKnown
 Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::NativeRef
 Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::RegisteredToggleRef
 Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObjectData::flags

--- a/tests/dotnet/UnitTests/expected/iOS-MonoVM-preservedapis.txt
+++ b/tests/dotnet/UnitTests/expected/iOS-MonoVM-preservedapis.txt
@@ -142,6 +142,7 @@ Microsoft.iOS.dll:Foundation.NSObject.set_Handle(ObjCRuntime.NativeHandle)
 Microsoft.iOS.dll:Foundation.NSObject.set_HasManagedRef(System.Boolean)
 Microsoft.iOS.dll:Foundation.NSObject.set_IsDirectBinding(System.Boolean)
 Microsoft.iOS.dll:Foundation.NSObject.ToString()
+Microsoft.iOS.dll:Foundation.NSObject.TryGetIsUserType(ObjCRuntime.NativeHandle, out System.Boolean&, out System.String&)
 Microsoft.iOS.dll:Foundation.NSObject.xamarin_release_managed_ref(System.IntPtr, System.Byte)
 Microsoft.iOS.dll:Foundation.NSObject.xamarin_set_gchandle_with_flags_safe(System.IntPtr, System.IntPtr, Foundation.NSObject/XamarinGCHandleFlags, System.IntPtr)
 Microsoft.iOS.dll:Foundation.NSObject[] Foundation.NSDictionary::Keys()
@@ -153,6 +154,8 @@ Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::HasManage
 Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::InFinalizerQueue
 Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsCustomType
 Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsDirectBinding
+Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsUserType
+Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::IsUserTypeKnown
 Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::NativeRef
 Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObject/Flags::RegisteredToggleRef
 Microsoft.iOS.dll:Foundation.NSObject/Flags Foundation.NSObjectData::flags


### PR DESCRIPTION

⚠️ This description needs some numbers to see if this is an actual improvement or not ⚠️

Cache whether an NSObject instance represents a user type in the object's existing native-backed flags.

This avoids repeating the class lookup and taking the global user-type cache lock when releasing an object. Invalidate the cached value when the native handle changes, and preserve current error handling for invalid handles.

Update the preserved-API baselines for the new helper and flags.

🤖 Pull request created by Copilot