### PR TITLE
[dotnet-linker] Remove DynamicDependency signature workaround. Fixes #26413

### DIFF
--- a/tests/assembly-preparer/PreserveBlockCodeHandlerTests.cs
+++ b/tests/assembly-preparer/PreserveBlockCodeHandlerTests.cs
@@ -45,9 +45,8 @@ public class PreserveBlockCodeHandlerTests : BaseClass {
 		Assert.That ((string) attribs [0].ConstructorArguments [1].Value, Is.EqualTo ("ObjCRuntime.Trampolines.SDInnerBlock"), "First attribute's second argument");
 		Assert.That ((string) attribs [0].ConstructorArguments [2].Value, Is.EqualTo ("Test"), "First attribute's third argument");
 
-		// Invoke method: DDA(string memberSignature) - same declaring type, so simpler constructor.
-		// The signature doesn't include the parameter list, because there's only one method named 'Invoke'.
+		// Invoke method: DDA(string memberSignature) - same declaring type, so simpler constructor
 		Assert.That (attribs [1].ConstructorArguments.Count, Is.EqualTo (1), "Second attribute's argument count");
-		Assert.That ((string) attribs [1].ConstructorArguments [0].Value, Is.EqualTo ("Invoke"), "Second attribute's first argument");
+		Assert.That ((string) attribs [1].ConstructorArguments [0].Value, Is.EqualTo ("Invoke(System.IntPtr,System.Int32)"), "Second attribute's first argument");
 	}
 }

--- a/tests/assembly-preparer/PreserveSmartEnumConversionsTest.cs
+++ b/tests/assembly-preparer/PreserveSmartEnumConversionsTest.cs
@@ -108,8 +108,7 @@ public class PreserveSmartEnumConversionsTests : BaseClass {
 
 		void AssertMethodHasDynamicDependencies (ICustomAttributeProvider provider)
 		{
-			// 'GetConstant' has no parameter list, because it's the only method with that name (unlike 'GetValue').
-			AssertHasDynamicDependency (provider, "GetConstant", "CoreAnimation.CAToneMapModeExtensions", $"Microsoft.{platform.AsString ()}");
+			AssertHasDynamicDependency (provider, "GetConstant(CoreAnimation.CAToneMapMode)", "CoreAnimation.CAToneMapModeExtensions", $"Microsoft.{platform.AsString ()}");
 			AssertHasDynamicDependency (provider, "GetValue(Foundation.NSString)", "CoreAnimation.CAToneMapModeExtensions", $"Microsoft.{platform.AsString ()}");
 		}
 

--- a/tools/dotnet-linker/AppBundleRewriter.cs
+++ b/tools/dotnet-linker/AppBundleRewriter.cs
@@ -1552,14 +1552,15 @@ namespace Xamarin.Linker {
 			if (!IsAssemblyTrimmed (dependsOn))
 				return false;
 
+			var signature = DocumentationComments.GetSignature (dependsOn);
 			if (addToMethod.DeclaringType == dependsOn.DeclaringType) {
-				var attribute = CreateDynamicDependencyAttribute (DocumentationComments.GetSignature (dependsOn));
+				var attribute = CreateDynamicDependencyAttribute (signature);
 				return AddAttributeOnlyOnce (addToMethod, attribute);
 			} else if (addToMethod.DeclaringType.Module == dependsOn.DeclaringType.Module) {
-				var attribute = CreateDynamicDependencyAttribute (DocumentationComments.GetSignature (dependsOn), dependsOn.DeclaringType);
+				var attribute = CreateDynamicDependencyAttribute (signature, dependsOn.DeclaringType);
 				return AddAttributeOnlyOnce (addToMethod, attribute);
 			} else {
-				var attribute = CreateDynamicDependencyAttribute (DocumentationComments.GetSignature (dependsOn), dependsOn.DeclaringType, dependsOn.DeclaringType.Module.Assembly);
+				var attribute = CreateDynamicDependencyAttribute (signature, dependsOn.DeclaringType, dependsOn.DeclaringType.Module.Assembly);
 				return AddAttributeOnlyOnce (addToMethod, attribute);
 			}
 		}
@@ -1703,13 +1704,14 @@ namespace Xamarin.Linker {
 		public bool AddDynamicDependencyAttributeToStaticConstructor (TypeDefinition onType, MethodDefinition forMethod)
 		{
 			CustomAttribute attrib;
+			var signature = DocumentationComments.GetSignature (forMethod);
 
 			if (onType == forMethod.DeclaringType) {
-				attrib = CreateDynamicDependencyAttribute (DocumentationComments.GetSignature (forMethod));
+				attrib = CreateDynamicDependencyAttribute (signature);
 			} else if (onType.Module == forMethod.DeclaringType.Module) {
-				attrib = CreateDynamicDependencyAttribute (DocumentationComments.GetSignature (forMethod), forMethod.DeclaringType);
+				attrib = CreateDynamicDependencyAttribute (signature, forMethod.DeclaringType);
 			} else {
-				attrib = CreateDynamicDependencyAttribute (DocumentationComments.GetSignature (forMethod), forMethod.DeclaringType, forMethod.Module.Assembly);
+				attrib = CreateDynamicDependencyAttribute (signature, forMethod.DeclaringType, forMethod.Module.Assembly);
 			}
 
 			return AddAttributeToStaticConstructor (onType, attrib);

--- a/tools/dotnet-linker/AppBundleRewriter.cs
+++ b/tools/dotnet-linker/AppBundleRewriter.cs
@@ -1547,52 +1547,19 @@ namespace Xamarin.Linker {
 			return action == AssemblyAction.Link;
 		}
 
-		/// <summary>
-		/// Returns the signature to use in a <c>[DynamicDependency]</c> attribute for a method: the
-		/// method name (and generic arity) if no other method in the same type has that name and
-		/// arity, otherwise the full signature (including the parameter list).
-		/// </summary>
-		/// <remarks>
-		///   <para>
-		///     The trimmer only compares the parameter lists when the signature has one, and computing
-		///     the signature of a parameter crashes the trimmer if the parameter's type is a nested type
-		///     reference (see <see cref="DocumentationComments.GetNameSignature (MethodDefinition)" />),
-		///     so use the name alone whenever it's unambiguous.
-		///   </para>
-		///   <para>
-		///     The trimmer matches a signature without a parameter list on both the name and the generic
-		///     arity, so methods that differ in arity (<c>Foo ()</c> vs <c>Foo&lt;T&gt; ()</c>) don't
-		///     collide and don't need a parameter list either.
-		///   </para>
-		/// </remarks>
-		static string GetDynamicDependencySignature (MethodDefinition method)
-		{
-			var count = 0;
-			foreach (var candidate in method.DeclaringType.Methods) {
-				if (candidate.Name != method.Name)
-					continue;
-				if (candidate.GenericParameters.Count != method.GenericParameters.Count)
-					continue;
-				if (++count > 1)
-					return DocumentationComments.GetSignature (method);
-			}
-			return DocumentationComments.GetNameSignature (method);
-		}
-
 		public bool AddDynamicDependencyAttribute (MethodDefinition addToMethod, MethodDefinition dependsOn)
 		{
 			if (!IsAssemblyTrimmed (dependsOn))
 				return false;
 
-			var signature = GetDynamicDependencySignature (dependsOn);
 			if (addToMethod.DeclaringType == dependsOn.DeclaringType) {
-				var attribute = CreateDynamicDependencyAttribute (signature);
+				var attribute = CreateDynamicDependencyAttribute (DocumentationComments.GetSignature (dependsOn));
 				return AddAttributeOnlyOnce (addToMethod, attribute);
 			} else if (addToMethod.DeclaringType.Module == dependsOn.DeclaringType.Module) {
-				var attribute = CreateDynamicDependencyAttribute (signature, dependsOn.DeclaringType);
+				var attribute = CreateDynamicDependencyAttribute (DocumentationComments.GetSignature (dependsOn), dependsOn.DeclaringType);
 				return AddAttributeOnlyOnce (addToMethod, attribute);
 			} else {
-				var attribute = CreateDynamicDependencyAttribute (signature, dependsOn.DeclaringType, dependsOn.DeclaringType.Module.Assembly);
+				var attribute = CreateDynamicDependencyAttribute (DocumentationComments.GetSignature (dependsOn), dependsOn.DeclaringType, dependsOn.DeclaringType.Module.Assembly);
 				return AddAttributeOnlyOnce (addToMethod, attribute);
 			}
 		}
@@ -1736,14 +1703,13 @@ namespace Xamarin.Linker {
 		public bool AddDynamicDependencyAttributeToStaticConstructor (TypeDefinition onType, MethodDefinition forMethod)
 		{
 			CustomAttribute attrib;
-			var signature = GetDynamicDependencySignature (forMethod);
 
 			if (onType == forMethod.DeclaringType) {
-				attrib = CreateDynamicDependencyAttribute (signature);
+				attrib = CreateDynamicDependencyAttribute (DocumentationComments.GetSignature (forMethod));
 			} else if (onType.Module == forMethod.DeclaringType.Module) {
-				attrib = CreateDynamicDependencyAttribute (signature, forMethod.DeclaringType);
+				attrib = CreateDynamicDependencyAttribute (DocumentationComments.GetSignature (forMethod), forMethod.DeclaringType);
 			} else {
-				attrib = CreateDynamicDependencyAttribute (signature, forMethod.DeclaringType, forMethod.Module.Assembly);
+				attrib = CreateDynamicDependencyAttribute (DocumentationComments.GetSignature (forMethod), forMethod.DeclaringType, forMethod.Module.Assembly);
 			}
 
 			return AddAttributeToStaticConstructor (onType, attrib);


### PR DESCRIPTION
Removes the workaround for https://github.com/dotnet/runtime/issues/131892 (the trimmer crashed with a `NullReferenceException`, surfaced as `error IL1012`, when computing the documentation signature of a method whose parameter type is a nested type from another assembly) now that the trimmer bug is fixed and we've moved to an SDK containing the fix.

`[DynamicDependency]` attributes now use precise method signatures (including the parameter list) again, instead of matching by name and generic arity alone, so fewer overloads are unnecessarily preserved.

Note: `DocumentationComments.GetNameSignature` and `AddPreserveAllMembersDynamicDependencyAttributes` are intentionally left untouched, since `[Preserve (AllMembers = true)]` preserves every overload anyway, so matching by name there is correct and cheaper.

Fixes https://github.com/dotnet/macios/issues/26413

🤖 Pull request created by Copilot