### PR TITLE
[tests] Test in-proc crash reports on macOS. Fixes #23864.

### DIFF
--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -167,8 +167,9 @@ This can be overriden by setting the `BundleCreateDump` property:
 
 Note: the `createdump` tool does currently not work for sandboxed apps ([#18961](https://github.com/dotnet/macios/issues/18961));
 
-Only applicable to projects that use the CoreCLR runtime (which, at the moment
-of this writing, is only macOS projects).
+Note: an alternative option is to enable the in-process crash reporter (see [EnableCrashReport](#enablecrashreport)). The in-process crash reporter also works for sandboxed apps.
+
+Only applicable to macOS projects.
 
 [createdump]: https://github.com/dotnet/runtime/blob/3b63eb1346f1ddbc921374a5108d025662fb5ffd/docs/design/coreclr/botr/xplat-minidump-generation.md
 
@@ -598,10 +599,6 @@ This setting is disabled by default, but it can be enabled like this:
 The crash reports are written to a subdirectory of the app's caches directory.
 
 See also: [Collect crash dumps](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/collect-dumps-crash).
-
-The in-process crash reporter is only available in the mobile CoreCLR runtime
-(iOS, tvOS and Mac Catalyst); the desktop macOS runtime relies on the
-[`createdump`](#bundlecreatedump) tool instead.
 
 ## EnableDefaultCodesignEntitlements
 

--- a/tests/dotnet/UnitTests/EnableCrashReportTest.cs
+++ b/tests/dotnet/UnitTests/EnableCrashReportTest.cs
@@ -8,16 +8,13 @@ namespace Xamarin.Tests {
 	public class EnableCrashReportTest : TestBaseClass {
 		[Test]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64")]
+		[TestCase (ApplePlatform.MacOSX, "osx-arm64")]
 		public void Enabled (ApplePlatform platform, string runtimeIdentifiers)
 		{
 			// When $(EnableCrashReport) is set to true, the DOTNET_EnableCrashReport=1 environment
 			// variable is set at startup, which makes the .NET runtime's in-process crash reporter
 			// write a JSON crash report when the app crashes. Verify this by crashing the app on
 			// launch and checking that a crash report file was created.
-			//
-			// Note: only the mobile CoreCLR flavor (iOS, tvOS and Mac Catalyst) has the in-process
-			// crash reporter; the desktop macOS runtime relies on 'createdump' instead (see the
-			// BundleCreateDump property), which is why macOS isn't tested here.
 			var project = "MySimpleApp";
 			Configuration.IgnoreIfIgnoredPlatform (platform);
 			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);


### PR DESCRIPTION
Add a macOS arm64 variation to EnableCrashReportTest now that the desktop runtime supports JSON crash reports through createdump.

The existing test verifies both an explicitly configured crash report directory and the default per-application caches directory.

Fixes https://github.com/dotnet/macios/issues/23864

🤖 Pull request created by Copilot