### PR TITLE
[msbuild] Add diagnostic logging for native reference resource resolution (#24564)

### DIFF
--- a/msbuild/Messaging/Xamarin.Messaging.Build/Handlers/CompareFilesMessageHandler.cs
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/Handlers/CompareFilesMessageHandler.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Messaging.Build {
 								var localHash = hashAlgorithm.ComputeHashAsString (stream);
 
 								if (file.Hash != localHash) {
-									tracer.Info ($"CompareFiles: '{file.ItemSpec}' has a different hash on the Mac (local: '{localHash}', remote: '{file.Hash}'), it will be copied.");
+									tracer.Info ($"CompareFiles: '{file.ItemSpec}' has a different hash on the Mac (mac: '{localHash}', windows: '{file.Hash}'), it will be copied.");
 									files.Add (file.ItemSpec);
 								} else {
 									tracer.Info ($"CompareFiles: '{file.ItemSpec}' already exists on the Mac with a matching hash, it will not be copied.");

--- a/msbuild/Messaging/Xamarin.Messaging.Build/Handlers/CompareFilesMessageHandler.cs
+++ b/msbuild/Messaging/Xamarin.Messaging.Build/Handlers/CompareFilesMessageHandler.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
@@ -7,6 +8,8 @@ using Xamarin.Messaging.Client;
 
 namespace Xamarin.Messaging.Build {
 	public class CompareFilesMessageHandler : RequestHandler<CompareItemsMessage, CompareItemsResult> {
+		static readonly ITracer tracer = Tracer.Get<CompareFilesMessageHandler> ();
+
 		protected override async Task<CompareItemsResult> ExecuteAsync (CompareItemsMessage message)
 		{
 			return await Task.Run (() => {
@@ -18,6 +21,7 @@ namespace Xamarin.Messaging.Build {
 						var targetPath = Path.Combine (buildPath, PlatformPath.GetPathForCurrentPlatform (file.ItemSpec));
 
 						if (!File.Exists (targetPath)) {
+							tracer.Info ($"CompareFiles: '{file.ItemSpec}' is missing on the Mac (expected at '{targetPath}'), it will be copied.");
 							files.Add (file.ItemSpec);
 						} else {
 
@@ -25,7 +29,10 @@ namespace Xamarin.Messaging.Build {
 								var localHash = hashAlgorithm.ComputeHashAsString (stream);
 
 								if (file.Hash != localHash) {
+									tracer.Info ($"CompareFiles: '{file.ItemSpec}' has a different hash on the Mac (local: '{localHash}', remote: '{file.Hash}'), it will be copied.");
 									files.Add (file.ItemSpec);
+								} else {
+									tracer.Info ($"CompareFiles: '{file.ItemSpec}' already exists on the Mac with a matching hash, it will not be copied.");
 								}
 							}
 						}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ResolveNativeReferences.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ResolveNativeReferences.cs
@@ -627,13 +627,18 @@ namespace Xamarin.MacDev.Tasks {
 			foreach (var reference in References) {
 				var resourcesPackage = Path.Combine (Path.GetDirectoryName (reference.ItemSpec)!, Path.GetFileNameWithoutExtension (reference.ItemSpec)) + ".resources";
 				if (Directory.Exists (resourcesPackage)) {
-					var resources = CreateItemsForAllFilesRecursively (new string [] { resourcesPackage });
+					var resources = CreateItemsForAllFilesRecursively (new string [] { resourcesPackage }).ToList ();
+					Log.LogMessage (MessageImportance.Low, $"Found the resources directory '{resourcesPackage}' for the reference '{reference.ItemSpec}', copying {resources.Count} file(s) from it.");
 					rv.AddRange (resources);
 					continue;
 				}
 				var zipPackage = resourcesPackage + ".zip";
-				if (File.Exists (zipPackage))
+				if (File.Exists (zipPackage)) {
+					Log.LogMessage (MessageImportance.Low, $"Found the resources zip file '{zipPackage}' for the reference '{reference.ItemSpec}', copying it.");
 					rv.Add (new TaskItem (zipPackage));
+				} else {
+					Log.LogMessage (MessageImportance.Low, $"No resources directory ('{resourcesPackage}') nor resources zip file ('{zipPackage}') found for the reference '{reference.ItemSpec}'.");
+				}
 			}
 			return rv;
 		}


### PR DESCRIPTION
Add low-importance diagnostic logging to help investigate #24564, where a Firebase.Crashlytics.resources.zip is not copied to the Mac during Pair-to-Mac builds:

* ResolveNativeReferences.GetAdditionalItemsToBeCopied(): log which branch (resources directory vs resources zip vs neither) is taken for each reference, including the exact paths checked.
* CompareFilesMessageHandler (Mac-side messaging handler): trace whether each file is missing, has a mismatched hash, or already matches on the Mac, to help diagnose why a file may not get copied over.