### PR TITLE
[tests] Fix CreateAndBuildProjectTemplate hang/flakiness for Mac Catalyst

### DIFF
--- a/tests/dotnet/UnitTests/TestBaseClass.cs
+++ b/tests/dotnet/UnitTests/TestBaseClass.cs
@@ -500,7 +500,10 @@ namespace Xamarin.Tests {
 					env [kvp.Key] = kvp.Value;
 			}
 
-			var rv = Execution.RunAsync (executable, Array.Empty<string> (), environment: env, timeout: TimeSpan.FromSeconds (30)).Result;
+			// Tell AppKit to skip its "Do you want to try to reopen its windows again?" prompt entirely (even if
+			// the OS thinks the app has a history of crashing), so that a persistent modal dialog doesn't hang the test.
+			var args = new [] { "-ApplePersistenceIgnoreState", "YES" };
+			var rv = Execution.RunAsync (executable, args, environment: env, timeout: TimeSpan.FromSeconds (30)).Result;
 			output = rv.Output.MergedOutput;
 
 			DeleteSavedState (executable);
@@ -540,14 +543,19 @@ namespace Xamarin.Tests {
 			if (string.IsNullOrEmpty (bundleIdentifier))
 				return;
 
-			var savedStateDir = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), "Library", "Saved Application State", $"{bundleIdentifier}.savedState");
-			try {
-				if (Directory.Exists (savedStateDir)) {
-					Directory.Delete (savedStateDir, true);
-					Console.WriteLine ($"Deleted saved application state: {savedStateDir}");
+			var savedStateParentDir = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), "Library", "Saved Application State");
+			// Mac Catalyst apps run under the "iosmac" personality, and macOS stores their saved state
+			// with a "~iosmac" suffix added to the bundle identifier, so delete both variants.
+			foreach (var identifier in new [] { bundleIdentifier, $"{bundleIdentifier}~iosmac" }) {
+				var savedStateDir = Path.Combine (savedStateParentDir, $"{identifier}.savedState");
+				try {
+					if (Directory.Exists (savedStateDir)) {
+						Directory.Delete (savedStateDir, true);
+						Console.WriteLine ($"Deleted saved application state: {savedStateDir}");
+					}
+				} catch (Exception e) {
+					Console.WriteLine ($"Could not delete saved application state '{savedStateDir}': {e.Message}");
 				}
-			} catch (Exception e) {
-				Console.WriteLine ($"Could not delete saved application state '{savedStateDir}': {e.Message}");
 			}
 		}
 

--- a/tests/dotnet/UnitTests/TestBaseClass.cs
+++ b/tests/dotnet/UnitTests/TestBaseClass.cs
@@ -500,15 +500,19 @@ namespace Xamarin.Tests {
 					env [kvp.Key] = kvp.Value;
 			}
 
-			// Tell AppKit to skip its "Do you want to try to reopen its windows again?" prompt entirely (even if
-			// the OS thinks the app has a history of crashing), so that a persistent modal dialog doesn't hang the test.
-			var args = new [] { "-ApplePersistenceIgnoreState", "YES" };
-			var rv = Execution.RunAsync (executable, args, environment: env, timeout: TimeSpan.FromSeconds (30)).Result;
-			output = rv.Output.MergedOutput;
-
-			DeleteSavedState (executable);
-
-			return rv;
+			var bundleIdentifier = GetBundleIdentifier (executable);
+			if (!string.IsNullOrEmpty (bundleIdentifier))
+				Execution.RunAsync ("/usr/bin/defaults", new [] { "write", bundleIdentifier, "ApplePersistenceIgnoreState", "-bool", "YES" }, timeout: TimeSpan.FromSeconds (30)).Result;
+			try {
+				var rv = Execution.RunAsync (executable, Array.Empty<string> (), environment: env, timeout: TimeSpan.FromSeconds (30)).Result;
+				output = rv.Output.MergedOutput;
+				return rv;
+			} finally {
+				// Remove the override so it doesn't affect a later test using the same bundle identifier.
+				if (!string.IsNullOrEmpty (bundleIdentifier))
+					Execution.RunAsync ("/usr/bin/defaults", new [] { "delete", bundleIdentifier, "ApplePersistenceIgnoreState" }, timeout: TimeSpan.FromSeconds (30)).Result;
+				DeleteSavedState (executable);
+			}
 		}
 
 		// Delete the saved application state for the app being launched, to prevent
@@ -516,30 +520,7 @@ namespace Xamarin.Tests {
 		// if the app crashed during a previous test run. See https://github.com/dotnet/macios/issues/25922
 		static void DeleteSavedState (string executable)
 		{
-			// Find the .app bundle directory from the executable path
-			var dir = Path.GetDirectoryName (executable);
-			while (!string.IsNullOrEmpty (dir) && !dir.EndsWith (".app", StringComparison.OrdinalIgnoreCase))
-				dir = Path.GetDirectoryName (dir);
-
-			if (string.IsNullOrEmpty (dir))
-				return;
-
-			// Read the bundle identifier from Info.plist
-			string? bundleIdentifier = null;
-			var infoPlistPath = Path.Combine (dir, "Contents", "Info.plist");
-			if (!File.Exists (infoPlistPath))
-				infoPlistPath = Path.Combine (dir, "Info.plist");
-			if (!File.Exists (infoPlistPath))
-				return;
-
-			try {
-				var infoPlist = PDictionary.OpenFile (infoPlistPath);
-				bundleIdentifier = infoPlist.GetString ("CFBundleIdentifier")?.Value;
-			} catch (Exception e) {
-				Console.WriteLine ($"Could not read bundle identifier from '{infoPlistPath}': {e.Message}");
-				return;
-			}
-
+			var bundleIdentifier = GetBundleIdentifier (executable);
 			if (string.IsNullOrEmpty (bundleIdentifier))
 				return;
 
@@ -556,6 +537,32 @@ namespace Xamarin.Tests {
 				} catch (Exception e) {
 					Console.WriteLine ($"Could not delete saved application state '{savedStateDir}': {e.Message}");
 				}
+			}
+		}
+
+		static string? GetBundleIdentifier (string executable)
+		{
+			// Find the .app bundle directory from the executable path
+			var dir = Path.GetDirectoryName (executable);
+			while (!string.IsNullOrEmpty (dir) && !dir.EndsWith (".app", StringComparison.OrdinalIgnoreCase))
+				dir = Path.GetDirectoryName (dir);
+
+			if (string.IsNullOrEmpty (dir))
+				return null;
+
+			// Read the bundle identifier from Info.plist
+			var infoPlistPath = Path.Combine (dir, "Contents", "Info.plist");
+			if (!File.Exists (infoPlistPath))
+				infoPlistPath = Path.Combine (dir, "Info.plist");
+			if (!File.Exists (infoPlistPath))
+				return null;
+
+			try {
+				var infoPlist = PDictionary.OpenFile (infoPlistPath);
+				return infoPlist.GetString ("CFBundleIdentifier")?.Value;
+			} catch (Exception e) {
+				Console.WriteLine ($"Could not read bundle identifier from '{infoPlistPath}': {e.Message}");
+				return null;
 			}
 		}
 

--- a/tests/dotnet/UnitTests/TestBaseClass.cs
+++ b/tests/dotnet/UnitTests/TestBaseClass.cs
@@ -530,9 +530,9 @@ namespace Xamarin.Tests {
 					}
 
 					if (cleanup) {
-						Execution.RunAsync ("/usr/bin/defaults", new [] { "delete", bundleIdentifier, "ApplePersistenceIgnoreState" }, timeout: TimeSpan.FromSeconds (30)).Result;
+						Execution.RunAsync ("/usr/bin/defaults", new [] { "delete", bundleIdentifier, "ApplePersistenceIgnoreState" }, timeout: TimeSpan.FromSeconds (30)).Wait ();
 					} else {
-						Execution.RunAsync ("/usr/bin/defaults", new [] { "write", bundleIdentifier, "ApplePersistenceIgnoreState", "-bool", "YES" }, timeout: TimeSpan.FromSeconds (30)).Result;
+						Execution.RunAsync ("/usr/bin/defaults", new [] { "write", bundleIdentifier, "ApplePersistenceIgnoreState", "-bool", "YES" }, timeout: TimeSpan.FromSeconds (30)).Wait ();
 					}
 				} catch (Exception e) {
 					Console.WriteLine ($"Could not delete saved application state '{savedStateDir}': {e.Message}");


### PR DESCRIPTION
Two issues in the 'Execute'/'DeleteSavedState' helpers used by the Mac Catalyst 'CreateAndBuildProjectTemplate' tests could cause the test process to hang for 30 seconds (or longer) waiting on an unattended 'Do you want to try to reopen its windows again?' AppKit modal dialog:

 * 'DeleteSavedState' only deleted '<bundleid>.savedState', but macOS stores Mac Catalyst apps' saved state under '<bundleid>~iosmac.savedState' (the 'iosmac' personality suffix), so the saved state was never actually being cleaned up.

 * Even with a clean Saved Application State folder, AppKit also tracks a separate persistent 'crash history' per bundle identifier that isn't stored in that folder and isn't cleared by deleting it. After many crashed/killed test runs sharing the same default bundle identifier, this alone could still trigger the modal.

Fix both: delete the '~iosmac' saved-state variant too, and set the application default 'ApplePersistenceIgnoreState' to 'YES', which tells AppKit to skip the restore-prompt flow entirely regardless of any tracked crash history.

Copilot-Session: 0d41380a-e6ee-470e-b837-68411050a4f6