### PR TITLE
[AppKit] Document ten enum types

### DIFF
--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -3111,12 +3111,13 @@ namespace AppKit {
 		TextField,
 	}
 
+	/// <summary>Specifies whether a date picker selects a single date or a date range.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSDatePickerMode : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>The date picker selects a single date.</summary>
 		Single,
-		/// <summary>To be added.</summary>
+		/// <summary>The date picker selects a range of dates.</summary>
 		Range,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -3801,9 +3801,9 @@ namespace AppKit {
 	[NoMacCatalyst]
 	[Native]
 	public enum NSLayoutConstraintOrientation : long {
-		/// <summary>The horizontal axis.</summary>
+		/// <summary>The constraint has a horizontal orientation.</summary>
 		Horizontal,
-		/// <summary>The vertical axis.</summary>
+		/// <summary>The constraint has a vertical orientation.</summary>
 		Vertical,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -4343,12 +4343,13 @@ namespace AppKit {
 		AllowReadWrite = 1 << 5,
 	}
 
+	/// <summary>Specifies a color gamut that a display can represent.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSDisplayGamut : long {
-		/// <summary>To be added.</summary>
+		/// <summary>The sRGB color gamut.</summary>
 		Srgb = 1,
-		/// <summary>To be added.</summary>
+		/// <summary>The Display P3 color gamut.</summary>
 		P3,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -1285,12 +1285,13 @@ namespace AppKit {
 		GrooveBorder,
 	}
 
+	/// <summary>Specifies the shape of a text field's bezel.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSTextFieldBezelStyle : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>A square bezel.</summary>
 		Square,
-		/// <summary>To be added.</summary>
+		/// <summary>A rounded bezel.</summary>
 		Rounded,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -4412,12 +4412,13 @@ namespace AppKit {
 		Indirect = (1 << (int) NSTouchType.Indirect),
 	}
 
+	/// <summary>Specifies how a scrubber responds to touch input.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSScrubberMode : long {
-		/// <summary>To be added.</summary>
+		/// <summary>Items remain fixed while the user moves the selection across them.</summary>
 		Fixed = 0,
-		/// <summary>To be added.</summary>
+		/// <summary>Items scroll freely in response to the user's touch.</summary>
 		Free,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -3641,12 +3641,13 @@ namespace AppKit {
 		TornOffMenu = 3,
 	}
 
+	/// <summary>Specifies whether a rule editor row is a leaf condition or a group of subrows.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSRuleEditorRowType : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>A leaf row that represents a single condition.</summary>
 		Simple = 0,
-		/// <summary>To be added.</summary>
+		/// <summary>A parent row that groups one or more subrows.</summary>
 		Compound,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -3793,12 +3793,13 @@ namespace AppKit {
 		Vertical,
 	}
 
+	/// <summary>Specifies the axis affected by Auto Layout constraints.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSLayoutConstraintOrientation : long {
-		/// <summary>To be added.</summary>
+		/// <summary>The horizontal axis.</summary>
 		Horizontal,
-		/// <summary>To be added.</summary>
+		/// <summary>The vertical axis.</summary>
 		Vertical,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -3724,12 +3724,13 @@ namespace AppKit {
 		BelowContent,
 	}
 
+	/// <summary>Specifies how a scroller is displayed relative to its content.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSScrollerStyle : long {
-		/// <summary>To be added.</summary>
+		/// <summary>The scroller occupies space reserved for it in the layout.</summary>
 		Legacy = 0,
-		/// <summary>To be added.</summary>
+		/// <summary>The scroller is drawn over the content without reserving layout space.</summary>
 		Overlay,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -3860,12 +3860,13 @@ namespace AppKit {
 		Large,
 	}
 
+	/// <summary>Specifies the edge of a table row where row actions appear.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSTableRowActionEdge : long {
-		/// <summary>To be added.</summary>
+		/// <summary>The leading edge in the current user interface layout direction.</summary>
 		Leading,
-		/// <summary>To be added.</summary>
+		/// <summary>The trailing edge in the current user interface layout direction.</summary>
 		Trailing,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -3918,12 +3918,13 @@ namespace AppKit {
 		Stack,
 	}
 
+	/// <summary>Specifies whether a dragging operation occurs within or outside the application.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSDraggingContext : long {
-		/// <summary>To be added.</summary>
+		/// <summary>The dragging operation occurs outside the application.</summary>
 		OutsideApplication,
-		/// <summary>To be added.</summary>
+		/// <summary>The dragging operation occurs within the application.</summary>
 		WithinApplication,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -3392,12 +3392,13 @@ namespace AppKit {
 		Large = 18,
 	}
 
+	/// <summary>Specifies the visual style of a progress indicator.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSProgressIndicatorStyle : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Displays progress as a bar.</summary>
 		Bar,
-		/// <summary>To be added.</summary>
+		/// <summary>Displays progress as a spinning indicator.</summary>
 		Spinning,
 	}
 

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22573,7 +22573,6 @@ T:AppKit.NSResponder_NSTouchBarProvider
 T:AppKit.NSResponder_NSWritingToolsSupport
 T:AppKit.NSRuleEditorNestingMode
 T:AppKit.NSRuleEditorNumberOfChildren
-T:AppKit.NSRuleEditorRowType
 T:AppKit.NSRulerEditorChildCriterion
 T:AppKit.NSRulerEditorDisplayValue
 T:AppKit.NSRulerEditorPredicateParts

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22587,7 +22587,6 @@ T:AppKit.NSScrollerKnobStyle
 T:AppKit.NSScrollerPart
 T:AppKit.NSScrollViewFindBarPosition
 T:AppKit.NSScrubberAlignment
-T:AppKit.NSScrubberMode
 T:AppKit.NSSegmentBackgroundStyle_NSSegmentedCell
 T:AppKit.NSSegmentDistribution
 T:AppKit.NSSegmentStyle

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22509,7 +22509,6 @@ T:AppKit.NSImageSymbolColorRenderingMode
 T:AppKit.NSImageSymbolScale
 T:AppKit.NSImageSymbolVariableValueMode
 T:AppKit.NSKey
-T:AppKit.NSLayoutConstraintOrientation
 T:AppKit.NSLayoutManager_NSTextViewSupport
 T:AppKit.NSLayoutPriority
 T:AppKit.NSLevelIndicatorPlaceholderVisibility

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22664,7 +22664,6 @@ T:AppKit.NSTextContentManagerEnumerationOptions
 T:AppKit.NSTextContentType
 T:AppKit.NSTextCursorAccessoryPlacement
 T:AppKit.NSTextField_NSTouchBar
-T:AppKit.NSTextFieldBezelStyle
 T:AppKit.NSTextFieldGetCandidates
 T:AppKit.NSTextFieldSelectCandidate
 T:AppKit.NSTextFieldTextCheckingResults

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22565,7 +22565,6 @@ T:AppKit.NSPrinterTableStatus
 T:AppKit.NSPrintPanelOptions
 T:AppKit.NSPrintPanelResult
 T:AppKit.NSPrintRenderingQuality
-T:AppKit.NSProgressIndicatorStyle
 T:AppKit.NSProgressIndicatorThickness
 T:AppKit.NSRectAlignment
 T:AppKit.NSRectEdge

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22619,7 +22619,6 @@ T:AppKit.NSStringDrawing_NSAttributedString
 T:AppKit.NSStringDrawing_NSString
 T:AppKit.NSSurfaceOrder
 T:AppKit.NSTableReorder
-T:AppKit.NSTableRowActionEdge
 T:AppKit.NSTableViewAnimation
 T:AppKit.NSTableViewAnimationOptions
 T:AppKit.NSTableViewCell

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22448,7 +22448,6 @@ T:AppKit.NSDocumentMoveCompletionHandler
 T:AppKit.NSDocumentMoveToUrlCompletionHandler
 T:AppKit.NSDocumentUnlockCompletionHandler
 T:AppKit.NSDocumentUnlockDocumentCompletionHandler
-T:AppKit.NSDraggingContext
 T:AppKit.NSDraggingEnumerator
 T:AppKit.NSDraggingFormation
 T:AppKit.NSDraggingItemEnumerationOptions

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22436,7 +22436,6 @@ T:AppKit.NSCursorFrameResizeDirections
 T:AppKit.NSCursorFrameResizePosition
 T:AppKit.NSCustomImageRepDrawingHandler
 T:AppKit.NSDatePickerElementFlags
-T:AppKit.NSDatePickerMode
 T:AppKit.NSDatePickerStyle
 T:AppKit.NSDirectionalRectEdge
 T:AppKit.NSDisplayGamut

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22585,7 +22585,6 @@ T:AppKit.NSScrollElasticity
 T:AppKit.NSScrollerArrow
 T:AppKit.NSScrollerKnobStyle
 T:AppKit.NSScrollerPart
-T:AppKit.NSScrollerStyle
 T:AppKit.NSScrollViewFindBarPosition
 T:AppKit.NSScrubberAlignment
 T:AppKit.NSScrubberMode

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22438,7 +22438,6 @@ T:AppKit.NSCustomImageRepDrawingHandler
 T:AppKit.NSDatePickerElementFlags
 T:AppKit.NSDatePickerStyle
 T:AppKit.NSDirectionalRectEdge
-T:AppKit.NSDisplayGamut
 T:AppKit.NSDocumentChangeType
 T:AppKit.NSDocumentCompletionHandler
 T:AppKit.NSDocumentControllerOpenPanelResultHandler


### PR DESCRIPTION
Document ten AppKit enum types and all their members:

- `NSDatePickerMode`
- `NSDisplayGamut`
- `NSDraggingContext`
- `NSLayoutConstraintOrientation`
- `NSProgressIndicatorStyle`
- `NSRuleEditorRowType`
- `NSTextFieldBezelStyle`
- `NSScrollerStyle`
- `NSScrubberMode`
- `NSTableRowActionEdge`

Remove the matching entries from the Cecil documentation known-failures list.

🤖 Pull request created by Copilot