### PR TITLE
[tests] Add MaxSupportedOSPlatformVersion regression test project

### DIFF
--- a/tests/dotnet/MaxSupportedOSPlatformVersion/AppDelegate.cs
+++ b/tests/dotnet/MaxSupportedOSPlatformVersion/AppDelegate.cs
@@ -1,0 +1,14 @@
+using System;
+
+using Foundation;
+
+namespace MaxSupportedOSPlatformVersion {
+	public class Program {
+		static int Main (string [] args)
+		{
+			GC.KeepAlive (typeof (NSObject)); // prevent linking away the platform assembly
+
+			return 0;
+		}
+	}
+}

--- a/tests/dotnet/MaxSupportedOSPlatformVersion/MacCatalyst/Makefile
+++ b/tests/dotnet/MaxSupportedOSPlatformVersion/MacCatalyst/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/MaxSupportedOSPlatformVersion/MacCatalyst/MaxSupportedOSPlatformVersion.csproj
+++ b/tests/dotnet/MaxSupportedOSPlatformVersion/MacCatalyst/MaxSupportedOSPlatformVersion.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/MaxSupportedOSPlatformVersion/Makefile
+++ b/tests/dotnet/MaxSupportedOSPlatformVersion/Makefile
@@ -1,0 +1,2 @@
+TOP=../../..
+include $(TOP)/tests/common/shared-dotnet-test.mk

--- a/tests/dotnet/MaxSupportedOSPlatformVersion/iOS/Makefile
+++ b/tests/dotnet/MaxSupportedOSPlatformVersion/iOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/MaxSupportedOSPlatformVersion/iOS/MaxSupportedOSPlatformVersion.csproj
+++ b/tests/dotnet/MaxSupportedOSPlatformVersion/iOS/MaxSupportedOSPlatformVersion.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/MaxSupportedOSPlatformVersion/macOS/Makefile
+++ b/tests/dotnet/MaxSupportedOSPlatformVersion/macOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/MaxSupportedOSPlatformVersion/macOS/MaxSupportedOSPlatformVersion.csproj
+++ b/tests/dotnet/MaxSupportedOSPlatformVersion/macOS/MaxSupportedOSPlatformVersion.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/MaxSupportedOSPlatformVersion/shared.csproj
+++ b/tests/dotnet/MaxSupportedOSPlatformVersion/shared.csproj
@@ -13,6 +13,12 @@
 
 		<ApplicationTitle>MaxSupportedOSPlatformVersion</ApplicationTitle>
 		<ApplicationId>com.xamarin.maxsupportedosplatformversion</ApplicationId>
+
+		<!-- Disable trimming so that all platforms behave the same way (some platforms, like
+		     Mac Catalyst, trim by default even for a plain 'dotnet build', which would otherwise
+		     remove the unreferenced obsoleted types this test project is trying to keep around).
+		     TrimMode=copy means framework assemblies are copied as-is, without any trimming. -->
+		<TrimMode>copy</TrimMode>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/tests/dotnet/MaxSupportedOSPlatformVersion/shared.csproj
+++ b/tests/dotnet/MaxSupportedOSPlatformVersion/shared.csproj
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+	This project intentionally does not import ../../common/shared-dotnet.csproj, because that
+	file (via SupportedOSPlatformVersions.targets) pins SupportedOSPlatformVersion to each
+	platform's minimum supported OS version. This project exists to test what happens when
+	SupportedOSPlatformVersion is *not* pinned, in which case the .NET SDK defaults it to the
+	highest TargetPlatformVersion available (i.e. the newest installed SDK) - see
+	Microsoft.NET.Sdk.targets ("Default SupportedOSPlatformVersion to TargetPlatformVersion").
+-->
+<Project>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+
+		<ApplicationTitle>MaxSupportedOSPlatformVersion</ApplicationTitle>
+		<ApplicationId>com.xamarin.maxsupportedosplatformversion</ApplicationId>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Compile Include="../AppDelegate.cs" />
+	</ItemGroup>
+</Project>

--- a/tests/dotnet/MaxSupportedOSPlatformVersion/shared.mk
+++ b/tests/dotnet/MaxSupportedOSPlatformVersion/shared.mk
@@ -1,0 +1,3 @@
+TOP=../../../..
+TESTNAME=MaxSupportedOSPlatformVersion
+include $(TOP)/tests/common/shared-dotnet.mk

--- a/tests/dotnet/MaxSupportedOSPlatformVersion/tvOS/Makefile
+++ b/tests/dotnet/MaxSupportedOSPlatformVersion/tvOS/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/MaxSupportedOSPlatformVersion/tvOS/MaxSupportedOSPlatformVersion.csproj
+++ b/tests/dotnet/MaxSupportedOSPlatformVersion/tvOS/MaxSupportedOSPlatformVersion.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/UnitTests/MaxSupportedOSPlatformVersionTest.cs
+++ b/tests/dotnet/UnitTests/MaxSupportedOSPlatformVersionTest.cs
@@ -1,0 +1,34 @@
+#nullable enable
+
+namespace Xamarin.Tests {
+	public class MaxSupportedOSPlatformVersionTest : TestBaseClass {
+		// This test builds a project that doesn't set SupportedOSPlatformVersion explicitly (and
+		// doesn't import tests/common/shared-dotnet.csproj, which would otherwise pin it to each
+		// platform's minimum supported OS version). In this configuration the .NET SDK defaults
+		// SupportedOSPlatformVersion to the highest installed TargetPlatformVersion (i.e. the
+		// newest Xcode SDK version), which is also what happens for any "plain" dotnet build that
+		// doesn't explicitly pin a deployment target.
+		//
+		// With a deployment target this high, the platform assemblies may contain types that
+		// Apple has obsoleted (removed) as of that exact SDK version, and the static registrar
+		// must correctly avoid emitting native implementations for such types (or their protocol
+		// conformances), or the native compiler will fail to build the generated registrar code.
+		[Test]
+		[TestCase (ApplePlatform.iOS, "iossimulator-arm64")]
+		[TestCase (ApplePlatform.TVOS, "tvossimulator-arm64")]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64")]
+		[TestCase (ApplePlatform.MacOSX, "osx-arm64")]
+		public void Build (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
+
+			var project = "MaxSupportedOSPlatformVersion";
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
+			Clean (project_path);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+
+			DotNet.AssertBuild (project_path, properties);
+		}
+	}
+}

--- a/tests/dotnet/UnitTests/MaxSupportedOSPlatformVersionTest.cs
+++ b/tests/dotnet/UnitTests/MaxSupportedOSPlatformVersionTest.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 namespace Xamarin.Tests {
+	[TestFixture]
 	public class MaxSupportedOSPlatformVersionTest : TestBaseClass {
 		// This test builds a project that doesn't set SupportedOSPlatformVersion explicitly (and
 		// doesn't import tests/common/shared-dotnet.csproj, which would otherwise pin it to each
@@ -24,7 +25,7 @@ namespace Xamarin.Tests {
 			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
 
 			var project = "MaxSupportedOSPlatformVersion";
-			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out _);
 			Clean (project_path);
 			var properties = GetDefaultProperties (runtimeIdentifiers);
 


### PR DESCRIPTION
This adds a new .NET test app project (tests/dotnet/MaxSupportedOSPlatformVersion) that deliberately does not import tests/common/shared-dotnet.csproj, so its SupportedOSPlatformVersion isn't pinned to each platform's minimum. Instead, it falls back to the .NET SDK's own default, which is the highest installed TargetPlatformVersion (i.e. the newest Xcode SDK version) - the same situation that caused the `MetalShadersNotRecompiled` test (in IncrementalBuildTest.cs) to be the only test failing when building with Xcode 27.

A corresponding unit test (MaxSupportedOSPlatformVersionTest.Build) was added with one test case per platform (iOS, tvOS, MacCatalyst, macOS).

Verified against Xcode 27 (without the registrar fix applied):
- iOS and MacCatalyst fail, because the static registrar emits a native declaration for UIAccelerometerDelegate, which the 27.0 SDK headers mark unavailable/obsoleted at that exact deployment target, and a Debug dotnet build for these platforms doesn't trim it away (TrimMode=copy is set explicitly in this test project to make Mac Catalyst behave the same as the other platforms, since it otherwise defaults to trimming even for a plain 'dotnet build').
- tvOS and macOS pass, because UIAccelerometer isn't available on those platforms ([NoTV], and UIKit types aren't used on the AppKit-based macOS).

No fix for the underlying registrar issue is included here; this is purely a regression test that documents a gap in the test matrix (deployment targets that float to the newest/highest SDK version, rather than being explicitly pinned).