### PR TITLE
Disable .NET CLI telemetry

### DIFF
--- a/.github/workflows/autoformat-v2.yml
+++ b/.github/workflows/autoformat-v2.yml
@@ -1,6 +1,9 @@
 name: Autoformat code v2
 on: pull_request
 
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/autoformat-v2.yml
+++ b/.github/workflows/autoformat-v2.yml
@@ -2,7 +2,7 @@ name: Autoformat code v2
 on: pull_request
 
 env:
-  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  DOTNET_CLI_TELEMETRY_OPTOUT: '1'
 
 permissions: {}
 

--- a/.github/workflows/maestro-changelog.yml
+++ b/.github/workflows/maestro-changelog.yml
@@ -3,7 +3,7 @@ name: Add changelog for Maestro bump
 on: pull_request
 
 env:
-  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  DOTNET_CLI_TELEMETRY_OPTOUT: '1'
 
 permissions: {}
 

--- a/.github/workflows/maestro-changelog.yml
+++ b/.github/workflows/maestro-changelog.yml
@@ -2,6 +2,9 @@ name: Add changelog for Maestro bump
 
 on: pull_request
 
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+
 permissions: {}
 
 jobs:

--- a/Make.config
+++ b/Make.config
@@ -267,6 +267,8 @@ endif
 
 # We don't need to be told there are workload updates
 export DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE=true
+# No telemetry for us
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
 # We don't need to be told we're using preview packages (we pretty much always are).
 export SuppressNETCoreSdkPreviewMessage=true
 

--- a/tools/devops/automation/templates/variables/common.yml
+++ b/tools/devops/automation/templates/variables/common.yml
@@ -93,6 +93,8 @@ variables:
 
 # Tighten the needed network calls to comply with restrictions
 # See https://devdiv.visualstudio.com/DevDiv/_git/Xamarin.yaml-templates/pullrequest/749941
+- name: DOTNET_CLI_TELEMETRY_OPTOUT
+  value: '1'
 - name: DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE
   value: 'true'
 - name: DOTNET_SDK_VULNERABILITY_CHECK_DISABLE


### PR DESCRIPTION
Set DOTNET_CLI_TELEMETRY_OPTOUT=1 for make-based local builds, Azure pipeline variables, and GitHub Actions workflows that install or run dotnet.

🤖 Pull request created by Copilot
