### PR TITLE
[AppKit] Document ten enum types

### DIFF
--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -3193,11 +3193,12 @@ namespace AppKit {
 		MpsSwapsInFlight = 315,
 	}
 
+	/// <summary>Specifies the position of an OpenGL surface relative to its window.</summary>
 	[NoMacCatalyst]
 	public enum NSSurfaceOrder {
-		/// <summary>To be added.</summary>
+		/// <summary>The surface is displayed above the window.</summary>
 		AboveWindow = 1,
-		/// <summary>To be added.</summary>
+		/// <summary>The surface is displayed below the window.</summary>
 		BelowWindow = -1,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2337,14 +2337,15 @@ namespace AppKit {
 		Clip,
 	}
 
+	/// <summary>Specifies the status of a table in a printer's PostScript Printer Description.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSPrinterTableStatus : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>The table is available.</summary>
 		Ok,
-		/// <summary>To be added.</summary>
+		/// <summary>The table was not found.</summary>
 		NotFound,
-		/// <summary>To be added.</summary>
+		/// <summary>An error occurred while accessing the table.</summary>
 		Error,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -1989,13 +1989,14 @@ namespace AppKit {
 	}
 
 	// NSStackView.h:typedef float NSStackViewVisibilityPriority
+	/// <summary>Specifies the priority for keeping a view visible in a stack view.</summary>
 	[NoMacCatalyst]
 	public enum NSStackViewVisibilityPriority : int {
-		/// <summary>To be added.</summary>
+		/// <summary>The view must remain attached to the stack view.</summary>
 		MustHold = 1000,
-		/// <summary>To be added.</summary>
+		/// <summary>The view is detached only when necessary.</summary>
 		DetachOnlyIfNecessary = 900,
-		/// <summary>To be added.</summary>
+		/// <summary>The view is not visible.</summary>
 		NotVisible = 0,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2948,14 +2948,15 @@ namespace AppKit {
 		NSNoTabsNoBorder,
 	}
 
+	/// <summary>Specifies the visual state of a tab view item.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSTabState : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>The tab is selected.</summary>
 		Selected,
-		/// <summary>To be added.</summary>
+		/// <summary>The tab is displayed in the background.</summary>
 		Background,
-		/// <summary>To be added.</summary>
+		/// <summary>The tab is being pressed.</summary>
 		Pressed,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -1386,14 +1386,15 @@ namespace AppKit {
 		ReadWrite,
 	}
 
+	/// <summary>Specifies where a window's backing store is located.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSWindowBackingLocation : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>The system determines the backing store location.</summary>
 		Default,
-		/// <summary>To be added.</summary>
+		/// <summary>The backing store is located in video memory.</summary>
 		VideoMemory,
-		/// <summary>To be added.</summary>
+		/// <summary>The backing store is located in main memory.</summary>
 		MainMemory,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -1989,7 +1989,7 @@ namespace AppKit {
 	}
 
 	// NSStackView.h:typedef float NSStackViewVisibilityPriority
-	/// <summary>Specifies the priority for keeping a view visible in a stack view.</summary>
+	/// <summary>Provides predefined visibility-priority values that can be cast to <see cref="float"/> for use with <see cref="NSStackView"/> APIs.</summary>
 	[NoMacCatalyst]
 	public enum NSStackViewVisibilityPriority : int {
 		/// <summary>The view must remain attached to the stack view.</summary>

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2906,13 +2906,14 @@ namespace AppKit {
 		Default = Async | AllowingClassicStartup,
 	}
 
+	/// <summary>Specifies legacy icon representations to exclude when creating a file icon.</summary>
 	[NoMacCatalyst]
 	[Flags]
 	[Native]
 	public enum NSWorkspaceIconCreationOptions : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Excludes QuickDraw icon representations.</summary>
 		NSExcludeQuickDrawElements = 1 << 1,
-		/// <summary>To be added.</summary>
+		/// <summary>Excludes icon representations introduced in macOS 10.4.</summary>
 		NSExclude10_4Elements = 1 << 2,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -4022,15 +4022,16 @@ namespace AppKit {
 		AllModesMask = unchecked((ulong) UInt32.MaxValue),
 	}
 
+	/// <summary>Specifies the scope in which a font collection is visible.</summary>
 	[NoMacCatalyst]
 	[Flags]
 	[Native]
 	public enum NSFontCollectionVisibility : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>The collection is visible only to the current process and is not persistent.</summary>
 		Process = 1 << 0,
-		/// <summary>To be added.</summary>
+		/// <summary>The collection is persisted and visible to all processes for the current user.</summary>
 		User = 1 << 1,
-		/// <summary>To be added.</summary>
+		/// <summary>The collection is persisted and visible to all users of the computer.</summary>
 		Computer = 1 << 2,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -3786,13 +3786,14 @@ namespace AppKit {
 		MayBegin = 32,
 	}
 
+	/// <summary>Specifies options for tracking a swipe gesture.</summary>
 	[NoMacCatalyst]
 	[Flags]
 	[Native]
 	public enum NSEventSwipeTrackingOptions : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Clamps the gesture amount to zero when the user reverses the initial swipe direction.</summary>
 		LockDirection = 1,
-		/// <summary>To be added.</summary>
+		/// <summary>Clamps the gesture amount to the range from -1.0 through 1.0.</summary>
 		ClampGestureAmount = 2,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -3796,14 +3796,15 @@ namespace AppKit {
 		ClampGestureAmount = 2,
 	}
 
+	/// <summary>Specifies the axis associated with a gesture event.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSEventGestureAxis : long {
-		/// <summary>To be added.</summary>
+		/// <summary>The gesture is not associated with an axis.</summary>
 		None,
-		/// <summary>To be added.</summary>
+		/// <summary>The gesture is associated with the horizontal axis.</summary>
 		Horizontal,
-		/// <summary>To be added.</summary>
+		/// <summary>The gesture is associated with the vertical axis.</summary>
 		Vertical,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -1668,14 +1668,15 @@ namespace AppKit {
 	#endregion
 
 	#region NSGraphics
+	/// <summary>Specifies the color depth of a window's backing store.</summary>
 	[NoMacCatalyst]
 	// NSGraphics.h:typedef int NSWindowDepth;
 	public enum NSWindowDepth : int {
-		/// <summary>To be added.</summary>
+		/// <summary>A 24-bit RGB color depth.</summary>
 		TwentyfourBitRgb = 0x208,
-		/// <summary>To be added.</summary>
+		/// <summary>A 64-bit RGB color depth.</summary>
 		SixtyfourBitRgb = 0x210,
-		/// <summary>To be added.</summary>
+		/// <summary>A 128-bit RGB color depth.</summary>
 		OneHundredTwentyEightBitRgb = 0x220,
 	}
 

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22611,7 +22611,6 @@ T:AppKit.NSStoryboardControllerCreator
 T:AppKit.NSStringAttributeKey
 T:AppKit.NSStringDrawing_NSAttributedString
 T:AppKit.NSStringDrawing_NSString
-T:AppKit.NSSurfaceOrder
 T:AppKit.NSTableReorder
 T:AppKit.NSTableViewAnimation
 T:AppKit.NSTableViewAnimationOptions

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22642,7 +22642,6 @@ T:AppKit.NSTableViewToolTip
 T:AppKit.NSTableViewUserCanChangeColumnVisibility
 T:AppKit.NSTableViewViewGetter
 T:AppKit.NSTabPosition
-T:AppKit.NSTabState
 T:AppKit.NSTabViewBorderType
 T:AppKit.NSTabViewControllerTabStyle
 T:AppKit.NSTabViewPredicate

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22607,7 +22607,6 @@ T:AppKit.NSSpringLoadingHighlight
 T:AppKit.NSSpringLoadingOptions
 T:AppKit.NSStackViewDistribution
 T:AppKit.NSStackViewGravity
-T:AppKit.NSStackViewVisibilityPriority
 T:AppKit.NSStandardKeyBindingMethods
 T:AppKit.NSStoryboardControllerCreator
 T:AppKit.NSStringAttributeKey

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22746,7 +22746,6 @@ T:AppKit.NSVisualEffectMaterial
 T:AppKit.NSVisualEffectState
 T:AppKit.NSWindowAnimationBehavior
 T:AppKit.NSWindowApplicationPresentationOptions
-T:AppKit.NSWindowBackingLocation
 T:AppKit.NSWindowButton
 T:AppKit.NSWindowClient
 T:AppKit.NSWindowCollectionBehavior

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22767,7 +22767,6 @@ T:AppKit.NSWindowUndoManager
 T:AppKit.NSWindowUserTabbingPreference
 T:AppKit.NSWindowWindows
 T:AppKit.NSWorkspaceAuthorizationType
-T:AppKit.NSWorkspaceIconCreationOptions
 T:AppKit.NSWorkspaceLaunchOptions
 T:AppKit.NSWorkspaceUrlHandler
 T:AppKit.NSWritingToolsBehavior

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22559,7 +22559,6 @@ T:AppKit.NSPointingDeviceType
 T:AppKit.NSPopoverBehavior
 T:AppKit.NSPopUpArrowPosition
 T:AppKit.NSPressureBehavior
-T:AppKit.NSPrinterTableStatus
 T:AppKit.NSPrintPanelOptions
 T:AppKit.NSPrintPanelResult
 T:AppKit.NSPrintRenderingQuality

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22454,7 +22454,6 @@ T:AppKit.NSDraggingItemImagesContentProvider
 T:AppKit.NSDragOperation
 T:AppKit.NSDrawerState
 T:AppKit.NSEventButtonMask
-T:AppKit.NSEventGestureAxis
 T:AppKit.NSEventMask
 T:AppKit.NSEventModifierFlags
 T:AppKit.NSEventModifierMask

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22750,7 +22750,6 @@ T:AppKit.NSWindowButton
 T:AppKit.NSWindowClient
 T:AppKit.NSWindowCollectionBehavior
 T:AppKit.NSWindowCompletionHandler
-T:AppKit.NSWindowDepth
 T:AppKit.NSWindowDocumentDrag
 T:AppKit.NSWindowFrame
 T:AppKit.NSWindowFramePredicate

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22461,7 +22461,6 @@ T:AppKit.NSEventPhase
 T:AppKit.NSEventSubtype
 T:AppKit.NSEventTrackHandler
 T:AppKit.NSEventType
-T:AppKit.NSFontCollectionVisibility
 T:AppKit.NSFontDescriptorSystemDesign
 T:AppKit.NSFontError
 T:AppKit.NSFontPanelMode

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22459,7 +22459,6 @@ T:AppKit.NSEventModifierFlags
 T:AppKit.NSEventModifierMask
 T:AppKit.NSEventPhase
 T:AppKit.NSEventSubtype
-T:AppKit.NSEventSwipeTrackingOptions
 T:AppKit.NSEventTrackHandler
 T:AppKit.NSEventType
 T:AppKit.NSFontCollectionVisibility


### PR DESCRIPTION

Document ten AppKit enum types and all their members:

- `NSWindowBackingLocation`
- `NSWindowDepth`
- `NSStackViewVisibilityPriority`
- `NSPrinterTableStatus`
- `NSWorkspaceIconCreationOptions`
- `NSTabState`
- `NSSurfaceOrder`
- `NSEventGestureAxis`
- `NSEventSwipeTrackingOptions`
- `NSFontCollectionVisibility`

Remove the matching entries from the Cecil documentation known-failures list.

🤖 Pull request created by Copilot