### PR TITLE
[release/10.0.1xx] [msbuild] Discard any simulators we get from devicectl in the GetAvailableDevices task.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetAvailableDevices.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetAvailableDevices.cs
@@ -45,14 +45,13 @@ public class GetAvailableDevices : XamarinTask, ICancelableTask {
 		System.Threading.Tasks.Task.WhenAll (new [] { devicectlTask, simctlTask }).Wait (cancellationTokenSource.Token);
 
 		var devices = new List<DeviceInfo> ();
-		devices.AddRange (simctlTask.Result);
-
-		// devicectl may return simulators as well, so exclude any devices we've already added
-		var existingUdids = new HashSet<string> (devices.Select (d => d.Udid), StringComparer.OrdinalIgnoreCase);
+		var simulators = simctlTask.Result.ToList ();
+		var simulatorUdids = new HashSet<string> (simulators.Select (d => d.Udid), StringComparer.OrdinalIgnoreCase);
 		foreach (var device in devicectlTask.Result) {
-			if (existingUdids.Add (device.Udid))
+			if (!simulatorUdids.Contains (device.Udid))
 				devices.Add (device);
 		}
+		devices.AddRange (simulators);
 
 		// filter to the current platform
 		foreach (var d in devices.Where (d => !d.Discarded && d.Platform != Platform))

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetAvailableDevices.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetAvailableDevices.cs
@@ -48,8 +48,11 @@ public class GetAvailableDevices : XamarinTask, ICancelableTask {
 		devices.AddRange (simctlTask.Result);
 
 		// devicectl may return simulators as well, so exclude any devices we've already added
-		var devicectlDevices = devicectlTask.Result;
-		devices.AddRange (devicectlDevices.Where (dev => !devices.Any (sim => sim.Udid == dev.Udid)));
+		var existingUdids = new HashSet<string> (devices.Select (d => d.Udid), StringComparer.OrdinalIgnoreCase);
+		foreach (var device in devicectlTask.Result) {
+			if (existingUdids.Add (device.Udid))
+				devices.Add (device);
+		}
 
 		// filter to the current platform
 		foreach (var d in devices.Where (d => !d.Discarded && d.Platform != Platform))

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetAvailableDevices.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetAvailableDevices.cs
@@ -45,8 +45,11 @@ public class GetAvailableDevices : XamarinTask, ICancelableTask {
 		System.Threading.Tasks.Task.WhenAll (new [] { devicectlTask, simctlTask }).Wait (cancellationTokenSource.Token);
 
 		var devices = new List<DeviceInfo> ();
-		devices.AddRange (devicectlTask.Result);
 		devices.AddRange (simctlTask.Result);
+
+		// devicectl may return simulators as well, so exclude any devices we've already added
+		var devicectlDevices = devicectlTask.Result;
+		devices.AddRange (devicectlDevices.Where (dev => !devices.Any (sim => sim.Udid == dev.Udid)));
 
 		// filter to the current platform
 		foreach (var d in devices.Where (d => !d.Discarded && d.Platform != Platform))
@@ -133,15 +136,17 @@ public class GetAvailableDevices : XamarinTask, ICancelableTask {
 
 	class DeviceInfo {
 		public ITaskItem Item { get; set; }
+		public string Udid { get; set; }
 		public IEnumerable<string> RuntimeIdentifiers { get; set; }
 		public ApplePlatform Platform { get; set; }
 		public IPhoneDeviceType DeviceType { get; set; }
 		public Version MinimumOSVersion { get; set; }
 		public string DiscardedReason { get; set; }
 		public bool Discarded { get => !string.IsNullOrEmpty (DiscardedReason); }
-		public DeviceInfo (ITaskItem item, IEnumerable<string> runtimeIdentifiers, ApplePlatform platform, IPhoneDeviceType deviceType, Version minimumOSVersion, string discardedReason)
+		public DeviceInfo (ITaskItem item, string udid, IEnumerable<string> runtimeIdentifiers, ApplePlatform platform, IPhoneDeviceType deviceType, Version minimumOSVersion, string discardedReason)
 		{
 			Item = item;
+			Udid = udid;
 			RuntimeIdentifiers = runtimeIdentifiers;
 			Platform = platform;
 			DeviceType = deviceType;
@@ -252,7 +257,7 @@ public class GetAvailableDevices : XamarinTask, ICancelableTask {
 
 			Version.TryParse (device.OSVersion, out var minimumOSVersion);
 
-			rv.Add (new DeviceInfo (item, [runtimeIdentifier], platform, deviceType, minimumOSVersion ?? new Version (0, 0), discardedReason));
+			rv.Add (new DeviceInfo (item, udid, [runtimeIdentifier], platform, deviceType, minimumOSVersion ?? new Version (0, 0), discardedReason));
 		}
 		return rv;
 	}
@@ -390,7 +395,7 @@ public class GetAvailableDevices : XamarinTask, ICancelableTask {
 				}
 			}
 
-			rv.Add (new DeviceInfo (item, runtimeIdentifiers, platform, deviceType, minimumOSVersion, discardedReason));
+			rv.Add (new DeviceInfo (item, device.Udid, runtimeIdentifiers, platform, deviceType, minimumOSVersion, discardedReason));
 		}
 		return rv;
 	}

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetAvailableDevicesTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetAvailableDevicesTest.cs
@@ -107,6 +107,20 @@ namespace Xamarin.MacDev.Tasks {
 		}
 
 		[Test]
+		public void DeviceCtlDuplicateSimulator ()
+		{
+			var platform = ApplePlatform.iOS;
+			var task = CreateTask (platform, SIMCTL_JSON_1, DEVICECTL_JSON_1.Replace ("00008003-012301230123ABCD", "3F1C114D-FC3D-481A-9CA1-499EE1339390"));
+			Assert.That (task.Execute (), Is.True, "Task should have succeeded.");
+
+			Assert.Multiple (() => {
+				Assert.That (task.Devices.Count, Is.EqualTo (4), "Devices count mismatch.");
+				Assert.That (task.Devices.Count (d => d.ItemSpec == "3F1C114D-FC3D-481A-9CA1-499EE1339390"), Is.EqualTo (1), "Duplicate simulator count mismatch.");
+				Assert.That (task.Devices.Single (d => d.ItemSpec == "3F1C114D-FC3D-481A-9CA1-499EE1339390").GetMetadata ("Type"), Is.EqualTo ("Simulator"), "Simulator metadata mismatch.");
+			});
+		}
+
+		[Test]
 		public void SimCtl1 ()
 		{
 			if (!Configuration.CanRunArm64)


### PR DESCRIPTION
In Xcode 27+, `devicectl` returns simulators too. Discard any simulators we get from `devicectl` (the json output from `devicectl` doesn't contain all the information we need) that matches an existing simulator we got from `simctl`.

Backport of #26576.