### PR TITLE
[tests] Avoid DispatchGroup console deadlock. Fixes #26537

### DIFF
--- a/tests/monotouch-test/CoreFoundation/DispatchGroupTest.cs
+++ b/tests/monotouch-test/CoreFoundation/DispatchGroupTest.cs
@@ -19,15 +19,15 @@ namespace MonoTouchFixtures.CoreFoundation {
 		{
 			using (var dg = DispatchGroup.Create ()) {
 				var dq = DispatchQueue.GetGlobalQueue (DispatchQueuePriority.Default);
-				var called = false;
+				var called = new TaskCompletionSource<bool> ();
 
 				dg.DispatchAsync (dq, delegate
 				{
-					called = true;
+					called.SetResult (true);
 				});
 
 				Assert.That (dg.Wait (DispatchTime.Forever), Is.True);
-				Assert.That (called, Is.True, "Called");
+				Assert.That (called.Task.Result, Is.True, "Called");
 				dq.Dispose ();
 			}
 		}

--- a/tests/monotouch-test/CoreFoundation/DispatchGroupTest.cs
+++ b/tests/monotouch-test/CoreFoundation/DispatchGroupTest.cs
@@ -7,6 +7,8 @@
 // Copyright 2013 Xamarin Inc. All rights reserved.
 //
 
+using System.Threading.Tasks;
+
 using Xamarin.Utils;
 
 namespace MonoTouchFixtures.CoreFoundation {

--- a/tests/monotouch-test/CoreFoundation/DispatchGroupTest.cs
+++ b/tests/monotouch-test/CoreFoundation/DispatchGroupTest.cs
@@ -19,13 +19,15 @@ namespace MonoTouchFixtures.CoreFoundation {
 		{
 			using (var dg = DispatchGroup.Create ()) {
 				var dq = DispatchQueue.GetGlobalQueue (DispatchQueuePriority.Default);
+				var called = false;
 
 				dg.DispatchAsync (dq, delegate
 				{
-					Console.WriteLine ("Inside dispatch");
+					called = true;
 				});
 
 				Assert.That (dg.Wait (DispatchTime.Forever), Is.True);
+				Assert.That (called, Is.True, "Called");
 				dq.Dispose ();
 			}
 		}


### PR DESCRIPTION
There's a deadlock when Console.WriteLine is called from background threads in our NUnit tests; there's a fix in progress (#26580).

However, calling Console.WriteLine in the background for this particular test is unnecessary anyways, so just don't do it, which also fixes this specific issue.

Fixes https://github.com/dotnet/macios/issues/26537.

🤖 Pull request created by Copilot