### PR TITLE
[dotnet] Use the existing '$(_BundlerDebug)' property instead of the '$(Configuration)' property to determine whether R2R assemblies are filtered or not.

### DIFF
--- a/dotnet/targets/Microsoft.Sdk.R2R.targets
+++ b/dotnet/targets/Microsoft.Sdk.R2R.targets
@@ -66,7 +66,12 @@
 		<CreateR2RFramework Condition="'$(CreateR2RFramework)' == '' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS')">true</CreateR2RFramework>
 		<CreateR2RDylib Condition="'$(CreateR2RDylib)' == '' And '$(CreateR2RFramework)' != 'true'">true</CreateR2RDylib>
 
-		<FilterReadyToRunAssemblies Condition="'$(FilterReadyToRunAssemblies)' == '' And '$(Configuration)' != 'Release'">true</FilterReadyToRunAssemblies>
+		<!--
+		We don't R2R user assemblies when we're building a debug build:
+		  * because R2R-compiled assemblies aren't debuggable.
+		  * to speed up debug builds.
+		-->
+		<FilterReadyToRunAssemblies Condition="'$(FilterReadyToRunAssemblies)' == '' And '$(_BundlerDebug)' == 'true'">true</FilterReadyToRunAssemblies>
 	</PropertyGroup>
 
 


### PR DESCRIPTION
We're trying to move away from build behavior depending on the '$(Configuration)' property (https://github.com/dotnet/sdk/issues/31918), so use the existing '$(_BundlerDebug)' property (which we use in a number of other places to determine whether we're building a debug build or a release build) instead of '$(Configuration)'.