### PR TITLE
[localization] Preserve Windows paths in LocProject.

### DIFF
--- a/tools/devops/generate-loc-project.sh
+++ b/tools/devops/generate-loc-project.sh
@@ -83,7 +83,7 @@ cat <<EOF
 EOF
 
 # Add entries for all template localization JSON files
-ABSTOP=$(cd "$TOP" && pwd)
+ABSTOP="$WORKING_DIRECTORY/../.."
 find "$ABSTOP/dotnet/Templates" -name 'templatestrings.en.json' | sort | while read -r f; do
 	dir=$(dirname "$f")
 	cat <<EOF


### PR DESCRIPTION
Use the working directory supplied by make when locating template localization files so Git Bash does not rewrite the drive prefix to `/d/`.

OneLocBuild otherwise interprets the generated path as relative and prepends the Windows drive, producing an invalid `D:\d\...` path. This has caused the localization stage on `main` to fail since template localization files were added to `LocProject.json`.

🤖 Pull request created by Copilot