### PR TITLE
[msbuild/bgen] Run bgen in the MSBuild task process. Fixes #26584

### DIFF
--- a/docs/website/generator-errors.md
+++ b/docs/website/generator-errors.md
@@ -359,6 +359,8 @@ and rename the binding method if a different factory method name is desired.
 
 ### <a name='BI1128'/>BI1128: The [Field] member '\*.\*' sets SymbolAddress, but its type is '\*'; only System.IntPtr is supported.
 
+### <a name='BI1129'/>BI1129: Export attribute contains invalid selector name: '\*'
+
 <!-- 2xxx: reserved -->
 <!-- 3xxx: reserved -->
 <!-- 4xxx: reserved -->

--- a/msbuild/ILMerge.targets
+++ b/msbuild/ILMerge.targets
@@ -22,6 +22,7 @@
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'DotNetZip'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'ILLink.Tasks'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'ILStrip'" />
+      <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Mono.Options'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Newtonsoft.Json'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Renci.SshNet'" />
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'BouncyCastle.Cryptography'" />

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/BGen.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/BGen.cs
@@ -68,6 +68,8 @@ namespace Xamarin.MacDev.Tasks {
 
 		public bool ProcessEnums { get; set; }
 
+		public bool UseExternalProcess { get; set; }
+
 		[Required]
 		public string ProjectDir { get; set; } = string.Empty;
 
@@ -271,9 +273,25 @@ namespace Xamarin.MacDev.Tasks {
 			if (Log.HasLoggedErrors)
 				return false;
 
-			var output = new StringBuilder ();
 			var customHome = Environment.GetEnvironmentVariable ("DOTNET_CUSTOM_HOME");
 			cancellationTokenSource = new CancellationTokenSource ();
+			if (UseExternalProcess) {
+				var env = new Dictionary<string, string?> ();
+				if (!string.IsNullOrEmpty (customHome))
+					env ["HOME"] = customHome;
+
+				var bgenPath = PathUtils.ConvertToMacPath (BGenToolPath);
+				var bgenExe = PathUtils.ConvertToMacPath (BGenToolExe);
+				args.Insert (0, Path.Combine (bgenPath, bgenExe));
+				var executable = this.GetDotNetPath ();
+				if (Log.HasLoggedErrors)
+					return false;
+
+				ExecuteAsync (executable, args, environment: env, cancellationToken: cancellationTokenSource.Token).Wait ();
+				return !Log.HasLoggedErrors;
+			}
+
+			var output = new StringBuilder ();
 			ThreadStaticTextWriter.ReplaceConsole (output);
 			int exitCode;
 			try {

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/BGen.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/BGen.cs
@@ -306,22 +306,9 @@ namespace Xamarin.MacDev.Tasks {
 			return !Log.HasLoggedErrors;
 		}
 
-		static readonly object homeEnvironmentLock = new ();
-
 		static int ExecuteBGen (List<string> args, string? customHome, CancellationToken cancellationToken)
 		{
-			if (string.IsNullOrEmpty (customHome))
-				return BindingTouch.Run (args.ToArray (), cancellationToken);
-
-			lock (homeEnvironmentLock) {
-				var previousHome = Environment.GetEnvironmentVariable ("HOME");
-				Environment.SetEnvironmentVariable ("HOME", customHome);
-				try {
-					return BindingTouch.Run (args.ToArray (), cancellationToken);
-				} finally {
-					Environment.SetEnvironmentVariable ("HOME", previousHome);
-				}
-			}
+			return BindingTouch.Run (args.ToArray (), cancellationToken, customHome);
 		}
 
 		public bool ShouldCopyToBuildServer (ITaskItem item) => !item.IsFrameworkItem ();

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/BGen.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/BGen.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -257,12 +256,6 @@ namespace Xamarin.MacDev.Tasks {
 			AttributeAssembly = PathUtils.ConvertToMacPath (AttributeAssembly);
 			BaseLibDll = PathUtils.ConvertToMacPath (BaseLibDll);
 
-			var customHome = Environment.GetEnvironmentVariable ("DOTNET_CUSTOM_HOME");
-			var env = new Dictionary<string, string?> ();
-			if (!string.IsNullOrEmpty (customHome)) {
-				env ["HOME"] = customHome;
-			}
-
 			if (!string.IsNullOrEmpty (SessionId) &&
 				!string.IsNullOrEmpty (GeneratedSourcesDir) &&
 				!Directory.Exists (GeneratedSourcesDir)) {
@@ -274,18 +267,43 @@ namespace Xamarin.MacDev.Tasks {
 				return false;
 			}
 
-			var bgenPath = PathUtils.ConvertToMacPath (BGenToolPath);
-			var bgenExe = PathUtils.ConvertToMacPath (BGenToolExe);
-			var bgen = Path.Combine (bgenPath, bgenExe);
 			var args = GenerateCommandLineArguments ();
-			args.Insert (0, bgen);
-			var executable = this.GetDotNetPath ();
 			if (Log.HasLoggedErrors)
 				return false;
 
+			var output = new StringBuilder ();
+			var customHome = Environment.GetEnvironmentVariable ("DOTNET_CUSTOM_HOME");
 			cancellationTokenSource = new CancellationTokenSource ();
-			ExecuteAsync (executable, args, environment: env, cancellationToken: cancellationTokenSource.Token).Wait ();
+			ThreadStaticTextWriter.ReplaceConsole (output);
+			int exitCode;
+			try {
+				exitCode = ExecuteBGen (args, customHome);
+			} finally {
+				ThreadStaticTextWriter.RestoreConsole ();
+			}
+			if (exitCode != 0)
+				Log.LogError (output.ToString ());
+			else if (output.Length > 0)
+				Log.LogMessage (MessageImportance.Low, output.ToString ());
 			return !Log.HasLoggedErrors;
+		}
+
+		static readonly object homeEnvironmentLock = new ();
+
+		static int ExecuteBGen (List<string> args, string? customHome)
+		{
+			if (string.IsNullOrEmpty (customHome))
+				return BindingTouch.Main (args.ToArray ());
+
+			lock (homeEnvironmentLock) {
+				var previousHome = Environment.GetEnvironmentVariable ("HOME");
+				Environment.SetEnvironmentVariable ("HOME", customHome);
+				try {
+					return BindingTouch.Main (args.ToArray ());
+				} finally {
+					Environment.SetEnvironmentVariable ("HOME", previousHome);
+				}
+			}
 		}
 
 		public bool ShouldCopyToBuildServer (ITaskItem item) => !item.IsFrameworkItem ();
@@ -330,6 +348,81 @@ namespace Xamarin.MacDev.Tasks {
 			}
 
 			File.WriteAllLines (GeneratedSourcesFileList, localGeneratedSourcesFileNames);
+		}
+
+		sealed class ThreadStaticTextWriter : TextWriter {
+			[ThreadStatic]
+			static TextWriter? currentWriter;
+
+			static readonly ThreadStaticTextWriter instance = new ();
+			static readonly object lockObject = new ();
+			static int counter;
+			static TextWriter? originalStdout;
+			static TextWriter? originalStderr;
+
+			public override Encoding Encoding => Encoding.UTF8;
+
+			public static void ReplaceConsole (StringBuilder output)
+			{
+				lock (lockObject) {
+					if (counter == 0) {
+						originalStdout = Console.Out;
+						originalStderr = Console.Error;
+						Console.SetOut (instance);
+						Console.SetError (instance);
+					}
+					counter++;
+					currentWriter = new StringWriter (output);
+				}
+			}
+
+			public static void RestoreConsole ()
+			{
+				lock (lockObject) {
+					currentWriter?.Dispose ();
+					currentWriter = null;
+					counter--;
+					if (counter == 0) {
+						if (originalStdout is null || originalStderr is null)
+							throw new InvalidOperationException ("The original console writers were not captured.");
+						Console.SetOut (originalStdout);
+						Console.SetError (originalStderr);
+						originalStdout = null;
+						originalStderr = null;
+					}
+				}
+			}
+
+			TextWriter CurrentWriter {
+				get {
+					lock (lockObject)
+						return currentWriter ?? originalStdout ?? TextWriter.Null;
+				}
+			}
+
+			public override void Write (char value)
+			{
+				lock (lockObject)
+					CurrentWriter.Write (value);
+			}
+
+			public override void Write (string? value)
+			{
+				lock (lockObject)
+					CurrentWriter.Write (value);
+			}
+
+			public override void WriteLine ()
+			{
+				lock (lockObject)
+					CurrentWriter.WriteLine ();
+			}
+
+			public override void WriteLine (string? value)
+			{
+				lock (lockObject)
+					CurrentWriter.WriteLine (value);
+			}
 		}
 
 		string GetLocalRelativePath (string path)

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/BGen.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/BGen.cs
@@ -295,7 +295,7 @@ namespace Xamarin.MacDev.Tasks {
 			ThreadStaticTextWriter.ReplaceConsole (output);
 			int exitCode;
 			try {
-				exitCode = ExecuteBGen (args, customHome);
+				exitCode = ExecuteBGen (args, customHome, cancellationTokenSource.Token);
 			} finally {
 				ThreadStaticTextWriter.RestoreConsole ();
 			}
@@ -308,16 +308,16 @@ namespace Xamarin.MacDev.Tasks {
 
 		static readonly object homeEnvironmentLock = new ();
 
-		static int ExecuteBGen (List<string> args, string? customHome)
+		static int ExecuteBGen (List<string> args, string? customHome, CancellationToken cancellationToken)
 		{
 			if (string.IsNullOrEmpty (customHome))
-				return BindingTouch.Main (args.ToArray ());
+				return BindingTouch.Run (args.ToArray (), cancellationToken);
 
 			lock (homeEnvironmentLock) {
 				var previousHome = Environment.GetEnvironmentVariable ("HOME");
 				Environment.SetEnvironmentVariable ("HOME", customHome);
 				try {
-					return BindingTouch.Main (args.ToArray ());
+					return BindingTouch.Run (args.ToArray (), cancellationToken);
 				} finally {
 					Environment.SetEnvironmentVariable ("HOME", previousHome);
 				}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/XamarinTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/XamarinTask.cs
@@ -426,13 +426,13 @@ namespace Xamarin.MacDev.Tasks {
 		protected void LogDiagnostic (ProductException exception)
 		{
 			switch (exception.GetWarningLevel (this)) {
-			case ErrorHelper.WarningLevel.Warning:
+			case Xamarin.Bundler.ErrorHelper.WarningLevel.Warning:
 				Log.LogWarning (exception.Code, exception.FileName, exception.LineNumber, exception.Message);
 				break;
-			case ErrorHelper.WarningLevel.Error:
+			case Xamarin.Bundler.ErrorHelper.WarningLevel.Error:
 				Log.LogError (exception.Code, exception.FileName, exception.LineNumber, exception.Message);
 				break;
-			case ErrorHelper.WarningLevel.Disable:
+			case Xamarin.Bundler.ErrorHelper.WarningLevel.Disable:
 			default:
 				Log.LogMessage (MessageImportance.Low, exception.Code, exception.FileName, exception.LineNumber, exception.Message);
 				break;

--- a/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
+++ b/msbuild/Xamarin.MacDev.Tasks/Xamarin.MacDev.Tasks.csproj
@@ -8,18 +8,20 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../product.snk</AssemblyOriginatorKeyFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants>$(DefineConstants);MSBUILD_TASKS</DefineConstants>
+    <DefineConstants>$(DefineConstants);MSBUILD_TASKS;BGENERATOR;NET_4_0;NO_AUTHENTICODE;STATIC;NO_SYMBOL_WRITER</DefineConstants>
     <NoWarn>$(NoWarn);NU1603</NoWarn> <!-- Xamarin.Messaging.Build.Common 1.6.24 depends on Merq (>= 1.1.0) but Merq 1.1.0 was not found. An approximate best match of Merq 1.1.4 was resolved. -->
     <NoWarn>$(NoWarn);NU1701</NoWarn> <!-- Package 'Microsoft.Build 16.10.0' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8, .NETFramework,Version=v4.8.1' instead of the project target framework '.NETStandard,Version=v2.0'. This package may not be fully compatible with your project. -->
     <NoWarn>$(NoWarn);MSB3277</NoWarn> <!-- warning MSB3277: Found conflicts between different versions of "System.Reflection.Metadata" that could not be resolved. -->
     <NoWarn>$(NoWarn);8002</NoWarn> <!-- Referenced projects aren't signed: this doesn't matter, because we use ILMerge to merge into a single assembly which we sign -->
     <NoWarn>$(NoWarn);CS0618</NoWarn> <!-- AppleSdkSettings is [Obsolete] in favor of XcodeLocator; suppress until migration is complete -->
+    <NoWarn>$(NoWarn);APL0003</NoWarn>
     <CopyLocalLockFileAssemblies Condition="'$(TargetFramework)' == 'net$(BundledNETCoreAppTargetFrameworkVersion)'">true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <Import Project="..\..\eng\Versions.props" />
 
   <ItemGroup>
+    <PackageReference Include="Mono.Options" Version="6.12.0.148" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="Mono.Cecil" Version="$(MonoCecilPackageVersion)" />
@@ -71,6 +73,27 @@
   </Target>
 
   <ItemGroup>
+    <Compile Include="..\..\src\bgen\**\*.cs" Exclude="..\..\src\bgen\bin\**\*.cs;..\..\src\bgen\obj\**\*.cs" />
+    <Compile Include="..\..\src\ObjCBindings\BindingTypeAttribute.cs" />
+    <Compile Include="..\..\src\ObjCBindings\BindingTypeTag.cs" />
+    <Compile Include="..\..\src\ObjCRuntime\Stret.cs" />
+    <Compile Include="..\..\src\build\dotnet\generator-frameworks.g.cs" />
+    <Compile Include="..\..\src\Foundation\AdviceAttribute.cs" />
+    <Compile Include="..\..\src\Foundation\FieldAttribute.cs" />
+    <Compile Include="..\..\src\Foundation\ModelAttribute.cs" />
+    <Compile Include="..\..\src\Foundation\NotImplementedAttribute.cs" />
+    <Compile Include="..\..\src\Foundation\PreserveAttribute.cs" />
+    <Compile Include="..\..\src\Foundation\ProtocolAttribute.cs" />
+    <Compile Include="..\..\src\Foundation\RegisterAttribute.cs" />
+    <Compile Include="..\..\src\Foundation\XpcInterfaceAttribute.cs" />
+    <Compile Include="..\..\src\ObjCRuntime\BindAsAttribute.cs" />
+    <Compile Include="..\..\src\ObjCRuntime\BlockCallbackAttribute.cs" />
+    <Compile Include="..\..\src\ObjCRuntime\CCallbackAttribute.cs" />
+    <Compile Include="..\..\src\ObjCRuntime\NativeAttribute.cs" />
+    <Compile Include="..\..\src\ObjCRuntime\ObjectiveCFrameworkAttribute.cs" />
+    <Compile Include="..\..\src\ObjCRuntime\SupportedSimulatorAttribute.cs" />
+    <Compile Include="..\..\src\ObjCRuntime\Registrar.core.cs" />
+    <Compile Include="..\..\src\ObjCRuntime\RequiresSuperAttribute.cs" />
     <Compile Include="..\..\tools\common\JsonExtensions.cs">
       <Link>external\JsonExtensions.cs</Link>
     </Compile>
@@ -96,6 +119,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="../../src/Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <StronglyTypedFileName>$(IntermediateOutputPath)BGenResources.Designer.cs</StronglyTypedFileName>
+      <StronglyTypedLanguage>CSharp</StronglyTypedLanguage>
+      <StronglyTypedNamespace>bgen</StronglyTypedNamespace>
+      <StronglyTypedClassName>Resources</StronglyTypedClassName>
+      <ManifestResourceName>bgen.Resources</ManifestResourceName>
+      <GenerateResource>true</GenerateResource>
+      <PublicClass>false</PublicClass>
+    </EmbeddedResource>
     <EmbeddedResource Include="../../tools/mtouch/Errors.resx">
 
     <!--

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2098,6 +2098,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 			BGenToolPath="$(BGenToolPath)"
 			BGenToolExe="$(BGenToolExe)"
+			UseExternalProcess="$(_BGenUseExternalProcess)"
 			>
 		</BGen>
 	</Target>

--- a/scripts/generate-frameworks/README.md
+++ b/scripts/generate-frameworks/README.md
@@ -9,7 +9,7 @@ Example output file for iOS:
 ```cs
 using System.Collections.Generic;
 
-partial class Frameworks {
+partial class BGenFrameworks {
 	internal readonly HashSet<string> iosframeworks = new HashSet<string> {
 		"Accelerate",
 		"Accessibility",

--- a/scripts/generate-frameworks/generate-frameworks.cs
+++ b/scripts/generate-frameworks/generate-frameworks.cs
@@ -38,7 +38,7 @@ try {
 	var sb = new StringBuilder ();
 	sb.AppendLine ("using System.Collections.Generic;");
 	sb.AppendLine ();
-	sb.AppendLine ("partial class Frameworks {");
+	sb.AppendLine ("partial class BGenFrameworks {");
 
 	for (int i = 0; i < names.Length; i++) {
 		var name = names [i];

--- a/src/ObjCRuntime/Stret.cs
+++ b/src/ObjCRuntime/Stret.cs
@@ -38,9 +38,9 @@ namespace ObjCRuntime {
 		/// <returns><see langword="true"/> if stret calling conventions are required; otherwise, <see langword="false"/>.</returns>
 		public static bool X86_64NeedStret (Type returnType, Generator? generator)
 		{
-			ArgumentNullException.ThrowIfNull (returnType);
+			ThrowIfNull (returnType, nameof (returnType));
 #if BGENERATOR
-			ArgumentNullException.ThrowIfNull (generator);
+			ThrowIfNull (generator, nameof (generator));
 #endif
 
 			Type t = returnType;
@@ -56,10 +56,10 @@ namespace ObjCRuntime {
 		[UnconditionalSuppressMessage ("", "IL2070", Justification = "Computing the size of a struct is safe, because the trimmer can't remove fields that would affect the size of a marshallable struct (it could affect marshalling behavior).")]
 		internal static int GetValueTypeSize (Type type, List<Type> fieldTypes, Generator? generator)
 		{
-			ArgumentNullException.ThrowIfNull (type);
-			ArgumentNullException.ThrowIfNull (fieldTypes);
+			ThrowIfNull (type, nameof (type));
+			ThrowIfNull (fieldTypes, nameof (fieldTypes));
 #if BGENERATOR
-			ArgumentNullException.ThrowIfNull (generator);
+			ThrowIfNull (generator, nameof (generator));
 #endif
 
 			int size = 0;
@@ -99,13 +99,13 @@ namespace ObjCRuntime {
 
 		static bool IsBuiltInType (Type type)
 		{
-			ArgumentNullException.ThrowIfNull (type);
+			ThrowIfNull (type, nameof (type));
 			return IsBuiltInType (type, out var _);
 		}
 
 		internal static bool IsBuiltInType (Type type, out int type_size)
 		{
-			ArgumentNullException.ThrowIfNull (type);
+			ThrowIfNull (type, nameof (type));
 			type_size = 0;
 
 			if (type.IsNested)
@@ -168,11 +168,11 @@ namespace ObjCRuntime {
 		[UnconditionalSuppressMessage ("", "IL2070", Justification = "Computing the size of a struct is safe, because the trimmer can't remove fields that would affect the size of a marshallable struct (it could affect marshalling behavior).")]
 		static void GetValueTypeSize (Type original_type, Type type, List<Type> field_types, ref int size, ref int max_element_size, Generator? generator)
 		{
-			ArgumentNullException.ThrowIfNull (original_type);
-			ArgumentNullException.ThrowIfNull (type);
-			ArgumentNullException.ThrowIfNull (field_types);
+			ThrowIfNull (original_type, nameof (original_type));
+			ThrowIfNull (type, nameof (type));
+			ThrowIfNull (field_types, nameof (field_types));
 #if BGENERATOR
-			ArgumentNullException.ThrowIfNull (generator);
+			ThrowIfNull (generator, nameof (generator));
 #endif
 
 			// FIXME:
@@ -233,6 +233,16 @@ namespace ObjCRuntime {
 				size = AlignAndAdd (original_type, size, type_size, ref max_element_size);
 				size += (multiplier - 1) * size;
 			}
+		}
+
+		static void ThrowIfNull ([NotNull] object? value, string parameterName)
+		{
+#if NET
+			ArgumentNullException.ThrowIfNull (value, parameterName);
+#else
+			if (value is null)
+				throw new ArgumentNullException (parameterName);
+#endif
 		}
 
 		static string GetTypeName (Type? type)

--- a/src/Resources.Designer.cs
+++ b/src/Resources.Designer.cs
@@ -1230,5 +1230,14 @@ namespace bgen {
                 return ResourceManager.GetString("BI1128", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Export attribute contains invalid selector name: {0}.
+        /// </summary>
+        internal static string BI1129 {
+            get {
+                return ResourceManager.GetString("BI1129", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -656,4 +656,8 @@
 	<data name="BI1128" xml:space="preserve">
 		<value>The [Field] member '{0}.{1}' sets SymbolAddress, but its type is '{2}'; only System.IntPtr is supported.</value>
 	</data>
+
+	<data name="BI1129" xml:space="preserve">
+		<value>Export attribute contains invalid selector name: {0}</value>
+	</data>
 </root>

--- a/src/bgen/AttributeManager.cs
+++ b/src/bgen/AttributeManager.cs
@@ -393,7 +393,11 @@ public class AttributeManager {
 
 		Version? version = null;
 		if (arg.Length > len) {
+#if NET
 			if (!Version.TryParse (arg [len..], out version))
+#else
+			if (!Version.TryParse (arg.Substring (len), out version))
+#endif
 				throw new BindingException (1047, arg);
 		}
 		return (name, version);

--- a/src/bgen/BindingTouch.cs
+++ b/src/bgen/BindingTouch.cs
@@ -36,6 +36,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Threading;
 using Mono.Options;
 
 using Assembly = System.Reflection.Assembly;
@@ -45,10 +46,20 @@ using Xamarin.Utils;
 
 #if XAMMACIOS_DEBUGGER
 using System.Diagnostics;
-using System.Threading;
 #endif
 
 public class BindingTouch : IDisposable, IToolLog {
+	readonly CancellationToken cancellationToken;
+
+	public BindingTouch () : this (CancellationToken.None)
+	{
+	}
+
+	BindingTouch (CancellationToken cancellationToken)
+	{
+		this.cancellationToken = cancellationToken;
+	}
+
 	public static ApplePlatform [] AllPlatforms = new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.TVOS, ApplePlatform.MacCatalyst };
 	public static PlatformName [] AllPlatformNames = new PlatformName [] { PlatformName.iOS, PlatformName.MacOSX, PlatformName.TvOS, PlatformName.MacCatalyst };
 	public PlatformName CurrentPlatform;
@@ -108,6 +119,11 @@ public class BindingTouch : IDisposable, IToolLog {
 
 	public static int Main (string [] args)
 	{
+		return Run (args, CancellationToken.None);
+	}
+
+	public static int Run (string [] args, CancellationToken cancellationToken)
+	{
 		try {
 #if XAMMACIOS_DEBUGGER
 			// the following code will only be available for the macios
@@ -122,16 +138,18 @@ public class BindingTouch : IDisposable, IToolLog {
 
 			Console.WriteLine ("Debugger attached");
 #endif
-			return Main2 (args);
+			return Main2 (args, cancellationToken);
+		} catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+			throw;
 		} catch (Exception ex) {
 			ErrorHelper.Show (ex, false);
 			return 1;
 		}
 	}
 
-	static int Main2 (string [] args)
+	static int Main2 (string [] args, CancellationToken cancellationToken)
 	{
-		using var touch = new BindingTouch ();
+		using var touch = new BindingTouch (cancellationToken);
 		return touch.Main3 (args);
 	}
 
@@ -352,6 +370,7 @@ public class BindingTouch : IDisposable, IToolLog {
 
 	int Main3 (string [] args)
 	{
+		ThrowIfCancellationRequested ();
 		ErrorHelper.ClearWarningLevels ();
 		BindingTouchConfig config = new ();
 
@@ -366,6 +385,7 @@ public class BindingTouch : IDisposable, IToolLog {
 		libraryInfo = LibraryInfo.LibraryInfoBuilder.Build (references, config);
 		CurrentPlatform = LibraryManager.DetermineCurrentPlatform (TargetFramework.Platform);
 
+		ThrowIfCancellationRequested ();
 		if (!TryInitializeApi (config, out Api? api) || !TryGenerate (config, api))
 			return 1;
 
@@ -375,12 +395,14 @@ public class BindingTouch : IDisposable, IToolLog {
 	bool TryGenerate (BindingTouchConfig config, Api api)
 	{
 		try {
+			ThrowIfCancellationRequested ();
 			var g = new Generator (this, api, config.IsPublicMode, config.IsExternal, config.IsDebug) {
 				BaseDir = config.BindingFilesOutputDirectory ?? config.TemporaryFileDirectory!,
 				InlineSelectors = config.InlineSelectors ?? (CurrentPlatform != PlatformName.MacOSX),
 			};
 
 			g.Go ();
+			ThrowIfCancellationRequested ();
 
 			if (config.GeneratedFileList is not null) {
 				using (var f = File.CreateText (config.GeneratedFileList)) {
@@ -590,6 +612,11 @@ public class BindingTouch : IDisposable, IToolLog {
 	public void Log (string message)
 	{
 		Console.WriteLine (message);
+	}
+
+	public void ThrowIfCancellationRequested ()
+	{
+		cancellationToken.ThrowIfCancellationRequested ();
 	}
 
 	public void LogError (string message)

--- a/src/bgen/BindingTouch.cs
+++ b/src/bgen/BindingTouch.cs
@@ -560,7 +560,9 @@ public class BindingTouch : IDisposable, IToolLog {
 		var environment = new Dictionary<string, string?> ();
 		if (!string.IsNullOrEmpty (customHome))
 			environment ["HOME"] = customHome;
-		if (Driver.RunCommand (this, compile_command [0], arguments, environment, out var compile_output, true, Verbosity) != 0)
+		var exitCode = Driver.RunCommand (this, compile_command [0], arguments, environment, out var compile_output, true, Verbosity, cancellationToken);
+		cancellationToken.ThrowIfCancellationRequested ();
+		if (exitCode != 0)
 			throw ErrorHelper.CreateError (errorCode, $"{compiler} {StringUtils.FormatArguments (arguments)}\n{compile_output}".Replace ("\n", "\n\t"));
 		var output = string.Join (Environment.NewLine, compile_output.ToString ().Split (new char [] { '\n' }, StringSplitOptions.RemoveEmptyEntries));
 		if (!string.IsNullOrEmpty (output))

--- a/src/bgen/BindingTouch.cs
+++ b/src/bgen/BindingTouch.cs
@@ -27,12 +27,18 @@
 
 #nullable enable
 
+#if !NET
+#pragma warning disable CS8604
+#endif
+
 using System.IO;
 using System.Linq;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Mono.Options;
+
+using Assembly = System.Reflection.Assembly;
 
 using Xamarin.Bundler;
 using Xamarin.Utils;
@@ -60,7 +66,7 @@ public class BindingTouch : IDisposable, IToolLog {
 	public bool SupportsXmlDocumentation { get => supportsXmlDocumentation; }
 
 	public MetadataLoadContext? universe;
-	public Frameworks? Frameworks;
+	public BGenFrameworks? Frameworks;
 
 	DocumentationManager? documentationManager;
 	public DocumentationManager DocumentationManager => documentationManager!;
@@ -290,12 +296,16 @@ public class BindingTouch : IDisposable, IToolLog {
 
 			documentationManager = new DocumentationManager (supportsXmlDocumentation ? tmpass : string.Empty);
 
-			Frameworks = new Frameworks (CurrentPlatform);
+			Frameworks = new BGenFrameworks (CurrentPlatform);
 
 			// Explicitly load our attribute library so that IKVM doesn't try (and fail) to find it.
 			universe.LoadFromAssemblyPath (LibraryManager.GetAttributeLibraryPath (LibraryInfo, CurrentPlatform));
 
-			typeCache ??= new (universe, Frameworks, CurrentPlatform, apiAssembly, universe.CoreAssembly, baselib,
+			var coreAssembly = universe.CoreAssembly;
+			if (coreAssembly is null)
+				throw new InvalidOperationException ("Could not load the core assembly.");
+
+			typeCache ??= new (universe, Frameworks, CurrentPlatform, apiAssembly, coreAssembly, baselib,
 				BindThirdPartyLibrary);
 			attributeManager ??= new (typeCache);
 			typeManager ??= new (this);
@@ -597,6 +607,18 @@ public class BindingTouch : IDisposable, IToolLog {
 		ErrorHelper.Show (exception);
 	}
 
+#if MSBUILD_TASKS
+	public void LogError (Xamarin.Bundler.ProductException exception)
+	{
+		ErrorHelper.Show (exception);
+	}
+
+	public void LogWarning (Xamarin.Bundler.ProductException exception)
+	{
+		ErrorHelper.Show (exception);
+	}
+#endif
+
 	public void LogException (Exception exception)
 	{
 		ErrorHelper.Show (exception);
@@ -610,7 +632,9 @@ public class BindingTouch : IDisposable, IToolLog {
 }
 
 namespace Xamarin.Bundler {
+#if !MSBUILD_TASKS
 	public partial class Driver {
 		public static int GetDefaultVerbosity () => 0;
 	}
+#endif
 }

--- a/src/bgen/BindingTouch.cs
+++ b/src/bgen/BindingTouch.cs
@@ -50,14 +50,16 @@ using System.Diagnostics;
 
 public class BindingTouch : IDisposable, IToolLog {
 	readonly CancellationToken cancellationToken;
+	readonly string? customHome;
 
-	public BindingTouch () : this (CancellationToken.None)
+	public BindingTouch () : this (CancellationToken.None, null)
 	{
 	}
 
-	BindingTouch (CancellationToken cancellationToken)
+	BindingTouch (CancellationToken cancellationToken, string? customHome)
 	{
 		this.cancellationToken = cancellationToken;
+		this.customHome = customHome;
 	}
 
 	public static ApplePlatform [] AllPlatforms = new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.TVOS, ApplePlatform.MacCatalyst };
@@ -119,10 +121,10 @@ public class BindingTouch : IDisposable, IToolLog {
 
 	public static int Main (string [] args)
 	{
-		return Run (args, CancellationToken.None);
+		return Run (args, CancellationToken.None, null);
 	}
 
-	public static int Run (string [] args, CancellationToken cancellationToken)
+	public static int Run (string [] args, CancellationToken cancellationToken, string? customHome)
 	{
 		try {
 #if XAMMACIOS_DEBUGGER
@@ -138,7 +140,7 @@ public class BindingTouch : IDisposable, IToolLog {
 
 			Console.WriteLine ("Debugger attached");
 #endif
-			return Main2 (args, cancellationToken);
+			return Main2 (args, cancellationToken, customHome);
 		} catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
 			throw;
 		} catch (Exception ex) {
@@ -147,9 +149,9 @@ public class BindingTouch : IDisposable, IToolLog {
 		}
 	}
 
-	static int Main2 (string [] args, CancellationToken cancellationToken)
+	static int Main2 (string [] args, CancellationToken cancellationToken, string? customHome)
 	{
-		using var touch = new BindingTouch (cancellationToken);
+		using var touch = new BindingTouch (cancellationToken, customHome);
 		return touch.Main3 (args);
 	}
 
@@ -555,7 +557,10 @@ public class BindingTouch : IDisposable, IToolLog {
 			arguments.Insert (i - 1, compile_command [i]);
 		}
 
-		if (Driver.RunCommand (this, compile_command [0], arguments, null, out var compile_output, true, Verbosity) != 0)
+		var environment = new Dictionary<string, string?> ();
+		if (!string.IsNullOrEmpty (customHome))
+			environment ["HOME"] = customHome;
+		if (Driver.RunCommand (this, compile_command [0], arguments, environment, out var compile_output, true, Verbosity) != 0)
 			throw ErrorHelper.CreateError (errorCode, $"{compiler} {StringUtils.FormatArguments (arguments)}\n{compile_output}".Replace ("\n", "\n\t"));
 		var output = string.Join (Environment.NewLine, compile_output.ToString ().Split (new char [] { '\n' }, StringSplitOptions.RemoveEmptyEntries));
 		if (!string.IsNullOrEmpty (output))

--- a/src/bgen/Caches/NamespaceCache.cs
+++ b/src/bgen/Caches/NamespaceCache.cs
@@ -6,7 +6,7 @@ using ObjCRuntime;
 
 public class NamespaceCache {
 	PlatformName CurrentPlatform => Frameworks!.CurrentPlatform;
-	Frameworks? Frameworks { get; set; }
+	BGenFrameworks? Frameworks { get; set; }
 
 	// Where user-overrideable messaging may live
 	public string ObjCRuntime { get; private set; }

--- a/src/bgen/Caches/TypeCache.cs
+++ b/src/bgen/Caches/TypeCache.cs
@@ -164,7 +164,7 @@ public class TypeCache {
 	public TypeCache () { }
 #pragma warning restore CS8618
 
-	public TypeCache (MetadataLoadContext universe, Frameworks frameworks, PlatformName currentPlatform, Assembly apiAssembly, Assembly corlibAssembly, Assembly platformAssembly, bool bindThirdPartyLibrary)
+	public TypeCache (MetadataLoadContext universe, BGenFrameworks frameworks, PlatformName currentPlatform, Assembly apiAssembly, Assembly corlibAssembly, Assembly platformAssembly, bool bindThirdPartyLibrary)
 	{
 		if (frameworks is null)
 			throw ErrorHelper.CreateError (3, currentPlatform);
@@ -322,7 +322,7 @@ public class TypeCache {
 		NSValueCreateMap = BuildNSValueCreateMap (frameworks);
 	}
 
-	Dictionary<Type, string> BuildNSValueCreateMap (Frameworks frameworks)
+	Dictionary<Type, string> BuildNSValueCreateMap (BGenFrameworks frameworks)
 	{
 		var nsvalueCreateMap = new Dictionary<Type, string> {
 			[CGAffineTransform] = "CGAffineTransform",

--- a/src/bgen/DocumentationManager.cs
+++ b/src/bgen/DocumentationManager.cs
@@ -84,7 +84,11 @@ public class DocumentationManager {
 				var idx2 = line.IndexOf ('"', idx + needle.Length);
 				if (idx2 < idx)
 					break;
+#if NET
 				var cref = line [(idx + needle.Length)..idx2];
+#else
+				var cref = line.Substring (idx + needle.Length, idx2 - idx - needle.Length);
+#endif
 
 				// Fixup this:
 				// error CS1584: XML comment has syntactically incorrect cref attribute
@@ -93,7 +97,11 @@ public class DocumentationManager {
 				cref = cref.Replace ("&amp;gt;", "}");
 
 				// replace the existing cref with the fixed version
+#if NET
 				line = line [..idx] + "cref=\"" + cref + "\"" + line [(idx2 + 1)..];
+#else
+				line = line.Substring (0, idx) + "cref=\"" + cref + "\"" + line.Substring (idx2 + 1);
+#endif
 
 				// there can be more than one cref per line, so keep looking
 				idx = line.IndexOf (needle, idx + needle.Length);
@@ -177,7 +185,7 @@ public class DocumentationManager {
 				name.Append ('`');
 			}
 			name.Append (tr.GenericParameterPosition);
-		} else if (tr.IsSZArray) {
+		} else if (IsSZArray (tr)) {
 			name.Append (GetDocId (tr.GetElementType ()!));
 			name.Append ("[]");
 		} else if (tr.IsArray) {
@@ -229,5 +237,15 @@ public class DocumentationManager {
 		}
 
 		return name.ToString ();
+	}
+
+	static bool IsSZArray (Type type)
+	{
+#if NET
+		return type.IsSZArray;
+#else
+		var elementType = type.GetElementType ();
+		return elementType is not null && type == elementType.MakeArrayType ();
+#endif
 	}
 }

--- a/src/bgen/Enums.cs
+++ b/src/bgen/Enums.cs
@@ -80,13 +80,21 @@ public partial class Generator {
 		if (!anyPropertiesWithFields)
 			return false;
 
+#if NET
 		var getConstantMethod = type.GetMethod ("GetConstant", BindingFlags.Public | BindingFlags.Static, new Type [] { type });
+#else
+		var getConstantMethod = type.GetMethod ("GetConstant", BindingFlags.Public | BindingFlags.Static, null, new Type [] { type }, null);
+#endif
 		if (getConstantMethod is null)
 			return false;
 
 		backingFieldType = getConstantMethod.ReturnType;
 
+#if NET
 		var getValueMethod = type.GetMethod ("GetValue", BindingFlags.Public | BindingFlags.Static, new Type [] { backingFieldType });
+#else
+		var getValueMethod = type.GetMethod ("GetValue", BindingFlags.Public | BindingFlags.Static, null, new Type [] { backingFieldType }, null);
+#endif
 		if (getValueMethod is null)
 			return false;
 

--- a/src/bgen/Extensions/StringExtensions.cs
+++ b/src/bgen/Extensions/StringExtensions.cs
@@ -4,6 +4,10 @@ using System.Diagnostics.CodeAnalysis;
 
 #nullable enable
 
+#if !NET
+#pragma warning disable CS8602
+#endif
+
 // Fixes bug 27430 - btouch doesn't escape identifiers with the same name as C# keywords
 public static class StringExtensions {
 

--- a/src/bgen/Frameworks.cs
+++ b/src/bgen/Frameworks.cs
@@ -2,12 +2,12 @@ using System.Collections.Generic;
 
 #nullable enable
 
-public partial class Frameworks {
+public partial class BGenFrameworks {
 	HashSet<string>? frameworks;
 
 	public PlatformName CurrentPlatform { get; private set; }
 
-	public Frameworks (PlatformName currentPlatform)
+	public BGenFrameworks (PlatformName currentPlatform)
 	{
 		CurrentPlatform = currentPlatform;
 	}

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -56,11 +56,15 @@ using Xamarin.Utils;
 
 #nullable enable
 
+#if !NET
+#pragma warning disable CS8600, CS8602, CS8604
+#endif
+
 public partial class Generator : IMemberGatherer {
 	internal bool IsPublicMode;
 	internal const string NativeHandleType = "NativeHandle";
 	BindingTouch BindingTouch;
-	Frameworks Frameworks { get { return BindingTouch.Frameworks!; } }
+	BGenFrameworks Frameworks { get { return BindingTouch.Frameworks!; } }
 	public TypeManager TypeManager { get { return BindingTouch.TypeManager; } }
 	public AttributeManager AttributeManager { get { return BindingTouch.AttributeManager; } }
 	NamespaceCache NamespaceCache { get { return BindingTouch.NamespaceCache; } }
@@ -8067,5 +8071,4 @@ public partial class Generator : IMemberGatherer {
 	{
 		return assembly == api.Assembly;
 	}
-
 }

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -1252,10 +1252,8 @@ public partial class Generator : IMemberGatherer {
 		if (string.IsNullOrEmpty (export.Selector))
 			throw new BindingException (1024, true, mo.DeclaringType!.FullName, mo.Name);
 
-		if (export.Selector.IndexOfAny (invalid_selector_chars) != -1) {
-			Console.Error.WriteLine ("Export attribute contains invalid selector name: {0}", export.Selector);
-			Environment.Exit (1);
-		}
+		if (export.Selector.IndexOfAny (invalid_selector_chars) != -1)
+			throw new BindingException (1129, true, export.Selector);
 
 		return export;
 	}

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -1357,6 +1357,7 @@ public partial class Generator : IMemberGatherer {
 		TypeManager.SetTypesThatMustAlwaysBeGloballyNamed (api.Types);
 
 		foreach (Type t in api.Types) {
+			BindingTouch.ThrowIfCancellationRequested ();
 			if (t.IsUnavailable (this))
 				continue;
 
@@ -1525,6 +1526,7 @@ public partial class Generator : IMemberGatherer {
 		}
 
 		foreach (Type t in api.Types) {
+			BindingTouch.ThrowIfCancellationRequested ();
 			if (t.IsUnavailable (this))
 				continue;
 

--- a/src/bgen/Models/MarshalTypeList.cs
+++ b/src/bgen/Models/MarshalTypeList.cs
@@ -6,7 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 
 public class MarshalTypeList : List<MarshalType> {
 
-	public void Load (TypeCache typeCache, Frameworks frameworks)
+	public void Load (TypeCache typeCache, BGenFrameworks frameworks)
 	{
 		Add (new MarshalType (typeCache.NSObject, create: "Runtime.GetNSObject (", closingCreate: ", %OWNS%)!"));
 		Add (new MarshalType (typeCache.Selector, create: "Selector.FromHandle (", closingCreate: ", %OWNS%)!"));

--- a/src/bgen/NetStandardCompatibility.cs
+++ b/src/bgen/NetStandardCompatibility.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if !NET
+namespace System.Diagnostics.CodeAnalysis {
+	[AttributeUsage (AttributeTargets.All, Inherited = false)]
+	public sealed class ExperimentalAttribute : Attribute {
+		public ExperimentalAttribute (string diagnosticId)
+		{
+			DiagnosticId = diagnosticId;
+		}
+
+		public string DiagnosticId { get; }
+		public string? UrlFormat { get; set; }
+	}
+
+	[AttributeUsage (AttributeTargets.All, Inherited = false, AllowMultiple = true)]
+	sealed class UnconditionalSuppressMessageAttribute : Attribute {
+		public UnconditionalSuppressMessageAttribute (string category, string checkId)
+		{
+			Category = category;
+			CheckId = checkId;
+		}
+
+		public string Category { get; }
+		public string CheckId { get; }
+		public string? Justification { get; set; }
+	}
+}
+
+namespace System.Runtime.CompilerServices {
+	sealed class IsExternalInit {
+	}
+
+	[AttributeUsage (AttributeTargets.All, Inherited = false)]
+	sealed class RequiredMemberAttribute : Attribute {
+	}
+
+	[AttributeUsage (AttributeTargets.All, Inherited = false, AllowMultiple = true)]
+	sealed class CompilerFeatureRequiredAttribute : Attribute {
+		public CompilerFeatureRequiredAttribute (string featureName)
+		{
+			FeatureName = featureName;
+		}
+
+		public string FeatureName { get; }
+		public bool IsOptional { get; init; }
+	}
+
+	[AttributeUsage (AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor, Inherited = false)]
+	public sealed class OverloadResolutionPriorityAttribute : Attribute {
+		public OverloadResolutionPriorityAttribute (int priority)
+		{
+			Priority = priority;
+		}
+
+		public int Priority { get; }
+	}
+}
+
+namespace System.Runtime.Versioning {
+	abstract class OSPlatformAttribute : Attribute {
+		protected OSPlatformAttribute (string platformName)
+		{
+			PlatformName = platformName;
+		}
+
+		public string PlatformName { get; }
+	}
+
+	sealed class SupportedOSPlatformAttribute : OSPlatformAttribute {
+		public SupportedOSPlatformAttribute (string platformName) : base (platformName)
+		{
+		}
+	}
+
+	sealed class UnsupportedOSPlatformAttribute : OSPlatformAttribute {
+		public UnsupportedOSPlatformAttribute (string platformName) : base (platformName)
+		{
+		}
+
+		public string? Message { get; set; }
+	}
+
+	sealed class ObsoletedOSPlatformAttribute : OSPlatformAttribute {
+		public ObsoletedOSPlatformAttribute (string platformName) : base (platformName)
+		{
+		}
+
+		public string? Message { get; set; }
+		public string? Url { get; set; }
+	}
+}
+#endif

--- a/src/bgen/NullabilityInfoContext.cs
+++ b/src/bgen/NullabilityInfoContext.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 
 #nullable enable
 
+#if NET
 namespace bgen {
 
 	public static class NullabilityInfoExtensions {
@@ -12,3 +13,4 @@ namespace bgen {
 			=> self.ReadState == NullabilityState.Nullable;
 	}
 }
+#endif

--- a/src/bgen/TypeManager.cs
+++ b/src/bgen/TypeManager.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 
 public class TypeManager {
 	public BindingTouch BindingTouch;
-	Frameworks Frameworks { get; }
+	BGenFrameworks Frameworks { get; }
 	AttributeManager AttributeManager { get { return BindingTouch.AttributeManager; } }
 	NamespaceCache NamespaceCache { get { return BindingTouch.NamespaceCache; } }
 	TypeCache TypeCache { get { return BindingTouch.TypeCache; } }

--- a/src/build/dotnet/generator-frameworks.g.cs
+++ b/src/build/dotnet/generator-frameworks.g.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-partial class Frameworks {
+partial class BGenFrameworks {
 	// GENERATED FILE - DO NOT EDIT
 	internal readonly HashSet<string> iosframeworks = new HashSet<string> {
 		"Accelerate",

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/BGenTaskTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/BGenTaskTest.cs
@@ -43,5 +43,19 @@ namespace Xamarin.MacDev.Tasks {
 			args.AddRange (File.ReadAllLines (task.ResponseFilePath));
 			Assert.That (args.Contains ("-invalid"), "incorrect ExtraArg not causing an exception");
 		}
+
+		[Test]
+		public void ExecutesInProcess ()
+		{
+			var task = CreateTask<BGen> ();
+
+			task.ApiDefinitions = new [] { new TaskItem ("ignored.cs") };
+			task.BGenToolPath = "/does/not/exist";
+			task.BGenToolExe = "bgen.dll";
+			task.ExtraArgs = "/help";
+			task.ResponseFilePath = Path.Combine (Cache.CreateTemporaryDirectory (), "response-file.txt");
+
+			ExecuteTask (task);
+		}
 	}
 }

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/BGenTaskTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/BGenTaskTest.cs
@@ -57,5 +57,20 @@ namespace Xamarin.MacDev.Tasks {
 
 			ExecuteTask (task);
 		}
+
+		[Test]
+		public void ExecutesExternalProcess ()
+		{
+			var task = CreateTask<BGen> ();
+
+			task.ApiDefinitions = new [] { new TaskItem ("ignored.cs") };
+			task.BGenToolPath = "/does/not/exist";
+			task.BGenToolExe = "bgen.dll";
+			task.ExtraArgs = "/help";
+			task.ResponseFilePath = Path.Combine (Cache.CreateTemporaryDirectory (), "response-file.txt");
+			task.UseExternalProcess = true;
+
+			ExecuteTask (task, expectedErrorCount: 1);
+		}
 	}
 }

--- a/tools/common/Driver.execution.cs
+++ b/tools/common/Driver.execution.cs
@@ -10,6 +10,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Xamarin.Utils;
@@ -22,6 +23,12 @@ namespace Xamarin.Bundler {
 		{
 			output = new StringBuilder ();
 			return RunCommand (log, path, args, env, output, suppressPrintOnErrors, verbose);
+		}
+
+		public static int RunCommand (IToolLog log, string path, IList<string> args, Dictionary<string, string?>? env, out StringBuilder output, bool suppressPrintOnErrors, int verbose, CancellationToken cancellationToken)
+		{
+			output = new StringBuilder ();
+			return RunCommand (log, path, args, env, output, output, suppressPrintOnErrors, verbose, cancellationToken);
 		}
 
 		public static int RunCommand (IToolLog log, string path, IList<string> args, Dictionary<string, string?>? env, out StringBuilder output, bool suppressPrintOnErrors)
@@ -77,6 +84,13 @@ namespace Xamarin.Bundler {
 			return RunCommand (log, path, args, env, output_received, error_received, suppressPrintOnErrors, verbosity);
 		}
 
+		public static int RunCommand (IToolLog log, string path, IList<string> args, Dictionary<string, string?>? env, StringBuilder? output, StringBuilder? error, bool suppressPrintOnErrors, int verbosity, CancellationToken cancellationToken)
+		{
+			var output_received = output is null ? null : new Action<string?> ((v) => { if (v is not null) output.AppendLine (v); });
+			var error_received = error is null ? null : new Action<string?> ((v) => { if (v is not null) error.AppendLine (v); });
+			return RunCommand (log, path, args, env, output_received, error_received, suppressPrintOnErrors, verbosity, cancellationToken);
+		}
+
 		static int RunCommand (IToolLog log, string path, IList<string> args, Dictionary<string, string?>? env, Action<string?>? output_received, bool suppressPrintOnErrors)
 		{
 			return RunCommand (log, path, args, env, output_received, output_received, suppressPrintOnErrors, log.Verbosity);
@@ -87,7 +101,7 @@ namespace Xamarin.Bundler {
 			return RunCommand (log, path, args, env, output_received, error_received, false, log.Verbosity);
 		}
 
-		static int RunCommand (IToolLog log, string path, IList<string> args, Dictionary<string, string?>? env, Action<string?>? output_received, Action<string?>? error_received, bool suppressPrintOnErrors, int verbosity)
+		static int RunCommand (IToolLog log, string path, IList<string> args, Dictionary<string, string?>? env, Action<string?>? output_received, Action<string?>? error_received, bool suppressPrintOnErrors, int verbosity, CancellationToken? cancellationToken = null)
 		{
 			var output = new StringBuilder ();
 			var outputCallback = new Action<string?> ((line) => {
@@ -105,7 +119,7 @@ namespace Xamarin.Bundler {
 
 			log.Log (1, $"{path} {StringUtils.FormatArguments (args)}");
 
-			var p = Execution.RunWithCallbacksAsync (path, args, env, outputCallback, errorCallback).Result;
+			var p = Execution.RunWithCallbacksAsync (path, args, env, outputCallback, errorCallback, cancellationToken: cancellationToken).Result;
 
 			if (output_received is not null)
 				output_received (null);


### PR DESCRIPTION
Compile bgen into Xamarin.MacDev.Tasks and invoke it directly for local builds, avoiding a separate bgen process by default.

Keep the external-process implementation available through the opt-in `_BGenUseExternalProcess` property, while preserving remote execution.

Add netstandard2.0 compatibility, cancellation support, isolated compiler environment handling, and task coverage for both execution modes.

Fixes https://github.com/dotnet/macios/issues/26584

🤖 Pull request created by Copilot