### PR TITLE
[HealthKit] Update bindings up to Xcode 27.0 RC1

### DIFF
--- a/src/healthkit.cs
+++ b/src/healthkit.cs
@@ -3350,6 +3350,14 @@ namespace HealthKit {
 		[iOS (18, 0), MacCatalyst (18, 0), Mac (15, 0)]
 		[Field ("HKQuantityTypeIdentifierAppleSleepingBreathingDisturbances")]
 		AppleSleepingBreathingDisturbances,
+
+		/// <summary>
+		/// Identifies heart rate variability as the root mean square of successive heartbeat interval differences,
+		/// in milliseconds.
+		/// </summary>
+		[NoTV, iOS (27, 0), MacCatalyst (27, 0), Mac (27, 0)]
+		[Field ("HKQuantityTypeIdentifierHeartRateVariabilityRMSSD")]
+		HeartRateVariabilityRmssd,
 	}
 
 	/// <summary>Contains constants that identify HealthKit correlation types.</summary>

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -650,6 +650,7 @@ namespace Introspection {
 			{ "Rint", All }, // round-to-integer function
 			{ "Rle", All }, // run-length encoding
 			{ "Rms", All }, // root mean square
+			{ "Rmssd", All & ~ApplePlatform.TVOS }, // root mean square of successive differences
 			{ "Rnn", All }, // recurrent neural network
 			{ "Roi", All }, // region of interest
 			{ "Romm", All }, // acronym: Reference Output Medium Metric

--- a/tests/monotouch-test/HealthKit/QuantityTypeIdentifierTest.cs
+++ b/tests/monotouch-test/HealthKit/QuantityTypeIdentifierTest.cs
@@ -129,6 +129,10 @@ namespace MonoTouchFixtures.HealthKit {
 					if (!TestRuntime.CheckXcodeVersion (16, 0))
 						continue;
 					break;
+				case HKQuantityTypeIdentifier.HeartRateVariabilityRmssd:
+					if (!TestRuntime.CheckXcodeVersion (27, 0))
+						continue;
+					break;
 				}
 
 				try {

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-HealthKit.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-HealthKit.todo
@@ -1,1 +1,0 @@
-!missing-field! HKQuantityTypeIdentifierHeartRateVariabilityRMSSD not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-HealthKit.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-HealthKit.todo
@@ -1,1 +1,0 @@
-!missing-field! HKQuantityTypeIdentifierHeartRateVariabilityRMSSD not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-HealthKit.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-HealthKit.todo
@@ -1,1 +1,0 @@
-!missing-field! HKQuantityTypeIdentifierHeartRateVariabilityRMSSD not bound


### PR DESCRIPTION
## Summary

Resolve the remaining HealthKit binding entries for Xcode 27.0 RC1.

| API | Availability |
| --- | --- |
| `HKQuantityTypeIdentifier.HeartRateVariabilityRmssd` (`HKQuantityTypeIdentifierHeartRateVariabilityRMSSD`) | iOS 27.0, macOS 27.0, Mac Catalyst 27.0; unavailable on tvOS |

The new smart-enum member is appended, preserving the existing numeric values. Its XML documentation describes RMSSD and its millisecond units. Availability and the native field spelling were checked against the RC1 SDK headers and newly generated reference bindings.

## Related changes

- `src/healthkit.cs`: add the documented smart-enum member.
- `tests/monotouch-test/HealthKit/QuantityTypeIdentifierTest.cs`: guard the new member on pre-27.0 runtimes in the existing enumeration/factory regression test.
- `tests/introspection/ApiTypoTest.cs`: recognize the scientific acronym `Rmssd` on non-tvOS platforms.
- Delete the completed iOS, macOS and Mac Catalyst `HealthKit.todo` files after xtro reported their entries resolved.

No API-diff suppressions, documentation-baseline changes, runtime-test exclusions, or expected-size files are added.

## Validation

`make world` succeeded before implementation, after the binding change, and again when ruling out stale artifacts during the Mac Catalyst crash investigation. Test suites and platforms were run sequentially.

The final clean xtro run removed generated references, response files, classification stamps and tool outputs before regenerating all four platforms: **Sanity check passed**. The final clean Cecil run had **112 passed, 4 skipped, 0 failed**, including documentation checks.

| Platform/runtime | Xtro | Cecil | Introspection | Quantity-identifier regression |
| --- | --- | --- | --- | --- |
| iOS 27.0 RC1 (`24A434`) | Pass | Pass | 43 passed initially; the spelling failure was fixed and its targeted retest passed | 1 passed; includes RMSSD |
| tvOS 27.0 RC1 (`24J360`) | Pass | Pass | 43 passed | Not applicable; tvOS test-app build passed |
| macOS 26.6.2 | Pass | Pass | 32 passed, 2 ignored | 1 passed; the new member is version-gated |
| Mac Catalyst on macOS 26.6.2 | Pass | Pass | 38 passed, 4 ignored, 1 environment-blocked check | 1 passed; the new member is version-gated |

The RC branch normally disables app-size tests and has no committed size baselines. A temporary, same-branch pre-change baseline was therefore captured with all cases explicitly enabled. The final run cleaned the test project and compared without either baseline-update environment variable: **16 passed, 0 skipped, 0 failed**. Fourteen configurations were byte-size unchanged; the two macOS CoreCLR configurations grew by **1,024 bytes** each, below the **10,240-byte** tolerance. All tvOS controls had no file or size drift, and preserved-API comparisons passed. The temporary repository baselines were removed afterward.

## Runtime limitations

Mac Catalyst's `DefaultCtorAllowed` check aborts in `__TCC_CRASHING_DUE_TO_PRIVACY_VIOLATION__` immediately after the location-button constructor diagnostic. It reproduced after another `make world` and a clean test-app build. The remaining fixtures and constructor checks were run separately and passed; no permissions were changed and no source exclusion was added. A suitable GUI/CI environment is still needed for that complete constructor check.

The host runs macOS 26.6.2, so new 27.0 macOS/Mac Catalyst symbols are availability-gated rather than runtime-validated there. The iOS 27.0 RC1 run exercised the new native field and quantity-type factory.

No HealthKit `.todo` entries remain.
