### PR TITLE
[CoreMedia] Update bindings up to Xcode 27.0 RC1

### DIFF
--- a/src/CoreMedia/CMEnums.cs
+++ b/src/CoreMedia/CMEnums.cs
@@ -387,6 +387,8 @@ namespace CoreMedia {
 		AllocationFailed = -12747,
 		/// <summary>To be added.</summary>
 		UnsupportedOperation = -12756,
+		/// <summary>No preferred start time is available because the system is not synchronized to a signal.</summary>
+		PreferredStartTimeNotAvailable = -12758,
 	}
 
 	// untyped enum (used as OSStatus) -> CMSync.h

--- a/src/CoreMedia/CMSync.cs
+++ b/src/CoreMedia/CMSync.cs
@@ -21,7 +21,7 @@ namespace CoreMedia {
 	[SupportedOSPlatform ("maccatalyst")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("tvos")]
-	public class CMClock : CMClockOrTimebase {
+	public partial class CMClock : CMClockOrTimebase {
 		[Preserve (Conditional = true)]
 		internal CMClock (NativeHandle handle, bool owns)
 			: base (handle, owns)
@@ -76,6 +76,49 @@ namespace CoreMedia {
 		}
 #endif
 
+#if __MACOS__ || __MACCATALYST__
+		[SupportedOSPlatform ("macos27.0")]
+		[SupportedOSPlatform ("maccatalyst27.0")]
+		[UnsupportedOSPlatform ("ios")]
+		[UnsupportedOSPlatform ("tvos")]
+		[DllImport (Constants.CoreMediaLibrary)]
+		extern static /* CMClockRef */ IntPtr CMClockCreateGenlockClock ();
+
+		/// <summary>Creates a clock that follows an external genlock signal when synchronized, or host time otherwise.</summary>
+		/// <returns>A genlock clock, or <see langword="null" /> if the clock could not be created.</returns>
+		/// <remarks>
+		///   Dispose the clock when it is no longer needed, because monitoring the genlock signal may increase energy use.
+		///   Multiple calls may return clocks backed by the same native clock.
+		/// </remarks>
+		[SupportedOSPlatform ("macos27.0")]
+		[SupportedOSPlatform ("maccatalyst27.0")]
+		[UnsupportedOSPlatform ("ios")]
+		[UnsupportedOSPlatform ("tvos")]
+		public static CMClock? CreateGenlockClock ()
+		{
+			var handle = CMClockCreateGenlockClock ();
+			return handle == IntPtr.Zero ? null : new CMClock (handle, owns: true);
+		}
+
+		[SupportedOSPlatform ("macos27.0")]
+		[SupportedOSPlatform ("maccatalyst27.0")]
+		[UnsupportedOSPlatform ("ios")]
+		[UnsupportedOSPlatform ("tvos")]
+		[DllImport (Constants.CoreMediaLibrary)]
+		extern static /* Boolean */ byte CMIsAnyDisplaySynchronizedToLockedGenlockSignal ();
+
+		/// <summary>Gets whether any display is synchronized to a locked external genlock signal.</summary>
+		[SupportedOSPlatform ("macos27.0")]
+		[SupportedOSPlatform ("maccatalyst27.0")]
+		[UnsupportedOSPlatform ("ios")]
+		[UnsupportedOSPlatform ("tvos")]
+		public static bool IsAnyDisplaySynchronizedToLockedGenlockSignal {
+			get {
+				return CMIsAnyDisplaySynchronizedToLockedGenlockSignal () != 0;
+			}
+		}
+#endif
+
 		[DllImport (Constants.CoreMediaLibrary)]
 		unsafe extern static /* OSStatus */ CMClockError CMClockGetAnchorTime (/* CMClockRef */ IntPtr clock, CMTime* outClockTime, CMTime* outReferenceClockTime);
 
@@ -110,6 +153,69 @@ namespace CoreMedia {
 			bool result = CMClockMightDrift (Handle, otherClock.Handle) != 0;
 			GC.KeepAlive (otherClock);
 			return result;
+		}
+
+		[SupportedOSPlatform ("ios27.0")]
+		[SupportedOSPlatform ("maccatalyst27.0")]
+		[SupportedOSPlatform ("macos27.0")]
+		[SupportedOSPlatform ("tvos27.0")]
+		[DllImport (Constants.CoreMediaLibrary)]
+		extern static /* Boolean */ byte CMClockImplementsGetPreferredStartTimePattern (/* CMClockRef */ IntPtr clock);
+
+		/// <summary>Gets whether this clock implements <see cref="GetPreferredStartTimePattern" />.</summary>
+		/// <exception cref="ObjectDisposedException">This clock has been disposed.</exception>
+		[SupportedOSPlatform ("ios27.0")]
+		[SupportedOSPlatform ("maccatalyst27.0")]
+		[SupportedOSPlatform ("macos27.0")]
+		[SupportedOSPlatform ("tvos27.0")]
+		public bool ImplementsGetPreferredStartTimePattern {
+			get {
+				var result = CMClockImplementsGetPreferredStartTimePattern (GetCheckedHandle ()) != 0;
+				GC.KeepAlive (this);
+				return result;
+			}
+		}
+
+		[SupportedOSPlatform ("ios27.0")]
+		[SupportedOSPlatform ("maccatalyst27.0")]
+		[SupportedOSPlatform ("macos27.0")]
+		[SupportedOSPlatform ("tvos27.0")]
+		[DllImport (Constants.CoreMediaLibrary)]
+		unsafe extern static /* OSStatus */ CMClockError CMClockGetPreferredStartTimePattern (
+			/* CMClockRef */ IntPtr clock,
+			CMTime* outClockStartTime,
+			CMTime* outHostClockStartTime,
+			CMTime* outDeltaBetweenPreferredStartTimes);
+
+		/// <summary>Gets the pattern of preferred start times for synchronization with an external signal.</summary>
+		/// <param name="clockStartTime">Receives the next preferred start time in this clock's time.</param>
+		/// <param name="hostClockStartTime">Receives the matching preferred start time in host-clock time.</param>
+		/// <param name="deltaBetweenPreferredStartTimes">Receives the interval between successive preferred start times.</param>
+		/// <returns>
+		///   <see cref="CMClockError.None" /> on success, <see cref="CMClockError.UnsupportedOperation" /> if unsupported,
+		///   or <c>kCMClockError_PreferredStartTimeNotAvailable</c> (<c>-12758</c>) if the system is not synchronized to a present signal.
+		/// </returns>
+		/// <exception cref="ObjectDisposedException">This clock has been disposed.</exception>
+		/// <remarks>
+		///   The output values are meaningful only on success. Add integer multiples of
+		///   <paramref name="deltaBetweenPreferredStartTimes" /> to both start times to calculate subsequent preferred start times in the near future.
+		/// </remarks>
+		[SupportedOSPlatform ("ios27.0")]
+		[SupportedOSPlatform ("maccatalyst27.0")]
+		[SupportedOSPlatform ("macos27.0")]
+		[SupportedOSPlatform ("tvos27.0")]
+		public CMClockError GetPreferredStartTimePattern (out CMTime clockStartTime, out CMTime hostClockStartTime, out CMTime deltaBetweenPreferredStartTimes)
+		{
+			clockStartTime = default;
+			hostClockStartTime = default;
+			deltaBetweenPreferredStartTimes = default;
+			unsafe {
+				fixed (CMTime* clockStartTimePtr = &clockStartTime, hostClockStartTimePtr = &hostClockStartTime, deltaPtr = &deltaBetweenPreferredStartTimes) {
+					var result = CMClockGetPreferredStartTimePattern (GetCheckedHandle (), clockStartTimePtr, hostClockStartTimePtr, deltaPtr);
+					GC.KeepAlive (this);
+					return result;
+				}
+			}
 		}
 
 		[DllImport (Constants.CoreMediaLibrary)]

--- a/src/CoreMedia/CMSync.cs
+++ b/src/CoreMedia/CMSync.cs
@@ -193,7 +193,7 @@ namespace CoreMedia {
 		/// <param name="deltaBetweenPreferredStartTimes">Receives the interval between successive preferred start times.</param>
 		/// <returns>
 		///   <see cref="CMClockError.None" /> on success, <see cref="CMClockError.UnsupportedOperation" /> if unsupported,
-		///   or <c>kCMClockError_PreferredStartTimeNotAvailable</c> (<c>-12758</c>) if the system is not synchronized to a present signal.
+		///   or <see cref="CMClockError.PreferredStartTimeNotAvailable" /> if the system is not synchronized to a present signal.
 		/// </returns>
 		/// <exception cref="ObjectDisposedException">This clock has been disposed.</exception>
 		/// <remarks>

--- a/src/coremedia.cs
+++ b/src/coremedia.cs
@@ -723,6 +723,23 @@ namespace CoreMedia {
 		IntPtr AgeOutPeriodSelector { get; }
 	}
 
+	[Partial]
+	interface CMClock {
+		/// <summary>Identifies the notification posted when a display enters or leaves genlock mode.</summary>
+		/// <remarks>
+		///   This notification is posted through the native CoreMedia <c>CMNotificationCenter</c>, not <see cref="NSNotificationCenter" />.
+		///   Its payload contains a boolean value under <see cref="AnyDisplayIsSynchronizedToLockedGenlockSignalKey" />.
+		/// </remarks>
+		[NoiOS, NoTV, Mac (27, 0), MacCatalyst (27, 0)]
+		[Field ("kCMGenlockClockNotification_DisplayGenlockModeChanged")]
+		NSString DisplayGenlockModeChangedNotification { get; }
+
+		/// <summary>Identifies the boolean payload value indicating whether any display is synchronized to a locked genlock signal.</summary>
+		[NoiOS, NoTV, Mac (27, 0), MacCatalyst (27, 0)]
+		[Field ("kCMGenlockClockNotificationPayload_AnyDisplayIsSynchronizedToLockedGenlockSignal")]
+		NSString AnyDisplayIsSynchronizedToLockedGenlockSignalKey { get; }
+	}
+
 	[TV (18, 0), Mac (15, 0), iOS (18, 0), MacCatalyst (18, 0)]
 	public enum CMFormatDescriptionProjectionKind {
 		[Field ("kCMFormatDescriptionProjectionKind_Rectilinear")]

--- a/tests/monotouch-test/CoreMedia/CMClockTest.cs
+++ b/tests/monotouch-test/CoreMedia/CMClockTest.cs
@@ -43,5 +43,80 @@ namespace MonoTouchFixtures.CoreMedia {
 				Assert.That (CFGetRetainCount (clock.Handle), Is.GreaterThanOrEqualTo ((nint) 1), "RetainCount");
 			}
 		}
+
+		[Test]
+		public void PreferredStartTimePattern ()
+		{
+			TestRuntime.AssertXcodeVersion (27, 0);
+
+			using (var clock = CMClock.HostTimeClock) {
+				AssertPreferredStartTimePattern (clock);
+			}
+		}
+
+		static void AssertPreferredStartTimePattern (CMClock clock)
+		{
+			var implements = clock.ImplementsGetPreferredStartTimePattern;
+			var error = clock.GetPreferredStartTimePattern (out var clockStartTime, out var hostClockStartTime, out var delta);
+			TestContext.WriteLine ($"Preferred start-time pattern: supported={implements}, status={error}");
+			if (implements) {
+				// kCMClockError_PreferredStartTimeNotAvailable is not exposed in CMClockError.
+				const CMClockError preferredStartTimeNotAvailable = (CMClockError) (-12758);
+				Assert.That (error, Is.EqualTo (CMClockError.None).Or.EqualTo (preferredStartTimeNotAvailable), "Error");
+			} else {
+				Assert.That (error, Is.EqualTo (CMClockError.UnsupportedOperation), "Error");
+			}
+			if (error == CMClockError.None) {
+				Assert.That (clockStartTime.IsNumeric, Is.True, "ClockStartTime");
+				Assert.That (hostClockStartTime.IsNumeric, Is.True, "HostClockStartTime");
+				Assert.That (delta.IsNumeric, Is.True, "Delta");
+			}
+		}
+
+		[Test]
+		public void PreferredStartTimePatternDisposed ()
+		{
+			TestRuntime.AssertXcodeVersion (27, 0);
+
+			using (var clock = CMClock.HostTimeClock) {
+				clock.Dispose ();
+				Assert.Throws<ObjectDisposedException> (() => { _ = clock.ImplementsGetPreferredStartTimePattern; }, "Implements");
+				Assert.Throws<ObjectDisposedException> (() => clock.GetPreferredStartTimePattern (out _, out _, out _), "Pattern");
+			}
+		}
+
+#if __MACOS__ || __MACCATALYST__
+		[Test]
+		public void CreateGenlockClock ()
+		{
+			TestRuntime.AssertXcodeVersion (27, 0);
+
+			using (var clock = CMClock.CreateGenlockClock ()) {
+				Assert.That (clock, Is.Not.Null, "Clock");
+				Assert.That (clock.Handle, Is.Not.EqualTo (NativeHandle.Zero), "Handle");
+				Assert.That (CFGetRetainCount (clock.Handle), Is.GreaterThanOrEqualTo ((nint) 1), "RetainCount");
+				Assert.That (clock.CurrentTime.IsNumeric, Is.True, "CurrentTime");
+				AssertPreferredStartTimePattern (clock);
+			}
+		}
+
+		[Test]
+		public void IsAnyDisplaySynchronizedToLockedGenlockSignal ()
+		{
+			TestRuntime.AssertXcodeVersion (27, 0);
+
+			// The result depends on connected displays and genlock hardware.
+			TestContext.WriteLine ($"Any display synchronized to genlock: {CMClock.IsAnyDisplaySynchronizedToLockedGenlockSignal}");
+		}
+
+		[Test]
+		public void GenlockNotificationConstants ()
+		{
+			TestRuntime.AssertXcodeVersion (27, 0);
+
+			Assert.That (CMClock.DisplayGenlockModeChangedNotification, Is.Not.Null, "Notification");
+			Assert.That (CMClock.AnyDisplayIsSynchronizedToLockedGenlockSignalKey, Is.Not.Null, "PayloadKey");
+		}
+#endif
 	}
 }

--- a/tests/monotouch-test/CoreMedia/CMClockTest.cs
+++ b/tests/monotouch-test/CoreMedia/CMClockTest.cs
@@ -45,6 +45,13 @@ namespace MonoTouchFixtures.CoreMedia {
 		}
 
 		[Test]
+		public void PreferredStartTimeNotAvailableError ()
+		{
+			Assert.That ((int) CMClockError.PreferredStartTimeNotAvailable, Is.EqualTo (-12758), "Native value");
+			Assert.That (Enum.GetName (typeof (CMClockError), -12758), Is.EqualTo (nameof (CMClockError.PreferredStartTimeNotAvailable)), "Name");
+		}
+
+		[Test]
 		public void PreferredStartTimePattern ()
 		{
 			TestRuntime.AssertXcodeVersion (27, 0);
@@ -60,9 +67,7 @@ namespace MonoTouchFixtures.CoreMedia {
 			var error = clock.GetPreferredStartTimePattern (out var clockStartTime, out var hostClockStartTime, out var delta);
 			TestContext.WriteLine ($"Preferred start-time pattern: supported={implements}, status={error}");
 			if (implements) {
-				// kCMClockError_PreferredStartTimeNotAvailable is not exposed in CMClockError.
-				const CMClockError preferredStartTimeNotAvailable = (CMClockError) (-12758);
-				Assert.That (error, Is.EqualTo (CMClockError.None).Or.EqualTo (preferredStartTimeNotAvailable), "Error");
+				Assert.That (error, Is.EqualTo (CMClockError.None).Or.EqualTo (CMClockError.PreferredStartTimeNotAvailable), "Error");
 			} else {
 				Assert.That (error, Is.EqualTo (CMClockError.UnsupportedOperation), "Error");
 			}
@@ -91,6 +96,8 @@ namespace MonoTouchFixtures.CoreMedia {
 		{
 			TestRuntime.AssertXcodeVersion (27, 0);
 
+			// The parameterless native factory has no documented way to force a null result.
+			// Without a genlock signal, it falls back to host time rather than failing.
 			using (var clock = CMClock.CreateGenlockClock ()) {
 				Assert.That (clock, Is.Not.Null, "Clock");
 				Assert.That (clock.Handle, Is.Not.EqualTo (NativeHandle.Zero), "Handle");

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CoreMedia.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CoreMedia.todo
@@ -1,6 +1,0 @@
-!missing-field! kCMGenlockClockNotification_DisplayGenlockModeChanged not bound
-!missing-field! kCMGenlockClockNotificationPayload_AnyDisplayIsSynchronizedToLockedGenlockSignal not bound
-!missing-pinvoke! CMClockCreateGenlockClock is not bound
-!missing-pinvoke! CMClockGetPreferredStartTimePattern is not bound
-!missing-pinvoke! CMClockImplementsGetPreferredStartTimePattern is not bound
-!missing-pinvoke! CMIsAnyDisplaySynchronizedToLockedGenlockSignal is not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreMedia.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreMedia.todo
@@ -1,2 +1,0 @@
-!missing-pinvoke! CMClockGetPreferredStartTimePattern is not bound
-!missing-pinvoke! CMClockImplementsGetPreferredStartTimePattern is not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreMedia.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreMedia.todo
@@ -1,6 +1,0 @@
-!missing-field! kCMGenlockClockNotification_DisplayGenlockModeChanged not bound
-!missing-field! kCMGenlockClockNotificationPayload_AnyDisplayIsSynchronizedToLockedGenlockSignal not bound
-!missing-pinvoke! CMClockCreateGenlockClock is not bound
-!missing-pinvoke! CMClockGetPreferredStartTimePattern is not bound
-!missing-pinvoke! CMClockImplementsGetPreferredStartTimePattern is not bound
-!missing-pinvoke! CMIsAnyDisplaySynchronizedToLockedGenlockSignal is not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-CoreMedia.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-CoreMedia.todo
@@ -1,2 +1,0 @@
-!missing-pinvoke! CMClockGetPreferredStartTimePattern is not bound
-!missing-pinvoke! CMClockImplementsGetPreferredStartTimePattern is not bound


### PR DESCRIPTION
## Summary

Bind all six native APIs listed in `*-CoreMedia.todo` for Xcode 27.0 RC1, plus the named error status returned by the new preferred-start-time API. All sixteen per-platform TODO entries are resolved, and the four completed TODO files are deleted.

| New `CMClock` API | Availability |
| --- | --- |
| `ImplementsGetPreferredStartTimePattern` | iOS, tvOS, macOS, Mac Catalyst 27.0 |
| `GetPreferredStartTimePattern(out CMTime, out CMTime, out CMTime)` | iOS, tvOS, macOS, Mac Catalyst 27.0 |
| `CreateGenlockClock()` | macOS, Mac Catalyst 27.0 |
| `IsAnyDisplaySynchronizedToLockedGenlockSignal` | macOS, Mac Catalyst 27.0 |
| `DisplayGenlockModeChangedNotification` | macOS, Mac Catalyst 27.0 |
| `AnyDisplayIsSynchronizedToLockedGenlockSignalKey` | macOS, Mac Catalyst 27.0 |

The P/Invokes use blittable native representations, checked handles, receiver keep-alives, pinned time outputs, and the factory's nullable retained ownership. The notification constants deliberately do not generate `NSNotificationCenter` observers: Apple posts these through its separate native `CMNotificationCenter`.

XML documentation describes availability, ownership, and error semantics. `CMClockError.PreferredStartTimeNotAvailable` binds the native error value `-12758`, and the documentation and tests use the named member. Error-enum members intentionally omit availability attributes, as enforced by `EnumTest.NoAvailabilityOnError`; the clock APIs that return the status retain their 27.0 availability.

Regression tests cover the capability/status contract, disposed access, genlock creation and retain counts, the display-state query, and notification constants. An OS-independent regression verifies the new error member's numeric value and runtime enum name. Host and genlock clocks share the same pattern assertions, including time-output validation when a synchronized clock returns success. The genlock integration test documents why its nullable failure path cannot be induced deterministically through the parameterless native API: an absent genlock signal falls back to host time rather than failing.

## Validation

The checkout was built initially with `make world`, and every subsequent binding/documentation rebuild also used `make world`. The review follow-up reran `make world`, clean xtro/Cecil, and the `CMClockTest` fixture on all four platforms. Introspection and forced app-size results below were collected during the initial binding validation.

- Clean xtro tool builds, fresh generation of all four reference bindings, and full reclassification: **Sanity check passed**.
- Clean Cecil run: **112 passed, 4 existing skips, 0 failed**, including documentation, cref resolution, availability, handle safety, and blittable P/Invoke checks. No baseline updates or suppressions were added.

| Platform/runtime | Introspection | Final `CMClockTest` fixture |
| --- | --- | --- |
| iOS 27.0 RC1, build 24A434 | 44 passed, 0 failed | 5 passed, 0 ignored |
| tvOS 27.0 RC1, build 24J360 | 43 passed, 0 failed | 5 passed, 0 ignored |
| macOS 26.6.2 | 32 passed, 2 OS-version skips | 2 passed, 5 OS-version skips |
| Mac Catalyst on macOS 26.6.2 | Full run blocked by the privacy failure below; all other checks passed across the original and focused runs | 3 passed, 5 OS-version skips |

The initial introspection bundles' platform assemblies were checked against the freshly installed 27.0 packs by SHA-256. The older version printed by `Touch.Client` is an inlined compile-time constant, not the version of the loaded platform assembly.

## Validation limits

- This host runs macOS 26.6.2, so the new desktop 27.0 APIs and notification fields are correctly gated out of runtime tests. iOS/tvOS exercise both new common P/Invokes and disposed-handle checks, returning `UnsupportedOperation` for the host clock. Successful genlock time-output marshalling and native desktop ownership still require macOS 27.0 and, for the synchronized path, suitable hardware.
- Full Mac Catalyst introspection aborts in the existing `DefaultCtorAllowed` test while constructing `CLLocationButton`, with `__TCC_CRASHING_DUE_TO_PRIVACY_VIOLATION__`. After another `make world` and clean test build, the remaining fixtures passed: 30 checks plus 2 simulator-only skips, in addition to 8 checks that passed before the abort. No unrelated constructor exclusions were changed.
- App-size tests normally skip all 16 cases on this RC branch; the clean review-follow-up run confirmed those skips. During initial binding validation, they were also run after a final clean with `XCODE_IS_STABLE=true` to obtain actual measurements: **all 16 configurations built and were measured**, but every comparison fails because `xcode27.0` contains no `tests/dotnet/UnitTests/expected` baselines and therefore expects zero bytes. No local expected files were manufactured and no comparison was represented as passing.

No CoreMedia TODO entries remain.
